### PR TITLE
[CLI] Allow config to be passed as a JSON o YAML string argument - not only as a file

### DIFF
--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -73,7 +73,7 @@ If you wish, you may write your configuration file in YAML format and then run:
 npx openapi-merge-cli --config path/to/openapi-merge.yaml
 ```
 
-or you can pass the configuration as a JSON string:
+You can pass the configuration as a JSON string:
 
 ```shell
 npx openapi-merge-cli --json-config '{
@@ -82,6 +82,16 @@ npx openapi-merge-cli --json-config '{
   ], 
   "output": ...
 }
+'
+```
+
+You can pass the configuration as a YAML string:
+
+```shell
+npx openapi-merge-cli --yaml-config '---
+inputs:
+  ...
+output: ...
 '
 ```
 

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -73,6 +73,18 @@ If you wish, you may write your configuration file in YAML format and then run:
 npx openapi-merge-cli --config path/to/openapi-merge.yaml
 ```
 
+or you can pass the configuration as a JSON string:
+
+```shell
+npx openapi-merge-cli --json-config '{
+  "inputs": [
+    ...
+  ], 
+  "output": ...
+}
+'
+```
+
 And the merge should be run and complete! Congratulations and enjoy!
 
 If you experience any issues then please [raise them in the bug tracker][1].

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -21,7 +21,8 @@ const program = new Command();
 program.version(pjson.version);
 
 program
-  .option('-c, --config <config_file>', 'The path to the configuration file for the merge tool.');
+  .option('-c, --config <config_file>', 'The path to the configuration file for the merge tool.')
+  .option('-j, --json-config <json_config>', 'The path to the configuration file for the merge tool.');
 
 
 class LogWithMillisDiff {
@@ -129,7 +130,25 @@ export async function main(): Promise<void> {
   program.parse(process.argv);
   logger.log(`## ${process.argv[0]}: Running v${pjson.version}`);
 
-  const config = await loadConfiguration(program.config);
+  var config
+  if (program.jsonConfig) {
+    try {
+      config = JSON.parse(program.jsonConfig);
+    } catch (e) {
+      // We need to make sure the code does propagate the error to the console!
+      if (e instanceof Error) {
+        config = e.message;
+      } else if (typeof e === 'string' || e instanceof String) {
+        // Make sure it's a string not a String
+        // Not sure i really need this
+        config = e.toString()
+      } else {
+        config = 'There was an error parsing the config'
+      }
+    }
+  } else {
+    config = await loadConfiguration(program.config);
+  }
 
   if (typeof config === 'string') {
     console.error(config);

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -22,7 +22,8 @@ program.version(pjson.version);
 
 program
   .option('-c, --config <config_file>', 'The path to the configuration file for the merge tool.')
-  .option('-j, --json-config <json_config>', 'The configuration as a JSON string to be parsed by the merge tool.');
+  .option('-j, --json-config <json_config>', 'The configuration as a JSON string to be parsed by the merge tool.')
+  .option('-y, --yaml-config <yaml_config>', 'The configuration as a YAML string to be parsed by the merge tool.');
 
 
 class LogWithMillisDiff {
@@ -134,6 +135,21 @@ export async function main(): Promise<void> {
   if (program.jsonConfig) {
     try {
       config = JSON.parse(program.jsonConfig);
+    } catch (e) {
+      // We need to make sure the code does propagate the error to the console!
+      if (e instanceof Error) {
+        config = e.message;
+      } else if (typeof e === 'string' || e instanceof String) {
+        // Make sure it's a string not a String
+        // Not sure i really need this
+        config = e.toString()
+      } else {
+        config = 'There was an error parsing the config'
+      }
+    }
+  } else if (program.yamlConfig) {
+    try {
+      config = yaml.load(program.yamlConfig);
     } catch (e) {
       // We need to make sure the code does propagate the error to the console!
       if (e instanceof Error) {

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -22,7 +22,7 @@ program.version(pjson.version);
 
 program
   .option('-c, --config <config_file>', 'The path to the configuration file for the merge tool.')
-  .option('-j, --json-config <json_config>', 'The path to the configuration file for the merge tool.');
+  .option('-j, --json-config <json_config>', 'The configuration as a JSON string to be parsed by the merge tool.');
 
 
 class LogWithMillisDiff {


### PR DESCRIPTION
I hope the title is self explanatory

Added the possibility to use

```shell
npx openapi-merge-cli --json-config '{
  "inputs": [
    ...
  ], 
  "output": ...
}
'
```

or 

```shell
npx openapi-merge-cli --yaml-config '---
inputs:
  ...
output: ...
'
```

 as added to docs