### PR TITLE
Update CLI README to describe title object

### DIFF
--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -1,10 +1,10 @@
 # openapi-merge-cli
 
-This tool is based on the [![npm](https://img.shields.io/npm/v/openapi-merge?label=openapi-merge&logo=npm)](https://bit.ly/2WnIytF) library. Please read 
+This tool is based on the [![npm](https://img.shields.io/npm/v/openapi-merge?label=openapi-merge&logo=npm)](https://bit.ly/2WnIytF) library. Please read
 that README for more details on how the merging algorithm works.
 
 This library is intended to be used for merging multiple OpenAPI 3.0 files together. The most common reason that developers want to do this is because
-they have multiple services that they wish to expose underneath a single API Gateway. Therefore, even though this merging logic is sufficiently generic to be 
+they have multiple services that they wish to expose underneath a single API Gateway. Therefore, even though this merging logic is sufficiently generic to be
 used for most use cases, some of the feature decisions are tailored for that specific use case.
 
 ## Getting started
@@ -28,7 +28,11 @@ called `openapi-merge.json` by default, in your current directory. It should loo
         "includeTags": ["included"]
       },
       "description": {
-        "append": true
+        "append": true,
+        "title": {
+          "value": "Jira",
+          "headingLevel" : 2
+        }
       }
     },
     {
@@ -43,21 +47,22 @@ called `openapi-merge.json` by default, in your current directory. It should loo
         "excludeTags": ["excluded"]
       }
     }
-  ], 
+  ],
   "output": "./output.swagger.json"
 }
 ```
 
 In this configuration you specify your inputs and your output file. For each input you have the following parameters:
 
- * `inputFile` or `inputURL`: the relative path (or URL), from the `openapi-merge.json`, to the OpenAPI schema file for that input (in JSON or Yaml format).
- * `dispute`: if two inputs both define a component with the same name then, in order to prevent incorrect overlaps, we will attempt to use the dispute prefix or suffix to come up with a unique name for that component. Please [read the documentation for more details on the format](https://github.com/robertmassaioli/openapi-merge/wiki/configuration-definitions-dispute).
- * `pathModification.stripStart`: When copying over the `paths` from your OpenAPI specification for this input, it will strip this string from the start of the path if it is found.
- * `pathModification.prepend`: When copying over the `paths` from your OpenAPI specification for this input, it will prepend this string to the start of the path if it is found. `prepend` will always run after `stripStart` so that it is deterministic.
- * `operationSelection.includeTags`: Only operations that are tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. This instruction will not remove other tags from the top level tags definition for this input.
- * `operationSelection.excludeTags`: Only operations that are NOT tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. Also, these tags will also be removed from the top level `tags` element for this file before being merged. If a single REST API operation has an `includeTags` reference and an `excludeTags` reference then the exclusion rule will take precidence.
- * `description.append`: All of the inputs with `append: true` will have their `info.description`s merged together, in order, and placed in the output OpenAPI file in the `info.description` section.
- * `description.title`: An optional field, that lets you spefify a custom heading for this inputs description when it is merged together in the output OpenAPI file.
+* `inputFile` or `inputURL`: the relative path (or URL), from the `openapi-merge.json`, to the OpenAPI schema file for that input (in JSON or Yaml format).
+* `dispute`: if two inputs both define a component with the same name then, in order to prevent incorrect overlaps, we will attempt to use the dispute prefix or suffix to come up with a unique name for that component. Please [read the documentation for more details on the format](https://github.com/robertmassaioli/openapi-merge/wiki/configuration-definitions-dispute).
+* `pathModification.stripStart`: When copying over the `paths` from your OpenAPI specification for this input, it will strip this string from the start of the path if it is found.
+* `pathModification.prepend`: When copying over the `paths` from your OpenAPI specification for this input, it will prepend this string to the start of the path if it is found. `prepend` will always run after `stripStart` so that it is deterministic.
+* `operationSelection.includeTags`: Only operations that are tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. This instruction will not remove other tags from the top level tags definition for this input.
+* `operationSelection.excludeTags`: Only operations that are NOT tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. Also, these tags will also be removed from the top level `tags` element for this file before being merged. If a single REST API operation has an `includeTags` reference and an `excludeTags` reference then the exclusion rule will take precidence.
+* `description.append`: All of the inputs with `append: true` will have their `info.description`s merged together, in order, and placed in the output OpenAPI file in the `info.description` section.
+* `description.title.value`: An optional string that lets you specify a custom section title for this input's description when it is merged together in the output OpenAPI file's `info.description` section
+* `description.title.headingLevel`: The integer heading level for the title, `1` to `6`. The default is `1`.
 
 And then, once you have your Inputs in place and your configuration file you merely run the following in the directory that has your configuration file:
 


### PR DESCRIPTION
Fixes #46

Also cleaned up Markdown to fix `markdownlint` warnings (list indentation, trailing whitespace)

(I did not bump the package version. I can do that if you prefer; different repos have different policies for that)