### PR TITLE
external ref equality

### DIFF
--- a/packages/openapi-merge/src/__tests__/component-equivalence.test.ts
+++ b/packages/openapi-merge/src/__tests__/component-equivalence.test.ts
@@ -1,0 +1,57 @@
+import { Swagger, SwaggerLookup } from "atlassian-openapi";
+import { deepEquality } from "../component-equivalence";
+import { toOAS } from "./oas-generation";
+
+describe("component-equivalence", () => {
+  describe("deepEquality", () => {
+    const schemas = {
+      FooNoRef: {
+        type: "number",
+      },
+      BarLocalRef: {
+        type: "object",
+        properties: {
+          referencedProp: { $ref: "#/components/schemas/FooNoRef" },
+        },
+      },
+      BazExternalRef: {
+        type: "object",
+        properties: {
+          referencedProp: { $ref: "/external/file.yaml#/components/schemas/Ref" },
+        },
+      },
+    } as const;
+    it("compares 2 equal Bar schemas", () => {
+      const oas1: Swagger.SwaggerV3 = toOAS({}, { schemas });
+      const lookup1 = new SwaggerLookup.InternalLookup(oas1);
+      const lookup2 = new SwaggerLookup.InternalLookup(oas1);
+
+      const compare = deepEquality(lookup1, lookup2);
+      const actualResult = compare(schemas.BarLocalRef, schemas.BarLocalRef);
+
+      expect(actualResult).toBe(true);
+    });
+
+    it("compares unequal Foo and Bar schemas", () => {
+      const oas1: Swagger.SwaggerV3 = toOAS({}, { schemas });
+      const lookup1 = new SwaggerLookup.InternalLookup(oas1);
+      const lookup2 = new SwaggerLookup.InternalLookup(oas1);
+
+      const compare = deepEquality(lookup1, lookup2);
+      const actualResult = compare(schemas.FooNoRef, schemas.BarLocalRef);
+
+      expect(actualResult).toBe(false);
+    }); 
+
+    it("compares 2 equal Baz schemas having external ref", () => {
+      const oas1: Swagger.SwaggerV3 = toOAS({}, { schemas });
+      const lookup1 = new SwaggerLookup.InternalLookup(oas1);
+      const lookup2 = new SwaggerLookup.InternalLookup(oas1);
+
+      const compare = deepEquality(lookup1, lookup2);
+      const actualResult = compare(schemas.BazExternalRef, schemas.BazExternalRef);
+
+      expect(actualResult).toBe(true);
+    });
+  });
+});

--- a/packages/openapi-merge/src/component-equivalence.ts
+++ b/packages/openapi-merge/src/component-equivalence.ts
@@ -76,7 +76,11 @@ export function deepEquality<A>(xLookup: Lookup.Lookup, yLookup: Lookup.Lookup):
       if (refRecord.checkAndStore(x, y) === 'seen-before') {
         return true;
       }
-
+      const isExternalRef = !x.$ref.startsWith('#')
+      if(isExternalRef &&  x.$ref === y.$ref) {
+        // as these refs are merged into a single output, they are going to reference the same external file
+        return true
+      }
       const xResult = isSchemaOrThrowError(x, xLookup.getSchema(x));
       const yResult = isSchemaOrThrowError(y, yLookup.getSchema(y));
       return compare(xResult, yResult);


### PR DESCRIPTION
Hi, thanks for this tool.
I stumbled across an issue when applying `deepEquality` on objects with external refs.

This change assumes that **external refs on same path equal** without the need to actually resolve the external files.
All existing tests are unaffected. But in case anybody considers this change might have some unwanted effect, it could possible be "hidden" behind some configuration option.
Cheers :v:
