### PR TITLE
Allow output files in non-existing directories

### DIFF
--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -121,6 +121,10 @@ function writeOutput(outputFullPath: string, outputSchema: Swagger.SwaggerV3): v
     ? dumpAsYaml(outputSchema)
     : JSON.stringify(outputSchema, null, 2);
 
+  const outputDir = path.dirname(outputFullPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
+  }
   fs.writeFileSync(outputFullPath, fileContents);
 }
 


### PR DESCRIPTION
Many tools allow developer to write results to non-existing directories (like tmp/ or something). I think it would be useful to handle directory creation in openapi-merge-cli.