### PR TITLE
feat(openapi): phase 2 -- merge OpenAPI 3.1

### DIFF
--- a/ai-planning/proposal-oas-phase2-31-support.md
+++ b/ai-planning/proposal-oas-phase2-31-support.md
@@ -1,0 +1,135 @@
+# Implementation Proposal: OpenAPI Support, Phase 2 — Merging 3.1
+
+**Status:** 📝 Proposal — implementation follows in this branch
+**Type:** Feature
+**Scope:** `packages/openapi-merge`, `packages/openapi-merge-cli`
+**Date:** 2026-07-26
+**Branch:** `feat/openapi-31-support`
+**Phase:** 2 of 3 — follows [`proposal-oas-phase1-version-checking.md`](proposal-oas-phase1-version-checking.md)
+
+---
+
+## 0. TL;DR
+
+Phase 1 made the library refuse 3.1 loudly. Phase 2 makes it **merge** 3.1, by
+adding the four structural things 3.1 introduced and then widening
+`SUPPORTED_MINOR_VERSIONS` to `['3.0', '3.1']`.
+
+| 3.1 addition | What the merge must do |
+| --- | --- |
+| `webhooks` | merge like `paths`: dedupe, dispute names, unique `operationId`s, walk `$ref`s |
+| `components.pathItems` | dedupe like every other component type |
+| `paths` becomes optional | stop assuming it exists — a webhooks-only document is legal |
+| `jsonSchemaDialect` | carry it through |
+
+**A correction to an earlier proposal.**
+[`proposal-openapi-3.2-support.md`](proposal-openapi-3.2-support.md) §2.4 called
+`@atlassian/atlassian-openapi` a *hard blocker*, on the grounds that it types
+`paths` as required and knows no 3.1 constructs. That is true but not blocking:
+3.1 can be modelled as a **local type delta** over the existing types, verified
+by compiling a webhooks-only document with `paths` omitted:
+
+```ts
+type Oas31 = Omit<Swagger.SwaggerV3, 'paths'> & {
+  paths?: Swagger.Paths;
+  webhooks?: { [key: string]: Swagger.PathItem | Swagger.Reference };
+  jsonSchemaDialect?: string;
+};
+```
+
+This compiles, and a 3.0-shaped document still fits it. So phase 2 does **not**
+need a dependency swap, which removes the largest risk and most of the cost from
+the estimate in that proposal. Replacing the dependency remains worth doing on
+its own merits — it is unmaintained at 1.0.6 — but it is no longer on this
+critical path and should not be bundled into a feature change.
+
+## 1. Goals
+
+1. `SUPPORTED_MINOR_VERSIONS` becomes `['3.0', '3.1']`, and that claim is true.
+2. `webhooks` survive a merge with the same guarantees `paths` get.
+3. `components.pathItems` dedupes like any other component type.
+4. A webhooks-only document (no `paths` at all) merges.
+5. `jsonSchemaDialect` is carried through.
+6. The output declares the **version the inputs actually used**, not a hard-coded
+   `3.0.3`.
+7. Mixed 3.0 + 3.1 inputs are refused — the `mixed-openapi-versions` rule written
+   and tested in phase 1 becomes reachable for the first time.
+
+## 2. Non-goals
+
+- 3.2. That is phase 3.
+- Automatic upconversion of 3.0 inputs to 3.1. See
+  [`proposal-mixed-version-inputs.md`](proposal-mixed-version-inputs.md); it is
+  unblocked *by* this phase, not part of it.
+- Replacing `@atlassian/atlassian-openapi` (see §0).
+- Validating output against the published JSON Schema. Worth doing; separate.
+
+## 3. Design
+
+### 3.1 A local 3.1 type delta — `oas31.ts`
+
+One module defines the document shape the merge works with. Everything else
+keeps importing `Swagger` for the constructs 3.1 did not change.
+
+Modelling only the delta keeps the change small and honest: we are not claiming
+to have re-typed OpenAPI, only to have described what 3.1 added.
+
+### 3.2 Webhooks merge exactly like paths
+
+`webhooks` is a map of name → Path Item, structurally identical to `paths`. The
+merge treats it the same way, which means it inherits — rather than
+reimplements — dispute handling, `operationId` uniqueness, and reference
+rewriting. Two inputs defining the same webhook name is a conflict in the same
+sense as a duplicate path, and gets the same error.
+
+This reuse is the main design decision in phase 2: sharing the machinery is what
+keeps the diff small and stops webhooks becoming a second-class citizen with
+subtly different behaviour.
+
+### 3.3 Output version
+
+`index.ts` currently writes `openapi: '3.0.3'` unconditionally. That cannot
+survive 3.1 support. The output now declares the **highest full version among
+the inputs**, which is well-defined because phase 1 guarantees they all share a
+`major.minor`.
+
+**This changes 3.0 behaviour**: inputs that all declare `3.0.0` now produce
+`3.0.0` rather than `3.0.3`. That is more honest, and re-labelling within 3.0.x
+is safe in both directions
+([`issues/proposal-76-openapi-version.md`](issues/proposal-76-openapi-version.md) §1),
+so no document becomes invalid. It is called out here because it is user-visible
+and issue #76 is about exactly this field — #76 should build its configurable
+strategy on top of this, not alongside it.
+
+## 4. Test plan
+
+- a webhooks-only 3.1 document merges, and its webhooks survive;
+- webhooks from two inputs combine; a name collision errors like a duplicate path;
+- `$ref`s inside webhooks are rewritten when the component they point at is renamed
+  — the orphaned-`Pet` failure from the 3.2 proposal, inverted into a passing test;
+- `operationId`s inside webhooks participate in uniqueness;
+- `components.pathItems` dedupes and renames;
+- `jsonSchemaDialect` is carried;
+- output version is the highest input version, for both 3.0 and 3.1;
+- mixed 3.0 + 3.1 gives `mixed-openapi-versions` (reachable at last) and exit 9;
+- every existing 3.0 test still passes unchanged.
+
+The end-to-end assertion that matters: **the exact 3.1 document from
+`proposal-openapi-3.2-support.md` §0 — which used to merge to exit 0 with its
+webhooks silently deleted — now merges with its webhooks intact.**
+
+## 5. Natural stopping point
+
+After phase 2 the tool merges 3.0 and 3.1, refuses 3.2 loudly, and refuses mixed
+versions. Every construct in a supported version either merges or produces an
+error; nothing is silently dropped. That is shippable and a reasonable place to
+stop if 3.2 is never funded.
+
+## 6. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Widening the `oas` type is a public API change for library consumers | It *widens* (accepts more), so existing callers still compile. Ship with the minor bump. |
+| Webhooks reuse the paths machinery but are not paths | Tests assert webhooks and paths do not collide with each other |
+| Output version change surprises 3.0 users | §3.3; documented in the README and the changelog note |
+| 3.1 schema-dialect semantics (`nullable` etc.) affect deduplication | Out of scope: within a single version there is one dialect, and phase 1 forbids mixing. Recorded in `proposal-mixed-version-inputs.md` §7 |

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -181,18 +181,25 @@ They are separate from each other so that CI can branch on **retryability**:
 
 ### OpenAPI version support
 
-This tool merges **OpenAPI 3.0.x** documents. Every input must declare a full
-`openapi` version (for example `"3.0.3"`), and all inputs must agree on the
-`major.minor` version — patch differences such as `3.0.0` and `3.0.3` are fine,
-since they are the same feature set.
+This tool merges **OpenAPI 3.0.x and 3.1.x** documents. Every input must
+declare a full `openapi` version (for example `"3.1.1"`), and all inputs must
+agree on the `major.minor` version — patch differences such as `3.1.0` and
+`3.1.1` are fine, since they are the same feature set, but 3.0 and 3.1 inputs
+cannot be mixed.
 
-An input declaring 3.1 or 3.2, or no version at all, exits with code `9` and a
-message naming the offending input. Previously such documents were merged under
-3.0 assumptions and anything unrecognised was silently discarded, so if you were
-relying on that behaviour, the merge was losing data.
+3.1 support covers the constructs 3.1 added: `webhooks` merge exactly like
+paths (same duplicate rule, same `operationId` uniqueness, same `$ref`
+rewriting), `components.pathItems` deduplicate like any other component,
+`jsonSchemaDialect` is carried through, and a webhooks-only document with no
+`paths` at all is valid input.
 
-To merge 3.1 or 3.2 documents today, convert your inputs to a single 3.0
-version first.
+An input declaring 3.2, no version at all, or a version that disagrees with the
+other inputs exits with code `9` and a message naming the offending input.
+
+**The output now declares the version the inputs used**, rather than always
+`3.0.3`. Merging documents that declare `3.0.0` now produces `3.0.0`. Relabelling
+within a minor is safe in both directions, so no document becomes invalid, but
+the emitted value has changed.
 
 For example, retrying only on a server-side failure:
 

--- a/packages/openapi-merge-cli/src/__tests__/load-configuration.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/load-configuration.test.ts
@@ -29,14 +29,14 @@ const validConfig = {
 /** `loadConfiguration` returns the error message as a plain string. */
 function expectError(result: Configuration | string): string {
   if (typeof result !== 'string') {
-    fail(`Expected an error string, got: ${JSON.stringify(result, null, 2)}`);
+    throw new Error(`Expected an error string, got: ${JSON.stringify(result, null, 2)}`);
   }
   return result as string;
 }
 
 function expectConfig(result: Configuration | string): Configuration {
   if (typeof result === 'string') {
-    fail(`Expected a Configuration, got the error: ${result}`);
+    throw new Error(`Expected a Configuration, got the error: ${result}`);
   }
   return result as Configuration;
 }

--- a/packages/openapi-merge-cli/src/__tests__/main-integration.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/main-integration.test.ts
@@ -451,8 +451,8 @@ describe('main - exit codes', () => {
 });
 
 describe('main - OpenAPI version checking', () => {
-  it('exits ErrorOpenApiVersion for a 3.1 input', async () => {
-    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.1.1' });
+  it('exits ErrorOpenApiVersion for a 3.2 input', async () => {
+    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.2.0' });
     const config = writeJson('openapi-merge.json', {
       inputs: [{ inputFile: './a.json' }],
       output: './output.json',
@@ -477,7 +477,7 @@ describe('main - OpenAPI version checking', () => {
 
   it('writes no output file when a version is unsupported', async () => {
     // The assertion that proves the failure is real rather than cosmetic.
-    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.1.0' });
+    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.2.0' });
     const config = writeJson('openapi-merge.json', {
       inputs: [{ inputFile: './a.json' }],
       output: './output.json',

--- a/packages/openapi-merge-cli/src/__tests__/path-resolution.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/path-resolution.test.ts
@@ -110,7 +110,7 @@ describe('assertOutputContained', () => {
     const exists = (): boolean => true;
     try {
       assertOutputContained(out, root, realpath, exists);
-      fail('expected OutputOutsideRootError');
+      throw new Error('expected OutputOutsideRootError');
     } catch (e) {
       expect(e).toBeInstanceOf(OutputOutsideRootError);
       expect((e as OutputOutsideRootError).message).toContain(path.resolve('/etc/passwd'));

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -9,6 +9,7 @@ import { merge, MergeInput } from 'openapi-merge';
 import fs from 'fs';
 import path from 'path';
 import { ErrorMergeResult, isErrorResult, SingleMergeInput } from "openapi-merge/dist/data";
+import { OpenApiDocument } from "openapi-merge/dist/oas31";
 import { Swagger } from "@atlassian/atlassian-openapi";
 import { dump as dumpYaml } from 'js-yaml';
 import { readFileAsString, readYamlOrJSON } from "./file-loading";
@@ -211,7 +212,7 @@ function dumpAsYaml(blob: unknown, indent: Indent = DEFAULT_INDENT): string {
   return dumpYaml(JSON.parse(JSON.stringify(blob)), { indent: indentToYamlArg(indent) });
 }
 
-function writeOutput(outputFullPath: string, outputSchema: Swagger.SwaggerV3, indent: Indent = DEFAULT_INDENT): void {
+function writeOutput(outputFullPath: string, outputSchema: OpenApiDocument, indent: Indent = DEFAULT_INDENT): void {
   const fileContents = isYamlExtension(outputFullPath)
     ? dumpAsYaml(outputSchema, indent)
     : JSON.stringify(outputSchema, null, indentToJsonStringifyArg(indent));

--- a/packages/openapi-merge/src/__tests__/component-types.test.ts
+++ b/packages/openapi-merge/src/__tests__/component-types.test.ts
@@ -13,7 +13,7 @@ function clone<A>(value: A): A {
 /** Narrows a MergeResult to its successful branch, failing the test otherwise. */
 function expectSuccess(result: MergeResult): SuccessfulMergeResult {
   if (isErrorResult(result)) {
-    fail(`Expected a successful merge, got: ${JSON.stringify(result, null, 2)}`);
+    throw new Error(`Expected a successful merge, got: ${JSON.stringify(result, null, 2)}`);
   }
   return result;
 }
@@ -148,7 +148,7 @@ describe('operationId conflict resolution', () => {
 
     const result = expectSuccess(merge(inputs));
 
-    expect(result.output.paths['/other'].get?.operationId).toBe('secondgetThing');
+    expect((result.output.paths ?? {})['/other'].get?.operationId).toBe('secondgetThing');
   });
 
   it('falls back to a numeric suffix when there is no dispute', () => {
@@ -157,7 +157,7 @@ describe('operationId conflict resolution', () => {
       toOAS({ '/other': { get: { operationId: 'getThing', responses: { '200': { description: 'ok' } } } } }),
     ])));
 
-    expect(result.output.paths['/other'].get?.operationId).toBe('getThing1');
+    expect((result.output.paths ?? {})['/other'].get?.operationId).toBe('getThing1');
   });
 
   it('falls back to a numeric suffix when the disputed id is also taken', () => {
@@ -172,7 +172,7 @@ describe('operationId conflict resolution', () => {
 
     const result = expectSuccess(merge(inputs));
 
-    expect(result.output.paths['/three'].get?.operationId).toBe('getThing1');
+    expect((result.output.paths ?? {})['/three'].get?.operationId).toBe('getThing1');
   });
 });
 
@@ -182,12 +182,12 @@ describe('pathModification.stripStart', () => {
   it('strips a prefix that is present', () => {
     const result = expectSuccess(merge([{ oas: toOAS(paths), pathModification: { stripStart: '/api' } }]));
 
-    expect(Object.keys(result.output.paths)).toEqual(['/thing']);
+    expect(Object.keys(result.output.paths ?? {})).toEqual(['/thing']);
   });
 
   it('leaves the path untouched when the prefix is absent', () => {
     const result = expectSuccess(merge([{ oas: toOAS(paths), pathModification: { stripStart: '/nope' } }]));
 
-    expect(Object.keys(result.output.paths)).toEqual(['/api/thing']);
+    expect(Object.keys(result.output.paths ?? {})).toEqual(['/api/thing']);
   });
 });

--- a/packages/openapi-merge/src/__tests__/oas31.test.ts
+++ b/packages/openapi-merge/src/__tests__/oas31.test.ts
@@ -1,0 +1,225 @@
+import { merge } from '..';
+import { isErrorResult, MergeResult, SingleMergeInput } from '../data';
+import { OpenApiDocument } from '../oas31';
+
+function doc(partial: Partial<OpenApiDocument>): OpenApiDocument {
+  return {
+    openapi: '3.1.1',
+    info: { title: 'Test', version: '1.0.0' },
+    ...partial,
+  } as OpenApiDocument;
+}
+
+function expectSuccess(result: MergeResult): OpenApiDocument {
+  if (isErrorResult(result)) {
+    throw new Error(`Expected a successful merge, got: ${result.message} (${result.type})`);
+  }
+  return result.output;
+}
+
+function expectFailure(result: MergeResult, type: string): string {
+  if (!isErrorResult(result)) {
+    throw new Error(`Expected an error, got: ${JSON.stringify(result, null, 2)}`);
+  }
+  expect(result.type).toBe(type);
+  return result.message;
+}
+
+const okResponse = { '200': { description: 'ok' } };
+
+describe('3.1 - paths are optional', () => {
+  it('merges a document that has only webhooks', () => {
+    // Legal in 3.1 and impossible in 3.0. Before phase 2 this document merged
+    // to a spec with no webhooks at all, and exit code 0.
+    const output = expectSuccess(merge([{ oas: doc({
+      webhooks: { newPet: { post: { operationId: 'onNewPet', responses: okResponse } } },
+    }) }]));
+
+    expect(Object.keys(output.webhooks ?? {})).toEqual(['newPet']);
+  });
+
+  it('leaves webhooks undefined when no input declared any', () => {
+    // Matches how `components` already behaves: the key is present with an
+    // undefined value rather than absent. What matters is that it never reaches
+    // a written document, which JSON.stringify guarantees.
+    const output = expectSuccess(merge([{ oas: doc({
+      openapi: '3.0.3',
+      paths: { '/a': { get: { responses: okResponse } } },
+    }) }]));
+
+    expect(output.webhooks).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('webhooks');
+  });
+
+  it('merges a webhooks-only input with a paths-only input', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ webhooks: { newPet: { post: { operationId: 'onNewPet', responses: okResponse } } } }) },
+      { oas: doc({ paths: { '/pets': { get: { operationId: 'listPets', responses: okResponse } } } }) },
+    ]));
+
+    expect(Object.keys(output.webhooks ?? {})).toEqual(['newPet']);
+    expect(Object.keys(output.paths ?? {})).toEqual(['/pets']);
+  });
+});
+
+describe('3.1 - webhooks merge like paths', () => {
+  it('combines webhooks from two inputs', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ webhooks: { a: { post: { operationId: 'onA', responses: okResponse } } } }) },
+      { oas: doc({ webhooks: { b: { post: { operationId: 'onB', responses: okResponse } } } }) },
+    ]));
+
+    expect(Object.keys(output.webhooks ?? {}).sort()).toEqual(['a', 'b']);
+  });
+
+  it('errors when two inputs declare the same webhook name', () => {
+    const message = expectFailure(merge([
+      { oas: doc({ webhooks: { dup: { post: { operationId: 'onA', responses: okResponse } } } }) },
+      { oas: doc({ webhooks: { dup: { post: { operationId: 'onB', responses: okResponse } } } }) },
+    ]), 'duplicate-webhooks');
+
+    expect(message).toContain('dup');
+    expect(message).toContain('Input 1');
+  });
+
+  it('makes operationIds unique across webhooks', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ webhooks: { a: { post: { operationId: 'same', responses: okResponse } } } }) },
+      { oas: doc({ webhooks: { b: { post: { operationId: 'same', responses: okResponse } } } }) },
+    ]));
+
+    expect(output.webhooks?.b.post?.operationId).toBe('same1');
+  });
+
+  it('makes operationIds unique between a path and a webhook', () => {
+    // Paths and webhooks share one operationId namespace; a clash across the
+    // two must still be resolved.
+    const output = expectSuccess(merge([
+      { oas: doc({ paths: { '/a': { get: { operationId: 'same', responses: okResponse } } } }) },
+      { oas: doc({ webhooks: { hook: { post: { operationId: 'same', responses: okResponse } } } }) },
+    ]));
+
+    expect(output.webhooks?.hook.post?.operationId).toBe('same1');
+  });
+
+  it('does not apply pathModification to webhook names', () => {
+    // A webhook key is an event name, not a URL, so prepending a path prefix
+    // to it would be meaningless.
+    const output = expectSuccess(merge([{
+      oas: doc({ webhooks: { newPet: { post: { operationId: 'onNewPet', responses: okResponse } } } }),
+      pathModification: { prepend: '/api' },
+    }]));
+
+    expect(Object.keys(output.webhooks ?? {})).toEqual(['newPet']);
+  });
+});
+
+describe('3.1 - references inside webhooks', () => {
+  it('rewrites a $ref inside a webhook when its component is renamed', () => {
+    // The inverse of the orphaned-component failure recorded in
+    // proposal-openapi-3.2-support.md: the webhook was dropped, its $ref went
+    // with it, and the schema it pointed at survived with nothing referencing
+    // it. Both inputs define a different `Pet`, so the second is renamed and
+    // the webhook's reference must follow.
+    const first: SingleMergeInput = { oas: doc({
+      paths: { '/pets': { get: { operationId: 'listPets', responses: okResponse } } },
+      components: { schemas: { Pet: { type: 'string' } } },
+    }) };
+    const second: SingleMergeInput = { oas: doc({
+      webhooks: { newPet: { post: {
+        operationId: 'onNewPet',
+        requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Pet' } } } },
+        responses: okResponse,
+      } } },
+      components: { schemas: { Pet: { type: 'number' } } },
+    }) };
+
+    const output = expectSuccess(merge([first, second]));
+
+    const body = output.webhooks?.newPet.post?.requestBody;
+    const ref = (body as { content: { [k: string]: { schema: { $ref: string } } } })
+      .content['application/json'].schema.$ref;
+
+    expect(Object.keys(output.components?.schemas ?? {}).sort()).toEqual(['Pet', 'Pet1']);
+    expect(ref).toBe('#/components/schemas/Pet1');
+  });
+});
+
+describe('3.1 - components.pathItems', () => {
+  it('carries pathItems through a merge', () => {
+    const output = expectSuccess(merge([{ oas: doc({
+      components: { pathItems: { Shared: { get: { operationId: 'shared', responses: okResponse } } } },
+    }) }]));
+
+    expect(Object.keys(output.components?.pathItems ?? {})).toEqual(['Shared']);
+  });
+
+  it('deduplicates identical pathItems from two inputs', () => {
+    const shared = { Shared: { get: { operationId: 'shared', responses: okResponse } } };
+    const output = expectSuccess(merge([
+      { oas: doc({ components: { pathItems: JSON.parse(JSON.stringify(shared)) } }) },
+      { oas: doc({ components: { pathItems: JSON.parse(JSON.stringify(shared)) } }) },
+    ]));
+
+    expect(Object.keys(output.components?.pathItems ?? {})).toEqual(['Shared']);
+  });
+
+  it('renames a conflicting pathItem rather than dropping it', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ components: { pathItems: { Shared: { get: { operationId: 'a', responses: okResponse } } } } }) },
+      { oas: doc({ components: { pathItems: { Shared: { get: { operationId: 'b', responses: okResponse } } } } }) },
+    ]));
+
+    expect(Object.keys(output.components?.pathItems ?? {}).sort()).toEqual(['Shared', 'Shared1']);
+  });
+});
+
+describe('3.1 - jsonSchemaDialect', () => {
+  it('carries the dialect through', () => {
+    const dialect = 'https://spec.openapis.org/oas/3.1/dialect/base';
+    const output = expectSuccess(merge([{ oas: doc({ jsonSchemaDialect: dialect, paths: {} }) }]));
+
+    expect(output.jsonSchemaDialect).toBe(dialect);
+  });
+
+  it('takes the first dialect when inputs disagree', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ jsonSchemaDialect: 'https://example.com/first', paths: {} }) },
+      { oas: doc({ jsonSchemaDialect: 'https://example.com/second', paths: {} }) },
+    ]));
+
+    expect(output.jsonSchemaDialect).toBe('https://example.com/first');
+  });
+
+  it('omits the dialect when no input declares one', () => {
+    const output = expectSuccess(merge([{ oas: doc({ paths: {} }) }]));
+
+    expect(output.jsonSchemaDialect).toBeUndefined();
+  });
+});
+
+describe('output version negotiation', () => {
+  it('declares the highest patch among 3.1 inputs', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ openapi: '3.1.0', paths: {} }) },
+      { oas: doc({ openapi: '3.1.1', paths: {} }) },
+    ]));
+
+    expect(output.openapi).toBe('3.1.1');
+  });
+
+  it('declares the input version for 3.0 rather than a hard-coded 3.0.3', () => {
+    const output = expectSuccess(merge([{ oas: doc({ openapi: '3.0.0', paths: {} }) }]));
+
+    expect(output.openapi).toBe('3.0.0');
+  });
+
+  it('declares the highest patch among 3.0 inputs', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ openapi: '3.0.0', paths: { '/a': { get: { responses: okResponse } } } }) },
+      { oas: doc({ openapi: '3.0.3', paths: { '/b': { get: { responses: okResponse } } } }) },
+    ]));
+
+    expect(output.openapi).toBe('3.0.3');
+  });
+});

--- a/packages/openapi-merge/src/__tests__/openapi-version.test.ts
+++ b/packages/openapi-merge/src/__tests__/openapi-version.test.ts
@@ -26,7 +26,7 @@ function inputsAt(...versions: unknown[]): SingleMergeInput[] {
 
 function expectError(result: MergeResult, type: string): string {
   if (!isErrorResult(result)) {
-    fail(`Expected an error, got a successful merge: ${JSON.stringify(result, null, 2)}`);
+    throw new Error(`Expected an error, got a successful merge: ${JSON.stringify(result, null, 2)}`);
   }
   expect(result.type).toBe(type);
   return result.message;
@@ -76,10 +76,11 @@ describe('toMinorVersion', () => {
 });
 
 describe('SUPPORTED_MINOR_VERSIONS', () => {
-  it('contains 3.0 in phase 1', () => {
-    // Widened by later phases. This pins the phase-1 contract so that adding a
-    // version is a deliberate act with a failing test to update.
-    expect([...SUPPORTED_MINOR_VERSIONS]).toEqual(['3.0']);
+  it('contains 3.0 and 3.1 after phase 2', () => {
+    // Widened by each phase. This pins the contract so that adding a version is
+    // a deliberate act with a failing test to update -- which is exactly what
+    // happened when phase 2 added '3.1'.
+    expect([...SUPPORTED_MINOR_VERSIONS]).toEqual(['3.0', '3.1']);
   });
 });
 
@@ -99,20 +100,20 @@ describe('validateInputVersions', () => {
 });
 
 describe('merge - unsupported versions', () => {
-  it('rejects a 3.1 input and names the index and version', () => {
-    const message = expectError(merge(inputsAt('3.1.1')), 'unsupported-openapi-version');
+  it('rejects a 3.2 input and names the index and version', () => {
+    const message = expectError(merge(inputsAt('3.2.0')), 'unsupported-openapi-version');
 
     expect(message).toContain('Input 0');
-    expect(message).toContain('3.1.1');
-    expect(message).toContain('3.0.x');
+    expect(message).toContain('3.2.0');
+    expect(message).toContain('3.1.x');
   });
 
-  it('rejects a 3.2 input', () => {
-    expect(expectError(merge(inputsAt('3.2.0')), 'unsupported-openapi-version')).toContain('3.2.0');
+  it('accepts a 3.1 input now that phase 2 supports it', () => {
+    expect(isErrorResult(merge(inputsAt('3.1.1')))).toBe(false);
   });
 
   it('names the offending input when it is not the first', () => {
-    const message = expectError(merge(inputsAt('3.0.3', '3.0.0', '3.1.0')), 'unsupported-openapi-version');
+    const message = expectError(merge(inputsAt('3.0.3', '3.0.0', '3.2.0')), 'unsupported-openapi-version');
 
     expect(message).toContain('Input 2');
   });
@@ -136,12 +137,12 @@ describe('merge - unsupported versions', () => {
 
 describe('merge - mixed versions', () => {
   it('rejects inputs that disagree on minor version', () => {
-    // Both are individually parseable; 3.1 is rejected first as unsupported.
-    // To reach the mixed check, every version present must be supported -- so
-    // this asserts the error the user actually gets today.
-    const message = expectError(merge(inputsAt('3.0.3', '3.1.0')), 'unsupported-openapi-version');
+    // Reachable for the first time in phase 2: both 3.0 and 3.1 are supported
+    // individually, so the mixed rule is what stops them being merged together.
+    const message = expectError(merge(inputsAt('3.0.3', '3.1.0')), 'mixed-openapi-versions');
 
-    expect(message).toContain('3.1.0');
+    expect(message).toContain('3.0.x');
+    expect(message).toContain('3.1.x');
   });
 
   it('reports a mixed-version error when both minors are supported', () => {
@@ -152,7 +153,7 @@ describe('merge - mixed versions', () => {
     const result = validateInputVersions(inputsAt('3.0.3', '3.1.0'), ['3.0', '3.1']);
 
     if (result === undefined) {
-      fail('Expected a mixed-openapi-versions error');
+      throw new Error('Expected a mixed-openapi-versions error');
     }
     expect(result.type).toBe('mixed-openapi-versions');
     expect(result.message).toContain('3.0.x');
@@ -177,7 +178,7 @@ describe('merge - version checking runs first', () => {
     // These two inputs also have duplicate paths, which would normally be a
     // 'duplicate-paths' error. The version problem must win, because nothing
     // should be merged at all.
-    const result = merge(inputsAt('3.1.0', '3.1.0'));
+    const result = merge(inputsAt('3.2.0', '3.2.0'));
 
     expectError(result, 'unsupported-openapi-version');
   });
@@ -194,8 +195,8 @@ describe('merge - version checking runs first', () => {
     const result = merge([first, second]);
 
     if (isErrorResult(result)) {
-      fail(`Expected a successful merge, got: ${result.message}`);
+      throw new Error(`Expected a successful merge, got: ${result.message}`);
     }
-    expect(Object.keys(result.output.paths).sort()).toEqual(['/other', '/thing']);
+    expect(Object.keys(result.output.paths ?? {}).sort()).toEqual(['/other', '/thing']);
   });
 });

--- a/packages/openapi-merge/src/__tests__/test-utils.ts
+++ b/packages/openapi-merge/src/__tests__/test-utils.ts
@@ -6,13 +6,13 @@ export function expectErrorType(result: MergeResult, type: ErrorType): void {
   if (isErrorResult(result)) {
     expect(result.type).toEqual(type);
   } else {
-    fail(`Expected an error, but instead got: ${JSON.stringify(result, null, 2)}`);
+    throw new Error(`Expected an error, but instead got: ${JSON.stringify(result, null, 2)}`);
   }
 }
 
 export function expectMergeResult(actual: MergeResult, expected: MergeResult): void {
   if(isErrorResult(actual)) {
-    fail(`We expected to have a successful merge and instead got: ${JSON.stringify(actual, null, 2)}`);
+    throw new Error(`We expected to have a successful merge and instead got: ${JSON.stringify(actual, null, 2)}`);
   }
 
   expect(actual).toEqual(expected);

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -1,4 +1,4 @@
-import { Swagger } from '@atlassian/atlassian-openapi';
+import { OpenApiDocument } from './oas31';
 
 export type OperationSelection = {
   /**
@@ -39,7 +39,7 @@ export interface DisputeSuffix extends DisputeBase {
 export type Dispute = DisputePrefix | DisputeSuffix;
 
 export interface SingleMergeInputBase {
-  oas: Swagger.SwaggerV3;
+  oas: OpenApiDocument;
 
   pathModification?: PathModification;
 
@@ -121,7 +121,7 @@ export type DescriptionTitle = {
 export type MergeInput = Array<SingleMergeInput>;
 
 export type SuccessfulMergeResult = {
-  output: Swagger.SwaggerV3;
+  output: OpenApiDocument;
 };
 
 export type ErrorType =
@@ -132,7 +132,9 @@ export type ErrorType =
   /** An input declared a version this library cannot merge, or none at all. */
   | 'unsupported-openapi-version'
   /** The inputs did not all declare the same OpenAPI major.minor version. */
-  | 'mixed-openapi-versions';
+  | 'mixed-openapi-versions'
+  /** Two inputs declared the same webhook name (3.1). */
+  | 'duplicate-webhooks';
 
 export type ErrorMergeResult = {
   type: ErrorType;

--- a/packages/openapi-merge/src/extensions.ts
+++ b/packages/openapi-merge/src/extensions.ts
@@ -1,9 +1,9 @@
-import { Swagger } from "@atlassian/atlassian-openapi";
+import { OpenApiDocument } from './oas31';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 type Extensions = { [extensionKey: string]: any };
 
-function extractExtensions(input: Swagger.SwaggerV3): Extensions {
+function extractExtensions(input: OpenApiDocument): Extensions {
   const result: Extensions = {};
 
   const plainObject: Extensions = input;
@@ -43,7 +43,7 @@ function mergeExtensionsHelper(extensions: Extensions[]): Extensions {
   return result;
 }
 
-export function mergeExtensions(mergeTarget: Swagger.SwaggerV3, oass: Swagger.SwaggerV3[]): Swagger.SwaggerV3 {
+export function mergeExtensions(mergeTarget: OpenApiDocument, oass: OpenApiDocument[]): OpenApiDocument {
   return {
     ...mergeTarget,
     ...mergeExtensionsHelper([extractExtensions(mergeTarget), ...oass.map(extractExtensions)])

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -3,9 +3,9 @@ import { MergeInput, MergeResult, isErrorResult, PathModification, OperationSele
 import { mergeTags } from './tags';
 import { mergePathsAndComponents } from './paths-and-components';
 import { mergeExtensions } from './extensions';
-import { Swagger } from '@atlassian/atlassian-openapi';
 import { mergeInfos } from './info';
-import { validateInputVersions } from './openapi-version';
+import { negotiateOutputVersion, validateInputVersions } from './openapi-version';
+import { OpenApiDocument } from './oas31';
 
 export { isErrorResult };
 export type { MergeInput, MergeResult, PathModification, OperationSelection };
@@ -44,19 +44,24 @@ export function merge(inputs: MergeInput): MergeResult {
     return pathAndComponentResult;
   }
 
-  const { paths, components: retComponents } = pathAndComponentResult;
+  const { paths, webhooks, components: retComponents } = pathAndComponentResult;
 
   const components = Object.keys(retComponents).length === 0 ? undefined : retComponents;
 
-  const output: Swagger.SwaggerV3 = mergeExtensions(
+  const output: OpenApiDocument = mergeExtensions(
     {
-      openapi: '3.0.3',
+      // The version the inputs actually declared, rather than a hard-coded
+      // 3.0.3. Well defined because every input shares a major.minor by now.
+      openapi: negotiateOutputVersion(inputs) ?? '3.0.3',
       info: mergeInfos(inputs),
       servers: getFirstMatching(inputs, input => input.oas.servers),
       externalDocs: getFirstMatching(inputs, input => input.oas.externalDocs),
       security: getFirstMatching(inputs, input => input.oas.security),
       tags: mergeTags(inputs),
       paths,
+      // Omitted entirely for 3.0 documents, which cannot declare webhooks.
+      webhooks: Object.keys(webhooks).length === 0 ? undefined : webhooks,
+      jsonSchemaDialect: getFirstMatching(inputs, input => input.oas.jsonSchemaDialect),
       components,
     },
     inputs.map(input => input.oas)

--- a/packages/openapi-merge/src/oas31.ts
+++ b/packages/openapi-merge/src/oas31.ts
@@ -1,0 +1,57 @@
+import { Swagger } from '@atlassian/atlassian-openapi';
+
+/**
+ * OpenAPI 3.1 modelled as a delta over the 3.0 types.
+ *
+ * The underlying type package describes 3.0 only: it types `paths` as required
+ * and knows nothing of `webhooks`, `components.pathItems` or
+ * `jsonSchemaDialect`. Rather than replace it -- a large change to an
+ * unmaintained but otherwise working dependency -- this module describes only
+ * what 3.1 added. Everything 3.1 left alone keeps using `Swagger.*` directly.
+ *
+ * This is deliberately not a re-typing of OpenAPI. It claims only to describe
+ * the constructs this library has to merge.
+ */
+
+/** A map of name to Path Item, the shape shared by `paths` and `webhooks`. */
+export type PathItemMap = { [key: string]: Swagger.PathItem };
+
+/**
+ * 3.1 adds `pathItems` to the component types.
+ *
+ * Modelled as an intersection so every existing component type keeps its
+ * original definition.
+ */
+export type Components31 = Swagger.Components & {
+  pathItems?: PathItemMap;
+};
+
+/**
+ * An OpenAPI document this library can merge: 3.0 or 3.1.
+ *
+ * Differences from `Swagger.SwaggerV3`, all of them 3.1 additions:
+ *
+ * - `paths` is **optional**. 3.1 allows a document that describes only
+ *   webhooks, which has no `paths` member at all. This is the change that
+ *   cannot be expressed by extension alone, hence the `Omit`.
+ * - `webhooks` is a map of Path Items, structurally identical to `paths`.
+ * - `jsonSchemaDialect` names the default JSON Schema dialect for Schema
+ *   Objects in the document.
+ * - `components` may carry `pathItems`.
+ */
+export type OpenApiDocument = Omit<Swagger.SwaggerV3, 'paths' | 'components'> & {
+  paths?: Swagger.Paths;
+  webhooks?: PathItemMap;
+  jsonSchemaDialect?: string;
+  components?: Components31;
+};
+
+/** `paths` is optional in 3.1; this is the "there are no paths" case flattened. */
+export function getPaths(oas: OpenApiDocument): Swagger.Paths {
+  return oas.paths ?? {};
+}
+
+/** `webhooks` is 3.1-only and optional even there. */
+export function getWebhooks(oas: OpenApiDocument): PathItemMap {
+  return oas.webhooks ?? {};
+}

--- a/packages/openapi-merge/src/openapi-version.ts
+++ b/packages/openapi-merge/src/openapi-version.ts
@@ -24,7 +24,7 @@ export type OpenApiVersion = {
  * 3 adds '3.2'. Adding an entry here is a claim that the merge logic handles
  * that version's constructs -- do not add one without the work behind it.
  */
-export const SUPPORTED_MINOR_VERSIONS: ReadonlyArray<string> = ['3.0'];
+export const SUPPORTED_MINOR_VERSIONS: ReadonlyArray<string> = ['3.0', '3.1'];
 
 /** `major.minor`, the granularity at which compatibility is decided. */
 export function toMinorVersion(version: OpenApiVersion): string {
@@ -134,4 +134,31 @@ export function validateInputVersions(
   }
 
   return undefined;
+}
+
+/**
+ * The version the merged document should declare.
+ *
+ * Every input shares a `major.minor` by the time this runs, so the only
+ * question is the patch. The highest one wins: patch releases within a minor
+ * are the same feature set, and a document written against 3.0.3 may use
+ * clarifications that a 3.0.0 consumer would not expect, so claiming the
+ * highest is the safe direction.
+ *
+ * Returns undefined only when there are no inputs, which `merge` rejects first.
+ */
+export function negotiateOutputVersion(inputs: MergeInput): string | undefined {
+  let best: OpenApiVersion | undefined;
+
+  for (const input of inputs) {
+    const version = parseOpenApiVersion(input.oas.openapi);
+    if (version === undefined) {
+      continue;
+    }
+    if (best === undefined || version.patch > best.patch) {
+      best = version;
+    }
+  }
+
+  return best?.raw;
 }

--- a/packages/openapi-merge/src/operation-selection.ts
+++ b/packages/openapi-merge/src/operation-selection.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { Swagger } from "@atlassian/atlassian-openapi";
 import { OperationSelection } from './data';
+import { OpenApiDocument } from './oas31';
 
 const allMethods: Swagger.Method[] = [
   'get' , 'put' , 'post' , 'delete' , 'options' , 'head' , 'patch' , 'trace'
@@ -10,7 +11,7 @@ function operationContainsAnyTag(operation: Swagger.Operation, tags: string[]): 
   return operation.tags !== undefined && operation.tags.some(tag => tags.includes(tag));
 }
 
-function dropOperationsThatHaveTags(originalOas: Swagger.SwaggerV3, excludedTags: string[]): Swagger.SwaggerV3 {
+function dropOperationsThatHaveTags(originalOas: OpenApiDocument, excludedTags: string[]): OpenApiDocument {
   if (excludedTags.length === 0) {
     return originalOas;
   }
@@ -36,7 +37,7 @@ function dropOperationsThatHaveTags(originalOas: Swagger.SwaggerV3, excludedTags
   return oas;
 }
 
-function includeOperationsThatHaveTags(originalOas: Swagger.SwaggerV3, includeTags: string[]): Swagger.SwaggerV3 {
+function includeOperationsThatHaveTags(originalOas: OpenApiDocument, includeTags: string[]): OpenApiDocument {
   if (includeTags.length === 0) {
     return originalOas;
   }
@@ -63,7 +64,7 @@ function includeOperationsThatHaveTags(originalOas: Swagger.SwaggerV3, includeTa
 }
 
 
-export function runOperationSelection(originalOas: Swagger.SwaggerV3, operationSelection: OperationSelection | undefined): Swagger.SwaggerV3 {
+export function runOperationSelection(originalOas: OpenApiDocument, operationSelection: OperationSelection | undefined): OpenApiDocument {
   if (operationSelection === undefined) {
     return originalOas;
   }

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -5,10 +5,13 @@ import _ from 'lodash';
 import { runOperationSelection } from "./operation-selection";
 import { deepEquality } from "./component-equivalence";
 import { applyDispute, getDispute } from './dispute';
+import { Components31, getPaths, getWebhooks, OpenApiDocument, PathItemMap } from './oas31';
 
 export type PathAndComponents = {
   paths: Swagger.Paths;
-  components: Swagger.Components;
+  /** 3.1 only; empty for 3.0 inputs, which cannot declare webhooks. */
+  webhooks: PathItemMap;
+  components: Components31;
 };
 
 function removeFromStart(input: string, trim: string): string {
@@ -87,7 +90,7 @@ function countOperationsInPathItem(pathItem: Swagger.PathItem): number {
   return count;
 }
 
-function dropPathItemsWithNoOperations(originalOas: Swagger.SwaggerV3): Swagger.SwaggerV3 {
+function dropPathItemsWithNoOperations(originalOas: OpenApiDocument): OpenApiDocument {
   const oas = _.cloneDeep(originalOas);
 
   for (const path in oas.paths) {
@@ -182,6 +185,7 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
   const seenOperationIds = new Set<string>();
 
   const result: PathAndComponents = {
+    webhooks: {},
     paths: {},
     components: {},
   };
@@ -200,7 +204,10 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
       // For each component in the original input, place it in the output with deduplicate taking place
     if (oas.components !== undefined) {
       const resultLookup = new SwaggerLookup.InternalLookup({ openapi: '3.0.1', info: { title: 'dummy', version: '0' }, paths: {}, components: result.components });
-      const currentLookup = new SwaggerLookup.InternalLookup(oas);
+      // InternalLookup is 3.0-shaped and needs a concrete `paths`. A 3.1
+      // document may legitimately have none, and the lookup only resolves
+      // component `$ref`s, so an empty object is equivalent for its purposes.
+      const currentLookup = new SwaggerLookup.InternalLookup({ ...oas, paths: getPaths(oas) });
       if (oas.components.schemas !== undefined) {
         result.components.schemas = result.components.schemas || {};
 
@@ -266,6 +273,16 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
         });
       }
 
+      // pathItems (3.1): a component type like any other, deduplicated and
+      // renamed on conflict with the same machinery.
+      if (oas.components.pathItems !== undefined) {
+        result.components.pathItems = result.components.pathItems || {};
+
+        processComponents(result.components.pathItems, oas.components.pathItems, deepEquality(resultLookup, currentLookup), dispute, (from: string, to: string) => {
+          referenceModification[`#/components/pathItems/${from}`] = `#/components/pathItems/${to}`;
+        });
+      }
+
       // callbacks
       if (oas.components.callbacks !== undefined) {
         result.components.callbacks = result.components.callbacks || {};
@@ -296,11 +313,38 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
         };
       }
 
-      const copyPathItem = oas.paths[originalPath];
+      const copyPathItem = getPaths(oas)[originalPath];
 
       ensureUniqueOperationIds(copyPathItem, seenOperationIds, dispute);
 
       result.paths[newPath] = copyPathItem;
+    }
+
+    // Webhooks (3.1) are a map of Path Items keyed by an event name. They merge
+    // like paths -- same duplicate rule, same operationId uniqueness, same
+    // reference rewriting -- but pathModification deliberately does NOT apply:
+    // a webhook key is an event name, not a URL path, so prepending "/api" to
+    // it would be meaningless.
+    const webhookNames = Object.keys(getWebhooks(oas));
+
+    for (let webhookIndex = 0; webhookIndex < webhookNames.length; webhookIndex++) {
+      const webhookName = webhookNames[webhookIndex];
+
+      if (result.webhooks[webhookName] !== undefined) {
+        return {
+          type: 'duplicate-webhooks',
+          message: `Input ${inputIndex}: The webhook '${webhookName}' has already been added by another input file`
+        };
+      }
+
+      const copyWebhook = getWebhooks(oas)[webhookName];
+
+      const webhookOpIdError = ensureUniqueOperationIds(copyWebhook, seenOperationIds, dispute);
+      if (webhookOpIdError !== undefined) {
+        return webhookOpIdError;
+      }
+
+      result.webhooks[webhookName] = copyWebhook;
     }
 
     // Update the references to point to the right location

--- a/packages/openapi-merge/src/reference-walker.ts
+++ b/packages/openapi-merge/src/reference-walker.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 import { Swagger, SwaggerTypeChecks as TC } from "@atlassian/atlassian-openapi";
+import { Components31, getPaths, getWebhooks, OpenApiDocument, PathItemMap } from './oas31';
 
 export type Modify = (input: string) => string;
 
@@ -225,7 +226,7 @@ function walkPathItemReferences(pathItem: Swagger.PathItem, modify: Modify): voi
   }
 }
 
-export function walkComponentReferences(components: Swagger.Components, modify: Modify): void {
+export function walkComponentReferences(components: Components31, modify: Modify): void {
   if (components.schemas !== undefined) {
     for (const schemaKey in components.schemas) {
       if (components.schemas.hasOwnProperty(schemaKey)) {
@@ -290,12 +291,29 @@ export function walkComponentReferences(components: Swagger.Components, modify: 
     }
   }
 
+  // 3.1 component type: a map of Path Items, walked like any other.
+  if (components.pathItems !== undefined) {
+    walkPathItemMapReferences(components.pathItems, modify);
+  }
+
   if (components.callbacks !== undefined) {
     for (const componentKey in components.callbacks) {
       if (components.callbacks.hasOwnProperty(componentKey)) {
         const callback = components.callbacks[componentKey];
         walkCallbackReferences(callback, modify);
       }
+    }
+  }
+}
+
+/**
+ * Walk a map of Path Items. Shared by `paths`, `webhooks` and
+ * `components.pathItems`, which are structurally identical.
+ */
+export function walkPathItemMapReferences(items: PathItemMap, modify: Modify): void {
+  for (const key in items) {
+    if (items.hasOwnProperty(key)) {
+      walkPathItemReferences(items[key], modify);
     }
   }
 }
@@ -309,7 +327,13 @@ export function walkPathReferences(paths: Swagger.Paths, modify: Modify): void {
   }
 }
 
-export function walkAllReferences(oas: Swagger.SwaggerV3, modify: Modify): void {
-  walkPathReferences(oas.paths, modify);
+export function walkAllReferences(oas: OpenApiDocument, modify: Modify): void {
+  walkPathReferences(getPaths(oas), modify);
+
+  // 3.1: webhooks are Path Items and carry references exactly as paths do.
+  // Missing them is how a $ref inside a webhook survived into the output while
+  // the component it pointed at was renamed underneath it.
+  walkPathItemMapReferences(getWebhooks(oas), modify);
+
   if (oas.components !== undefined) walkComponentReferences(oas.components, modify);
 }


### PR DESCRIPTION
Implements ai-planning/proposal-oas-phase2-31-support.md. Widens SUPPORTED_MINOR_VERSIONS to ['3.0', '3.1'] and makes that claim true.

Corrects an assumption from proposal-openapi-3.2-support.md, which called @atlassian/atlassian-openapi a hard blocker because it types `paths` as required and knows no 3.1 constructs. It is not blocking: 3.1 is modelled as a local type delta in the new oas31.ts, verified by compiling a webhooks-only document. No dependency swap, which removes the largest risk and most of the cost from that estimate. Replacing the dependency is still worth doing on its own merits, but it is not on this critical path.

What now merges:

- webhooks, reusing the paths machinery rather than reimplementing it, so they inherit dispute handling, operationId uniqueness and $ref rewriting. A name collision is a duplicate-webhooks error. pathModification deliberately does NOT apply: a webhook key is an event name, not a URL.
- components.pathItems, deduplicated and renamed on conflict like any other component type.
- documents with no `paths` at all, which 3.1 permits.
- jsonSchemaDialect, first-wins like info.

The output now declares the highest version among the inputs instead of a hard-coded 3.0.3. This is well defined because phase 1 guarantees the inputs share a major.minor. It changes 3.0 behaviour -- inputs declaring 3.0.0 now produce 3.0.0 -- which is more honest and safe in both directions per proposal-76, but is user-visible and documented in the README.

Mixed 3.0 + 3.1 inputs are now refused by the mixed-openapi-versions rule, which phase 1 wrote and tested but could not reach until a second version was supported.

Also fixes a latent bug across the whole test suite: `fail()` is typed by @types/jest but is not a bun:test global, so all nine call sites would have thrown "ReferenceError: fail is not defined" instead of reporting the real assertion. It only surfaced now because those guards had never tripped. All nine are now `throw new Error(...)`, which narrows identically and works in any runner.

Verified against the built binary: the 3.1 document from proposal-openapi-3.2-support.md §0 -- which previously merged to exit 0 with its webhooks silently deleted and the output mislabelled 3.0.3 -- now produces openapi 3.1.1 with its webhooks, its components.pathItems, and the $ref inside the webhook all intact and resolving.