### PR TITLE
feat(openapi): phase 3 -- merge OpenAPI 3.2

### DIFF
--- a/ai-planning/proposal-oas-phase3-32-support.md
+++ b/ai-planning/proposal-oas-phase3-32-support.md
@@ -1,0 +1,145 @@
+# Implementation Proposal: OpenAPI Support, Phase 3 — Merging 3.2
+
+**Status:** 📝 Proposal — implementation follows in this branch
+**Type:** Feature
+**Scope:** `packages/openapi-merge`, `packages/openapi-merge-cli`
+**Date:** 2026-07-26
+**Branch:** `feat/openapi-32-support`
+**Phase:** 3 of 3 — follows [`proposal-oas-phase2-31-support.md`](proposal-oas-phase2-31-support.md)
+
+---
+
+## 0. TL;DR
+
+3.1 → 3.2 introduced **no breaking changes**; everything it added is additive.
+That makes phase 3 much smaller than phase 2, and most of 3.2 already passes
+through the merge untouched because it lives *inside* objects the merger copies
+wholesale.
+
+Only a handful of additions actually interact with merge logic:
+
+| 3.2 addition | Why the merge must care |
+| --- | --- |
+| `query` method on Path Items | a **ninth** HTTP method — invisible to four hard-coded eight-method lists |
+| `additionalOperations` | arbitrary custom verbs, same problem |
+| `$self` | document identity — merging two is not obviously meaningful (§4) |
+| tag `summary` / `parent` / `kind` | tags merge by name; new fields must survive |
+
+Everything else — `itemSchema`, OAuth2 device flow, `oauth2MetadataUrl`,
+discriminator `defaultMapping`, `dataValue` / `serializedValue`, server `name`,
+`in: querystring` — sits inside operations, schemas, security schemes or
+examples that the merger copies as opaque values. Phase 3 asserts that
+pass-through rather than assuming it.
+
+**The most important fix is `query` and `additionalOperations`,** because of how
+the eight-method assumption fails. `countOperationsInPathItem` scores a path
+item by counting the eight classic methods, and `dropPathItemsWithNoOperations`
+**deletes any path item scoring zero**. A 3.2 path whose only operations are
+`query` and `additionalOperations` therefore scores 0 and the entire endpoint is
+silently deleted — measured in
+[`proposal-openapi-3.2-support.md`](proposal-openapi-3.2-support.md) §0.
+
+## 1. Goals
+
+1. `SUPPORTED_MINOR_VERSIONS` becomes `['3.0', '3.1', '3.2']`, truthfully.
+2. `query` and `additionalOperations` are first-class everywhere a method is
+   considered: operation counting, `operationId` uniqueness, `$ref` walking, and
+   tag-based operation selection.
+3. `$self` has a defined, documented merge behaviour.
+4. Tag `summary` / `parent` / `kind` survive a merge.
+5. The additive 3.2 fields that need no logic are covered by tests proving they
+   pass through.
+
+## 2. Non-goals
+
+- Automatic upconversion between versions
+  ([`proposal-mixed-version-inputs.md`](proposal-mixed-version-inputs.md)).
+- Validating output against the published 3.2 JSON Schema. Still worth doing;
+  still separate.
+- Replacing `@atlassian/atlassian-openapi`. Phase 2 showed the local type delta
+  works; 3.2 extends the same delta.
+- Interpreting `x-tagGroups` in terms of the new native tag `parent`/`kind`.
+  That is issue #60's territory.
+
+## 3. Design
+
+### 3.1 One list of methods, not four
+
+The eight-method assumption is currently duplicated in four places:
+
+| File | Function |
+| --- | --- |
+| `paths-and-components.ts` | `countOperationsInPathItem` |
+| `paths-and-components.ts` | `ensureUniqueOperationIds` |
+| `reference-walker.ts` | `walkPathItemReferences` |
+| `operation-selection.ts` | `allMethods` |
+
+Four copies is why the `/search` deletion bug was possible at all: adding a
+method means remembering four places, and forgetting one fails silently.
+
+Phase 3 replaces all four with a single shared helper that yields every
+operation in a Path Item — the nine standard methods plus every entry in
+`additionalOperations`. Each call site then iterates that instead of naming
+methods. Adding a tenth method in some future OpenAPI version becomes a one-line
+change with no silent-failure mode.
+
+This is the main structural decision in phase 3, and it is worth more than 3.2
+support on its own.
+
+### 3.2 `$self`
+
+`$self` declares a document's own identity URI. Two inputs with different
+`$self` values are two documents with two identities, and the merged output is a
+third document that is neither.
+
+Options: take the first (like `info`), drop it, or error. **Taking the first
+would be wrong** — it would assert an identity the merged document does not
+have, and `$self` participates in reference resolution, so a stale value can
+change how relative `$ref`s resolve.
+
+**Decision: drop `$self` from the output**, and do so silently only when there
+is nothing to lose. Concretely: if exactly one input declares `$self` and it is
+the only input, keep it; otherwise omit it. A merged document should not claim
+to be one of its inputs.
+
+### 3.3 Tags
+
+`tags.ts` merges by `name` and copies the whole tag object, so `summary`,
+`parent` and `kind` should already survive. Phase 3 asserts this rather than
+assuming it, and checks that two inputs declaring the same tag name with
+different `parent` values do not silently lose one.
+
+## 4. Test plan
+
+- a path item whose only operation is `query` **survives** — the regression test
+  for the deleted `/search` endpoint;
+- a path item whose only operations are in `additionalOperations` survives;
+- `operationId`s inside `query` and `additionalOperations` participate in
+  uniqueness;
+- `$ref`s inside `query` and `additionalOperations` operations are rewritten;
+- `excludeTags` / `includeTags` apply to `query` and `additionalOperations`;
+- `$self` is dropped when merging more than one input, kept for a single input;
+- tag `summary` / `parent` / `kind` survive;
+- pass-through assertions for `itemSchema`, discriminator `defaultMapping`,
+  OAuth2 device flow, and `in: querystring`;
+- mixed 3.1 + 3.2 is refused with `mixed-openapi-versions`;
+- every existing 3.0 and 3.1 test still passes.
+
+## 5. Natural stopping point
+
+After phase 3 the library merges every published OpenAPI 3.x version, refuses
+mixed versions, and refuses anything it does not know. The four-way duplication
+that made silent method-related loss possible is gone.
+
+That completes the three-phase sequence. The obvious follow-ups —
+validating output against the published JSON Schema, and auto-upconversion —
+are both already written up and both now unblocked.
+
+## 6. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Refactoring four call sites at once | 264 existing tests, all of which exercise these paths; the refactor is behaviour-preserving for 3.0/3.1 by construction |
+| `additionalOperations` keys are arbitrary | Treated as opaque strings; only their Operation values are interpreted |
+| Dropping `$self` surprises someone | Documented in the README and asserted by a test; §3.2 explains why keeping it would be worse |
+| `query` colliding with a `querystring` parameter location | Unrelated namespaces; a test covers both appearing together |

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -181,20 +181,32 @@ They are separate from each other so that CI can branch on **retryability**:
 
 ### OpenAPI version support
 
-This tool merges **OpenAPI 3.0.x and 3.1.x** documents. Every input must
-declare a full `openapi` version (for example `"3.1.1"`), and all inputs must
+This tool merges **OpenAPI 3.0.x, 3.1.x and 3.2.x** documents. Every input must
+declare a full `openapi` version (for example `"3.2.0"`), and all inputs must
 agree on the `major.minor` version — patch differences such as `3.1.0` and
-`3.1.1` are fine, since they are the same feature set, but 3.0 and 3.1 inputs
-cannot be mixed.
+`3.1.1` are fine, since they are the same feature set, but 3.0, 3.1 and 3.2
+inputs cannot be mixed with each other.
 
-3.1 support covers the constructs 3.1 added: `webhooks` merge exactly like
-paths (same duplicate rule, same `operationId` uniqueness, same `$ref`
-rewriting), `components.pathItems` deduplicate like any other component,
-`jsonSchemaDialect` is carried through, and a webhooks-only document with no
-`paths` at all is valid input.
+**3.1** support covers `webhooks` (which merge exactly like paths: same
+duplicate rule, same `operationId` uniqueness, same `$ref` rewriting),
+`components.pathItems`, `jsonSchemaDialect`, and documents with no `paths` at
+all.
 
-An input declaring 3.2, no version at all, or a version that disagrees with the
-other inputs exits with code `9` and a message naming the offending input.
+**3.2** support covers the `query` HTTP method and `additionalOperations`
+(custom verbs such as `PURGE`), which participate fully in operation counting,
+`operationId` uniqueness, `$ref` rewriting and tag-based selection. The new tag
+fields `summary`, `parent` and `kind` are carried through, as are
+`itemSchema`, discriminator `defaultMapping`, OAuth2 device-authorization
+flows and `in: querystring` parameters.
+
+`$self` is a special case: it declares a document's *own* identity, and a
+merged document is not any of its inputs. It is kept when there is exactly one
+input and **dropped** otherwise, rather than arbitrarily inheriting one input's
+identity — which would also affect how relative `$ref`s resolve.
+
+An input declaring a version this tool does not know, no version at all, or a
+version that disagrees with the other inputs exits with code `9` and a message
+naming the offending input.
 
 **The output now declares the version the inputs used**, rather than always
 `3.0.3`. Merging documents that declare `3.0.0` now produces `3.0.0`. Relabelling

--- a/packages/openapi-merge-cli/src/__tests__/main-integration.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/main-integration.test.ts
@@ -451,8 +451,8 @@ describe('main - exit codes', () => {
 });
 
 describe('main - OpenAPI version checking', () => {
-  it('exits ErrorOpenApiVersion for a 3.2 input', async () => {
-    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.2.0' });
+  it('exits ErrorOpenApiVersion for a 3.3 input', async () => {
+    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.3.0' });
     const config = writeJson('openapi-merge.json', {
       inputs: [{ inputFile: './a.json' }],
       output: './output.json',
@@ -462,7 +462,7 @@ describe('main - OpenAPI version checking', () => {
   });
 
   it('names the offending input and its version on stderr', async () => {
-    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.2.0' });
+    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.3.0' });
     const config = writeJson('openapi-merge.json', {
       inputs: [{ inputFile: './a.json' }],
       output: './output.json',
@@ -472,12 +472,12 @@ describe('main - OpenAPI version checking', () => {
 
     const output = stderr.join('\n');
     expect(output).toContain('Input 0');
-    expect(output).toContain('3.2.0');
+    expect(output).toContain('3.3.0');
   });
 
   it('writes no output file when a version is unsupported', async () => {
     // The assertion that proves the failure is real rather than cosmetic.
-    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.2.0' });
+    writeJson('a.json', { ...(oas({ '/a': getPath('getA') }) as object), openapi: '3.3.0' });
     const config = writeJson('openapi-merge.json', {
       inputs: [{ inputFile: './a.json' }],
       output: './output.json',

--- a/packages/openapi-merge/src/__tests__/oas32.test.ts
+++ b/packages/openapi-merge/src/__tests__/oas32.test.ts
@@ -1,0 +1,280 @@
+import { merge } from '..';
+import { isErrorResult, MergeResult } from '../data';
+import { getPathItemOperations, HTTP_METHODS, OpenApiDocument, PathItem32 } from '../oas31';
+
+function doc(partial: Partial<OpenApiDocument>): OpenApiDocument {
+  return { openapi: '3.2.0', info: { title: 'Test', version: '1.0.0' }, ...partial } as OpenApiDocument;
+}
+
+function expectSuccess(result: MergeResult): OpenApiDocument {
+  if (isErrorResult(result)) {
+    throw new Error(`Expected a successful merge, got: ${result.message} (${result.type})`);
+  }
+  return result.output;
+}
+
+const okResponse = { '200': { description: 'ok' } };
+const op = (operationId: string): { operationId: string; responses: typeof okResponse } =>
+  ({ operationId, responses: okResponse });
+
+describe('HTTP_METHODS', () => {
+  it('includes query, the 3.2 addition', () => {
+    expect([...HTTP_METHODS]).toEqual([
+      'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace', 'query',
+    ]);
+  });
+});
+
+describe('getPathItemOperations', () => {
+  it('finds standard methods and additionalOperations together', () => {
+    const pathItem: PathItem32 = {
+      get: op('getThing'),
+      query: op('queryThing'),
+      additionalOperations: { PURGE: op('purgeThing'), LOCK: op('lockThing') },
+    };
+
+    const found = getPathItemOperations(pathItem);
+
+    expect(found.map(f => f.method).sort()).toEqual(['LOCK', 'PURGE', 'get', 'query']);
+    expect(found.filter(f => f.isAdditional).map(f => f.method).sort()).toEqual(['LOCK', 'PURGE']);
+  });
+
+  it('returns nothing for a path item with no operations', () => {
+    expect(getPathItemOperations({ parameters: [] })).toEqual([]);
+  });
+});
+
+describe('3.2 - query and additionalOperations survive', () => {
+  it('keeps a path whose only operation is query', () => {
+    // The regression test for the measured bug: countOperationsInPathItem
+    // scored this 0 and dropPathItemsWithNoOperations deleted the endpoint.
+    const output = expectSuccess(merge([{ oas: doc({
+      paths: { '/search': { query: op('searchQ') } },
+    }) }]));
+
+    expect(Object.keys(output.paths ?? {})).toEqual(['/search']);
+    expect(output.paths?.['/search'].query?.operationId).toBe('searchQ');
+  });
+
+  it('keeps a path whose only operations are additionalOperations', () => {
+    const output = expectSuccess(merge([{ oas: doc({
+      paths: { '/cache': { additionalOperations: { PURGE: op('purge') } } },
+    }) }]));
+
+    expect(Object.keys(output.paths ?? {})).toEqual(['/cache']);
+    expect(output.paths?.['/cache'].additionalOperations?.PURGE.operationId).toBe('purge');
+  });
+
+  it('still drops a path item that genuinely has no operations', () => {
+    // The behaviour the counting exists for must not regress.
+    const output = expectSuccess(merge([{ oas: doc({
+      paths: { '/empty': { parameters: [] }, '/real': { get: op('getReal') } },
+    }) }]));
+
+    expect(Object.keys(output.paths ?? {})).toEqual(['/real']);
+  });
+});
+
+describe('3.2 - operationId uniqueness covers the new slots', () => {
+  it('disambiguates a clash between query operations', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ paths: { '/a': { query: op('same') } } }) },
+      { oas: doc({ paths: { '/b': { query: op('same') } } }) },
+    ]));
+
+    expect(output.paths?.['/b'].query?.operationId).toBe('same1');
+  });
+
+  it('disambiguates a clash between a get and an additionalOperations verb', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({ paths: { '/a': { get: op('same') } } }) },
+      { oas: doc({ paths: { '/b': { additionalOperations: { PURGE: op('same') } } } }) },
+    ]));
+
+    expect(output.paths?.['/b'].additionalOperations?.PURGE.operationId).toBe('same1');
+  });
+});
+
+describe('3.2 - references inside the new slots', () => {
+  it('rewrites a $ref inside a query operation when its component is renamed', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({
+        paths: { '/a': { get: op('getA') } },
+        components: { schemas: { Thing: { type: 'string' } } },
+      }) },
+      { oas: doc({
+        paths: { '/search': { query: {
+          operationId: 'searchQ',
+          requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Thing' } } } },
+          responses: okResponse,
+        } } },
+        components: { schemas: { Thing: { type: 'number' } } },
+      }) },
+    ]));
+
+    const body = output.paths?.['/search'].query?.requestBody;
+    const ref = (body as { content: { [k: string]: { schema: { $ref: string } } } })
+      .content['application/json'].schema.$ref;
+
+    expect(ref).toBe('#/components/schemas/Thing1');
+  });
+
+  it('rewrites a $ref inside an additionalOperations verb', () => {
+    const output = expectSuccess(merge([
+      { oas: doc({
+        paths: { '/a': { get: op('getA') } },
+        components: { schemas: { Thing: { type: 'string' } } },
+      }) },
+      { oas: doc({
+        paths: { '/cache': { additionalOperations: { PURGE: {
+          operationId: 'purge',
+          requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Thing' } } } },
+          responses: okResponse,
+        } } } },
+        components: { schemas: { Thing: { type: 'number' } } },
+      }) },
+    ]));
+
+    const body = output.paths?.['/cache'].additionalOperations?.PURGE.requestBody;
+    const ref = (body as { content: { [k: string]: { schema: { $ref: string } } } })
+      .content['application/json'].schema.$ref;
+
+    expect(ref).toBe('#/components/schemas/Thing1');
+  });
+});
+
+describe('3.2 - tag selection covers the new slots', () => {
+  it('excludes a query operation by tag', () => {
+    const output = expectSuccess(merge([{
+      oas: doc({ paths: { '/search': {
+        query: { ...op('searchQ'), tags: ['internal'] },
+        get: { ...op('getSearch'), tags: ['public'] },
+      } } }),
+      operationSelection: { excludeTags: ['internal'] },
+    }]));
+
+    expect(output.paths?.['/search'].query).toBeUndefined();
+    expect(output.paths?.['/search'].get).toBeDefined();
+  });
+
+  it('excludes an additionalOperations verb by tag', () => {
+    const output = expectSuccess(merge([{
+      oas: doc({ paths: { '/cache': {
+        get: { ...op('getCache'), tags: ['public'] },
+        additionalOperations: { PURGE: { ...op('purge'), tags: ['internal'] } },
+      } } }),
+      operationSelection: { excludeTags: ['internal'] },
+    }]));
+
+    expect(output.paths?.['/cache'].additionalOperations?.PURGE).toBeUndefined();
+    expect(output.paths?.['/cache'].get).toBeDefined();
+  });
+
+  it('includes only tagged query operations', () => {
+    const output = expectSuccess(merge([{
+      oas: doc({ paths: { '/search': {
+        query: { ...op('searchQ'), tags: ['wanted'] },
+        get: { ...op('getSearch'), tags: ['unwanted'] },
+      } } }),
+      operationSelection: { includeTags: ['wanted'] },
+    }]));
+
+    expect(output.paths?.['/search'].query).toBeDefined();
+    expect(output.paths?.['/search'].get).toBeUndefined();
+  });
+});
+
+describe('3.2 - $self', () => {
+  it('keeps $self when there is exactly one input', () => {
+    const output = expectSuccess(merge([{ oas: doc({
+      $self: 'https://example.com/api',
+      paths: { '/a': { get: op('getA') } },
+    }) }]));
+
+    expect(output.$self).toBe('https://example.com/api');
+  });
+
+  it('drops $self when merging more than one input', () => {
+    // A merged document is not any of its inputs, and $self participates in
+    // reference resolution, so carrying one forward would be actively wrong.
+    const output = expectSuccess(merge([
+      { oas: doc({ $self: 'https://example.com/first', paths: { '/a': { get: op('getA') } } }) },
+      { oas: doc({ $self: 'https://example.com/second', paths: { '/b': { get: op('getB') } } }) },
+    ]));
+
+    expect(output.$self).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('$self');
+  });
+});
+
+describe('3.2 - additive fields pass through', () => {
+  it('carries tag summary, parent and kind', () => {
+    const output = expectSuccess(merge([{ oas: doc({
+      tags: [{ name: 'admin', summary: 'Admin', parent: 'root', kind: 'nav' }],
+      paths: { '/a': { get: op('getA') } },
+    }) }]));
+
+    expect(output.tags?.[0]).toEqual({ name: 'admin', summary: 'Admin', parent: 'root', kind: 'nav' });
+  });
+
+  it('carries discriminator defaultMapping and itemSchema', () => {
+    const output = expectSuccess(merge([{ oas: doc({
+      paths: { '/a': { get: op('getA') } },
+      components: { schemas: { Pet: {
+        oneOf: [{ $ref: '#/components/schemas/Dog' }],
+        discriminator: { propertyName: 'kind', defaultMapping: '#/components/schemas/Dog' },
+        itemSchema: { type: 'string' },
+      }, Dog: { type: 'object' } } },
+    } as Partial<OpenApiDocument>) }]));
+
+    const pet = output.components?.schemas?.Pet as Record<string, unknown>;
+    expect((pet.discriminator as Record<string, unknown>).defaultMapping).toBe('#/components/schemas/Dog');
+    expect(pet.itemSchema).toEqual({ type: 'string' });
+  });
+
+  it('carries an in: querystring parameter alongside a query operation', () => {
+    // Unrelated namespaces that happen to share a word; both must survive.
+    const output = expectSuccess(merge([{ oas: doc({
+      paths: { '/search': { query: {
+        ...op('searchQ'),
+        parameters: [{ name: 'filter', in: 'querystring', schema: { type: 'string' } }],
+      } } },
+    } as Partial<OpenApiDocument>) }]));
+
+    const params = output.paths?.['/search'].query?.parameters as Array<Record<string, unknown>>;
+    expect(params[0].in).toBe('querystring');
+  });
+
+  it('carries an OAuth2 device authorization flow', () => {
+    const output = expectSuccess(merge([{ oas: doc({
+      paths: { '/a': { get: op('getA') } },
+      components: { securitySchemes: { oauth: { type: 'oauth2', oauth2MetadataUrl: 'https://example.com/.well-known', flows: {
+        deviceAuthorization: { deviceAuthorizationUrl: 'https://example.com/device', tokenUrl: 'https://example.com/token', scopes: {} },
+      } } } },
+    } as Partial<OpenApiDocument>) }]));
+
+    const scheme = output.components?.securitySchemes?.oauth as Record<string, unknown>;
+    expect(scheme.oauth2MetadataUrl).toBe('https://example.com/.well-known');
+    expect((scheme.flows as Record<string, unknown>).deviceAuthorization).toBeDefined();
+  });
+});
+
+describe('3.2 - version rules', () => {
+  it('refuses a mix of 3.1 and 3.2 inputs', () => {
+    const result = merge([
+      { oas: doc({ openapi: '3.1.1', paths: { '/a': { get: op('getA') } } }) },
+      { oas: doc({ openapi: '3.2.0', paths: { '/b': { get: op('getB') } } }) },
+    ]);
+
+    if (!isErrorResult(result)) {
+      throw new Error('Expected a mixed-openapi-versions error');
+    }
+    expect(result.type).toBe('mixed-openapi-versions');
+  });
+
+  it('declares 3.2.0 on the output', () => {
+    const output = expectSuccess(merge([{ oas: doc({ paths: { '/a': { get: op('getA') } } }) }]));
+
+    expect(output.openapi).toBe('3.2.0');
+  });
+});

--- a/packages/openapi-merge/src/__tests__/openapi-version.test.ts
+++ b/packages/openapi-merge/src/__tests__/openapi-version.test.ts
@@ -76,11 +76,11 @@ describe('toMinorVersion', () => {
 });
 
 describe('SUPPORTED_MINOR_VERSIONS', () => {
-  it('contains 3.0 and 3.1 after phase 2', () => {
+  it('contains every published 3.x version after phase 3', () => {
     // Widened by each phase. This pins the contract so that adding a version is
-    // a deliberate act with a failing test to update -- which is exactly what
-    // happened when phase 2 added '3.1'.
-    expect([...SUPPORTED_MINOR_VERSIONS]).toEqual(['3.0', '3.1']);
+    // a deliberate act with a failing test to update -- which is what happened
+    // when phase 2 added '3.1' and phase 3 added '3.2'.
+    expect([...SUPPORTED_MINOR_VERSIONS]).toEqual(['3.0', '3.1', '3.2']);
   });
 });
 
@@ -100,20 +100,21 @@ describe('validateInputVersions', () => {
 });
 
 describe('merge - unsupported versions', () => {
-  it('rejects a 3.2 input and names the index and version', () => {
-    const message = expectError(merge(inputsAt('3.2.0')), 'unsupported-openapi-version');
+  it('rejects a 3.3 input and names the index and version', () => {
+    const message = expectError(merge(inputsAt('3.3.0')), 'unsupported-openapi-version');
 
     expect(message).toContain('Input 0');
-    expect(message).toContain('3.2.0');
-    expect(message).toContain('3.1.x');
+    expect(message).toContain('3.3.0');
+    expect(message).toContain('3.2.x');
   });
 
-  it('accepts a 3.1 input now that phase 2 supports it', () => {
+  it('accepts 3.1 and 3.2 inputs now that phases 2 and 3 support them', () => {
     expect(isErrorResult(merge(inputsAt('3.1.1')))).toBe(false);
+    expect(isErrorResult(merge(inputsAt('3.2.0')))).toBe(false);
   });
 
   it('names the offending input when it is not the first', () => {
-    const message = expectError(merge(inputsAt('3.0.3', '3.0.0', '3.2.0')), 'unsupported-openapi-version');
+    const message = expectError(merge(inputsAt('3.0.3', '3.0.0', '3.3.0')), 'unsupported-openapi-version');
 
     expect(message).toContain('Input 2');
   });
@@ -178,7 +179,7 @@ describe('merge - version checking runs first', () => {
     // These two inputs also have duplicate paths, which would normally be a
     // 'duplicate-paths' error. The version problem must win, because nothing
     // should be merged at all.
-    const result = merge(inputsAt('3.2.0', '3.2.0'));
+    const result = merge(inputsAt('3.3.0', '3.3.0'));
 
     expectError(result, 'unsupported-openapi-version');
   });

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -23,6 +23,19 @@ function getFirstMatching<A, B>(inputs: Array<A>, extract: (input: A) => B | und
 }
 
 /**
+ * `$self` (3.2) declares a document's own identity URI.
+ *
+ * Merging several documents produces a third document that is none of them, so
+ * carrying one input's `$self` forward would assert an identity the output does
+ * not have -- and because `$self` participates in reference resolution, a stale
+ * value can change how relative `$ref`s resolve. It is therefore kept only in
+ * the degenerate single-input case, where the output really is that document.
+ */
+function mergeSelf(inputs: MergeInput): string | undefined {
+  return inputs.length === 1 ? inputs[0].oas.$self : undefined;
+}
+
+/**
  * Swagger Merge Tool
  */
 export function merge(inputs: MergeInput): MergeResult {
@@ -62,6 +75,7 @@ export function merge(inputs: MergeInput): MergeResult {
       // Omitted entirely for 3.0 documents, which cannot declare webhooks.
       webhooks: Object.keys(webhooks).length === 0 ? undefined : webhooks,
       jsonSchemaDialect: getFirstMatching(inputs, input => input.oas.jsonSchemaDialect),
+      $self: mergeSelf(inputs),
       components,
     },
     inputs.map(input => input.oas)

--- a/packages/openapi-merge/src/oas31.ts
+++ b/packages/openapi-merge/src/oas31.ts
@@ -13,8 +13,77 @@ import { Swagger } from '@atlassian/atlassian-openapi';
  * the constructs this library has to merge.
  */
 
+/**
+ * The nine HTTP methods a Path Item may carry.
+ *
+ * `query` is the 3.2 addition. This list exists once; every place that needs to
+ * consider "all the operations in a path item" goes through
+ * {@link getPathItemOperations} rather than repeating it. Four separate copies
+ * of the eight-method version of this list is why a 3.2 path item containing
+ * only `query` was scored as having zero operations and deleted outright.
+ */
+export const HTTP_METHODS = [
+  'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace', 'query',
+] as const;
+
+export type HttpMethod = typeof HTTP_METHODS[number];
+
+/**
+ * A Path Item, including the 3.2 additions.
+ *
+ * `query` is a normal method slot. `additionalOperations` maps arbitrary custom
+ * verbs (`PURGE`, `LOCK`, ...) to Operations; its keys are opaque to us, only
+ * the Operation values are interpreted.
+ */
+export type PathItem32 = Swagger.PathItem & {
+  query?: Swagger.Operation;
+  additionalOperations?: { [method: string]: Swagger.Operation };
+};
+
+/**
+ * A Tag, including the 3.2 additions.
+ *
+ * `summary` supersedes the `x-displayName` extension, `parent` enables
+ * hierarchical tags, and `kind` classifies a tag (`nav`, `badge`, `audience`).
+ * They are carried through the merge as ordinary tag fields.
+ */
+export type Tag32 = Swagger.Tag & {
+  summary?: string;
+  parent?: string;
+  kind?: string;
+};
+
 /** A map of name to Path Item, the shape shared by `paths` and `webhooks`. */
-export type PathItemMap = { [key: string]: Swagger.PathItem };
+export type PathItemMap = { [key: string]: PathItem32 };
+
+/**
+ * Every operation a Path Item contains: the nine standard methods plus any
+ * custom verbs under `additionalOperations`.
+ *
+ * Returns entries rather than just values so callers that need to delete an
+ * operation (tag-based selection) can address it.
+ */
+export function getPathItemOperations(
+  pathItem: PathItem32,
+): Array<{ method: string; operation: Swagger.Operation; isAdditional: boolean }> {
+  const found: Array<{ method: string; operation: Swagger.Operation; isAdditional: boolean }> = [];
+
+  for (const method of HTTP_METHODS) {
+    const operation = pathItem[method];
+    if (operation !== undefined) {
+      found.push({ method, operation, isAdditional: false });
+    }
+  }
+
+  const additional = pathItem.additionalOperations;
+  if (additional !== undefined) {
+    for (const method of Object.keys(additional)) {
+      found.push({ method, operation: additional[method], isAdditional: true });
+    }
+  }
+
+  return found;
+}
 
 /**
  * 3.1 adds `pathItems` to the component types.
@@ -40,7 +109,10 @@ export type Components31 = Swagger.Components & {
  * - `components` may carry `pathItems`.
  */
 export type OpenApiDocument = Omit<Swagger.SwaggerV3, 'paths' | 'components'> & {
-  paths?: Swagger.Paths;
+  paths?: PathItemMap;
+  /** 3.2: the document's own identity URI. See the merge policy in oas32 tests. */
+  $self?: string;
+  tags?: Tag32[];
   webhooks?: PathItemMap;
   jsonSchemaDialect?: string;
   components?: Components31;

--- a/packages/openapi-merge/src/openapi-version.ts
+++ b/packages/openapi-merge/src/openapi-version.ts
@@ -24,7 +24,7 @@ export type OpenApiVersion = {
  * 3 adds '3.2'. Adding an entry here is a claim that the merge logic handles
  * that version's constructs -- do not add one without the work behind it.
  */
-export const SUPPORTED_MINOR_VERSIONS: ReadonlyArray<string> = ['3.0', '3.1'];
+export const SUPPORTED_MINOR_VERSIONS: ReadonlyArray<string> = ['3.0', '3.1', '3.2'];
 
 /** `major.minor`, the granularity at which compatibility is decided. */
 export function toMinorVersion(version: OpenApiVersion): string {

--- a/packages/openapi-merge/src/operation-selection.ts
+++ b/packages/openapi-merge/src/operation-selection.ts
@@ -1,11 +1,19 @@
 import _ from 'lodash';
 import { Swagger } from "@atlassian/atlassian-openapi";
 import { OperationSelection } from './data';
-import { OpenApiDocument } from './oas31';
+import { getPathItemOperations, HttpMethod, OpenApiDocument, PathItem32 } from './oas31';
 
-const allMethods: Swagger.Method[] = [
-  'get' , 'put' , 'post' , 'delete' , 'options' , 'head' , 'patch' , 'trace'
-]
+/**
+ * Remove an operation from a Path Item, whether it sits in a standard method
+ * slot or under `additionalOperations`.
+ */
+function deleteOperation(pathItem: PathItem32, method: string, isAdditional: boolean): void {
+  if (isAdditional) {
+    delete pathItem.additionalOperations?.[method];
+  } else {
+    delete pathItem[method as HttpMethod];
+  }
+}
 
 function operationContainsAnyTag(operation: Swagger.Operation, tags: string[]): boolean {
   return operation.tags !== undefined && operation.tags.some(tag => tags.includes(tag));
@@ -23,12 +31,11 @@ function dropOperationsThatHaveTags(originalOas: OpenApiDocument, excludedTags: 
     if (oas.paths.hasOwnProperty(path)) {
       const pathItem = oas.paths[path];
 
-      for (let i = 0; i < allMethods.length; i++) {
-        const method = allMethods[i];
-        const operation = pathItem[method];
-
-        if (operation !== undefined && operationContainsAnyTag(operation, excludedTags)) {
-          delete pathItem[method];
+      // Covers `query` and every custom verb in `additionalOperations`, so tag
+      // filtering cannot silently skip a 3.2 operation.
+      for (const { method, operation, isAdditional } of getPathItemOperations(pathItem)) {
+        if (operationContainsAnyTag(operation, excludedTags)) {
+          deleteOperation(pathItem, method, isAdditional);
         }
       }
     }
@@ -49,12 +56,11 @@ function includeOperationsThatHaveTags(originalOas: OpenApiDocument, includeTags
     if (oas.paths.hasOwnProperty(path)) {
       const pathItem = oas.paths[path];
 
-      for (let i = 0; i < allMethods.length; i++) {
-        const method = allMethods[i];
-        const operation = pathItem[method];
-
-        if (operation !== undefined && !operationContainsAnyTag(operation, includeTags)) {
-          delete pathItem[method];
+      // Covers `query` and every custom verb in `additionalOperations`, so tag
+      // filtering cannot silently skip a 3.2 operation.
+      for (const { method, operation, isAdditional } of getPathItemOperations(pathItem)) {
+        if (!operationContainsAnyTag(operation, includeTags)) {
+          deleteOperation(pathItem, method, isAdditional);
         }
       }
     }

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import { runOperationSelection } from "./operation-selection";
 import { deepEquality } from "./component-equivalence";
 import { applyDispute, getDispute } from './dispute';
-import { Components31, getPaths, getWebhooks, OpenApiDocument, PathItemMap } from './oas31';
+import { Components31, getPathItemOperations, getPaths, getWebhooks, OpenApiDocument, PathItem32, PathItemMap } from './oas31';
 
 export type PathAndComponents = {
   paths: Swagger.Paths;
@@ -77,17 +77,11 @@ function processComponents<A>(results: Components<A>, components: Components<A>,
   }
 }
 
-function countOperationsInPathItem(pathItem: Swagger.PathItem): number {
-  let count = 0;
-  count += pathItem.get !== undefined ? 1 : 0;
-  count += pathItem.put !== undefined ? 1 : 0;
-  count += pathItem.post !== undefined ? 1 : 0;
-  count += pathItem.delete !== undefined ? 1 : 0;
-  count += pathItem.options !== undefined ? 1 : 0;
-  count += pathItem.head !== undefined ? 1 : 0;
-  count += pathItem.patch !== undefined ? 1 : 0;
-  count += pathItem.trace !== undefined ? 1 : 0;
-  return count;
+function countOperationsInPathItem(pathItem: PathItem32): number {
+  // Counts `query` and `additionalOperations` too. Undercounting here is not a
+  // cosmetic bug: dropPathItemsWithNoOperations deletes anything scoring zero,
+  // so a 3.2 path item using only the new operation slots used to vanish.
+  return getPathItemOperations(pathItem).length;
 }
 
 function dropPathItemsWithNoOperations(originalOas: OpenApiDocument): OpenApiDocument {
@@ -147,26 +141,13 @@ function ensureUniqueOperationId(operation: Swagger.Operation, seenOperationIds:
   }
 }
 
-function ensureUniqueOperationIds(pathItem: Swagger.PathItem, seenOperationIds: Set<string>, dispute: Dispute | undefined): ErrorMergeResult | undefined {
-  const operations = [
-    pathItem.get,
-    pathItem.put,
-    pathItem.post,
-    pathItem.delete,
-    pathItem.patch,
-    pathItem.head,
-    pathItem.trace,
-    pathItem.options
-  ];
+function ensureUniqueOperationIds(pathItem: PathItem32, seenOperationIds: Set<string>, dispute: Dispute | undefined): ErrorMergeResult | undefined {
+  const operations = getPathItemOperations(pathItem);
 
   for (let opIndex = 0; opIndex < operations.length; opIndex++) {
-    const operation = operations[opIndex];
-
-    if (operation !== undefined) {
-      const result = ensureUniqueOperationId(operation, seenOperationIds, dispute);
-      if (result !== undefined) {
-        return result;
-      }
+    const result = ensureUniqueOperationId(operations[opIndex].operation, seenOperationIds, dispute);
+    if (result !== undefined) {
+      return result;
     }
   }
 }

--- a/packages/openapi-merge/src/reference-walker.ts
+++ b/packages/openapi-merge/src/reference-walker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-prototype-builtins */
 import { Swagger, SwaggerTypeChecks as TC } from "@atlassian/atlassian-openapi";
-import { Components31, getPaths, getWebhooks, OpenApiDocument, PathItemMap } from './oas31';
+import { Components31, getPathItemOperations, getPaths, getWebhooks, OpenApiDocument, PathItem32, PathItemMap } from './oas31';
 
 export type Modify = (input: string) => string;
 
@@ -205,18 +205,15 @@ function walkOperationReferences(operation: Swagger.Operation, modify: Modify): 
   }
 }
 
-function walkPathItemReferences(pathItem: Swagger.PathItem, modify: Modify): void {
+function walkPathItemReferences(pathItem: PathItem32, modify: Modify): void {
   if (pathItem['$ref'] !== undefined) {
     pathItem['$ref'] = modify(pathItem['$ref']);
   } else {
-    if (pathItem.get !== undefined) walkOperationReferences(pathItem.get, modify);
-    if (pathItem.put !== undefined) walkOperationReferences(pathItem.put, modify);
-    if (pathItem.post !== undefined) walkOperationReferences(pathItem.post, modify);
-    if (pathItem.delete !== undefined) walkOperationReferences(pathItem.delete, modify);
-    if (pathItem.options !== undefined) walkOperationReferences(pathItem.options, modify);
-    if (pathItem.head !== undefined) walkOperationReferences(pathItem.head, modify);
-    if (pathItem.patch !== undefined) walkOperationReferences(pathItem.patch, modify);
-    if (pathItem.trace !== undefined) walkOperationReferences(pathItem.trace, modify);
+    // Includes `query` and every custom verb in `additionalOperations`; a $ref
+    // inside one of those is a real reference and must be rewritten like any other.
+    for (const { operation } of getPathItemOperations(pathItem)) {
+      walkOperationReferences(operation, modify);
+    }
 
     if (pathItem.parameters !== undefined) {
       for (let parameterIndex = 0; parameterIndex < pathItem.parameters.length; parameterIndex++) {

--- a/packages/openapi-merge/src/tags.ts
+++ b/packages/openapi-merge/src/tags.ts
@@ -1,7 +1,7 @@
 import { MergeInput } from './data';
-import { Swagger } from '@atlassian/atlassian-openapi';
+import { Tag32 } from './oas31';
 
-function getNonExcludedTags(originalTags: Swagger.Tag[], excludedTagNames: string[]): Swagger.Tag[] {
+function getNonExcludedTags(originalTags: Tag32[], excludedTagNames: string[]): Tag32[] {
   if (excludedTagNames.length === 0) {
     return originalTags;
   }
@@ -9,8 +9,8 @@ function getNonExcludedTags(originalTags: Swagger.Tag[], excludedTagNames: strin
   return originalTags.filter(tag => !excludedTagNames.includes(tag.name));
 }
 
-export function mergeTags(inputs: MergeInput): Swagger.Tag[] | undefined {
-  const result = new Array<Swagger.Tag>();
+export function mergeTags(inputs: MergeInput): Tag32[] | undefined {
+  const result = new Array<Tag32>();
 
   const seenTags = new Set<string>();
   inputs.forEach(input => {


### PR DESCRIPTION
Implements ai-planning/proposal-oas-phase3-32-support.md. Widens SUPPORTED_MINOR_VERSIONS to ['3.0', '3.1', '3.2'], completing the sequence: the library now merges every published OpenAPI 3.x version.

3.1 -> 3.2 introduced no breaking changes, so most of 3.2 already passed through untouched -- it lives inside objects the merger copies wholesale. This phase asserts that pass-through with tests (itemSchema, discriminator defaultMapping, OAuth2 device flow, in: querystring) rather than assuming it, and implements the additions that genuinely interact with merge logic.

The important fix is `query` and `additionalOperations`. countOperationsInPathItem counted only the eight classic methods, and dropPathItemsWithNoOperations deletes any path item scoring zero -- so a 3.2 path whose only operations were `query` and a custom verb scored 0 and the entire endpoint was silently deleted.

The eight-method assumption was duplicated across four call sites (countOperationsInPathItem, ensureUniqueOperationIds, walkPathItemReferences, and operation-selection's allMethods). Four copies is why that bug was possible: adding a method meant remembering four places, and forgetting one failed silently. All four now go through a single getPathItemOperations helper that yields the nine standard methods plus every additionalOperations verb, so a future tenth method is a one-line change with no silent-failure mode. That refactor is worth more than 3.2 support on its own.

$self is dropped when merging more than one input and kept only for a single input. Carrying one forward would assert an identity the merged document does not have, and since $self participates in reference resolution, a stale value can change how relative $refs resolve.

Tag summary/parent/kind are modelled in the type delta rather than cast around, which meant tags.ts now returns Tag32.

Verified against the built binary: the 3.2 document whose /search endpoint was previously deleted outright now merges to openapi 3.2.0 with the endpoint intact, both its query and PURGE operations present, $self kept for the single input, and all three new tag fields carried through.