### PR TITLE
feat(merge): make securitySchemes merging configurable (#33)

### DIFF
--- a/ai-planning/issues/19-proposal-33-security-schemes.md
+++ b/ai-planning/issues/19-proposal-33-security-schemes.md
@@ -347,47 +347,88 @@ it('should update per-operation security references when scheme is renamed', () 
 
 Branch `issue/33-security-schemes`.
 
-### 10.1 The bucket list had moved
+### 10.1 Configurable, not a fixed behaviour change
 
-§3.1 says to add a new conditional block after the `callbacks` block. That
-shape no longer exists: the nine near-identical blocks were collapsed into a
-`DEDUPLICATED_COMPONENT_TYPES` loop, so this is now one word added to a list.
-The special-case first-wins block for `securitySchemes` was deleted.
+The first version of this change simply made `securitySchemes` merge like every
+other bucket, and rewrote three tests that asserted the old behaviour. Raised in
+review: this repository already has a pattern for "the merge could reasonably do
+either" — `serversStrategy` (#4), `duplicatePathHandling` (#71),
+`pruneUnusedComponents` (#94) — and this is that kind of question, not a
+one-answer bug.
 
-### 10.2 Renames needed a second channel, not the reference walker
+It is now `securitySchemesStrategy` in `MergeOptions`, shaped after
+`serversStrategy`, with three values:
 
-§2 identified the important part and it is worth restating: a Security
-Requirement names its scheme as an **object key**, not a `$ref`. The
-`referenceModification` map only rewrites `#/components/...` strings, so a
-renamed scheme leaves every requirement pointing at a name that no longer
-exists — a document that looks valid and authorises nothing.
+| Value | Behaviour | Who it is for |
+| --- | --- | --- |
+| `merge` *(default)* | Combine like every other bucket: identical definitions collapse, differing ones are renamed via dispute prefix or numeric suffix, and every requirement naming a renamed scheme is rewritten | Anyone merging peer services |
+| `first` | Take the first input that declares any, drop the rest | An API gateway: it owns authentication, and a backend's scheme definitions are an implementation detail |
+| `error` | Combine, but refuse when two inputs define the same name differently | Anyone who would rather be told than find `oauth2` and `oauth21` in their output |
 
-Added `securitySchemeRenames`, populated from the same rename callback, applied
-by a new `renameSecurityRequirements` over the input's clone: the document-level
-`security` array and every operation's, across both `paths` and `webhooks`.
+### 10.2 Why `error` earns its place
 
-### 10.3 Document-level `security` had to move upstream
+It is not merely "strict mode". Under `merge`, two services that both define
+`oauth2` — pointing at different authorization URLs — produce a valid document
+containing `oauth2` and `oauth21`, and the second service's operations quietly
+require the renamed one. That is correct, and it is also the kind of thing a
+platform team would want to hear about rather than discover in a generated SDK.
 
-Not anticipated by the proposal. `index.ts` read `security` off the *original*
-inputs with `getFirstMatching`, so the rewritten copy was discarded and the
-top-level requirement kept the stale name. `PathAndComponents` now carries
-`security`, still first-wins but taken after renames. This was caught by a test,
-not by inspection.
+Identical definitions still collapse under `error`. Two inputs agreeing is not a
+conflict, and failing on agreement would make the option useless in the case it
+is most likely to be switched on for.
 
-### 10.4 This is a behaviour change, and three existing tests said so
+### 10.3 The default changes behaviour, deliberately
 
-Three tests asserted the old behaviour directly — that a later input's schemes
-are dropped. They encoded the bug, so they were rewritten to assert the new
-contract, with a comment saying what changed and why. Anyone relying on later
-inputs' schemes being discarded will see them appear.
+`serversStrategy` defaults to `'first'`, preserving what the tool always did.
+This one defaults to `'merge'`, which does not.
 
-Note the two concerns stay separate, exactly as §2 argued: top-level `security`
-is still first-wins. Only `securitySchemes` merges.
+The difference is that first-wins for `servers` produces a *defensible*
+document, while first-wins for `securitySchemes` produces an **invalid** one:
+a later input's operations survive while the schemes they require do not, so the
+output references a scheme it never defines. Issue #33 is filed as a bug and
+quotes exactly that symptom. Defaulting to `'first'` would leave it unfixed for
+everyone who does not read the changelog.
 
-### 10.5 Verification
+It remains a breaking change for anyone relying on the drop, and `'first'` is
+one word away. That trade is the reason this section exists.
 
-- 7 new tests in `components.test.ts`, which owns component deduplication and
-  renaming. **5 fail against `origin/main`**, confirmed in a detached worktree.
-- 3 rewritten tests in `document-metadata.test.ts` covering the first-wins
-  top-level `security` that did *not* change.
-- Gate green: lint, 390 tests, 48 artifact checks across Node and Bun.
+### 10.4 Renames need a second channel, not the reference walker
+
+Unchanged from the original design, and still the substantive part. A Security
+Requirement names its scheme as an **object key** — `{ apiKey: [] }` — not a
+`$ref`, so `referenceModification` cannot see it. A renamed scheme leaves every
+requirement pointing at a name that no longer exists: a document that looks
+valid and authorises nothing.
+
+`securitySchemeRenames` is populated from the same rename callback and applied
+by `renameSecurityRequirements` over the document-level `security` array and
+every operation's, across both `paths` and `webhooks`.
+
+### 10.5 Document-level `security` had to move upstream
+
+Also unchanged. `index.ts` read `security` off the *original* inputs, so the
+rewritten copy was discarded and the top-level requirement kept the stale name.
+`PathAndComponents` now carries it — still first-wins, but after renames. Caught
+by a test, not by inspection.
+
+### 10.6 Three tests changed meaning
+
+Three existing tests asserted that a later input's schemes are dropped. They now
+assert the same thing under `securitySchemesStrategy: 'first'`, and the default
+path has its own coverage. Nobody's expectation is deleted; it is relabelled as
+one of three choices.
+
+One of them pins the defect deliberately: under `'first'`, a later input's
+requirement still names a scheme the output no longer defines. That is the
+documented cost of the gateway behaviour, and choosing it should be informed.
+
+### 10.7 Verification
+
+- 10 strategy tests in `components.test.ts` covering all three values, the
+  default, `error` collapsing identical definitions, `error` not firing on a
+  scheme only one input declares, and that the other nine buckets keep merging
+  regardless.
+- 7 tests for the rename machinery, unchanged from the original design.
+- 4 CLI tests: the default, `first`, `error` exiting 3, and ajv rejecting an
+  unknown value.
+- Gate green: lint, 487 tests, 48 artifact checks.

--- a/ai-planning/issues/19-proposal-33-security-schemes.md
+++ b/ai-planning/issues/19-proposal-33-security-schemes.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#33 — Merge securitySchemes of input files](https://github.com/robertmassaioli/openapi-merge/issues/33)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 | **Effort:** 3 | **ROI:** High
 
@@ -339,3 +339,55 @@ it('should update per-operation security references when scheme is renamed', () 
 6. [ ] Run `yarn lint` to ensure compliance.
 
 7. [ ] (Optional) Update README or CHANGELOG to document the new behavior.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/33-security-schemes`.
+
+### 10.1 The bucket list had moved
+
+§3.1 says to add a new conditional block after the `callbacks` block. That
+shape no longer exists: the nine near-identical blocks were collapsed into a
+`DEDUPLICATED_COMPONENT_TYPES` loop, so this is now one word added to a list.
+The special-case first-wins block for `securitySchemes` was deleted.
+
+### 10.2 Renames needed a second channel, not the reference walker
+
+§2 identified the important part and it is worth restating: a Security
+Requirement names its scheme as an **object key**, not a `$ref`. The
+`referenceModification` map only rewrites `#/components/...` strings, so a
+renamed scheme leaves every requirement pointing at a name that no longer
+exists — a document that looks valid and authorises nothing.
+
+Added `securitySchemeRenames`, populated from the same rename callback, applied
+by a new `renameSecurityRequirements` over the input's clone: the document-level
+`security` array and every operation's, across both `paths` and `webhooks`.
+
+### 10.3 Document-level `security` had to move upstream
+
+Not anticipated by the proposal. `index.ts` read `security` off the *original*
+inputs with `getFirstMatching`, so the rewritten copy was discarded and the
+top-level requirement kept the stale name. `PathAndComponents` now carries
+`security`, still first-wins but taken after renames. This was caught by a test,
+not by inspection.
+
+### 10.4 This is a behaviour change, and three existing tests said so
+
+Three tests asserted the old behaviour directly — that a later input's schemes
+are dropped. They encoded the bug, so they were rewritten to assert the new
+contract, with a comment saying what changed and why. Anyone relying on later
+inputs' schemes being discarded will see them appear.
+
+Note the two concerns stay separate, exactly as §2 argued: top-level `security`
+is still first-wins. Only `securitySchemes` merges.
+
+### 10.5 Verification
+
+- 7 new tests in `components.test.ts`, which owns component deduplication and
+  renaming. **5 fail against `origin/main`**, confirmed in a detached worktree.
+- 3 rewritten tests in `document-metadata.test.ts` covering the first-wins
+  top-level `security` that did *not* change.
+- Gate green: lint, 390 tests, 48 artifact checks across Node and Bun.

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -279,3 +279,48 @@ describe('main - tag injection (issue #112)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #33: securitySchemesStrategy reaching the library from a config file.
+ */
+describe('main - securitySchemesStrategy (issue #33)', () => {
+  const withScheme = (pathName: string, opId: string, headerName: string) => ({
+    openapi: '3.0.3',
+    info: { title: 'T', version: '1.0.0' },
+    paths: { [pathName]: { get: { operationId: opId, responses: { '200': { description: 'ok' } }, security: [{ auth: [] }] } } },
+    components: { securitySchemes: { auth: { type: 'apiKey', in: 'header', name: headerName } } },
+  });
+
+  const twoInputs = (strategy?: string) => {
+    cli.writeJson('a.json', withScheme('/a', 'getA', 'X-First'));
+    cli.writeJson('b.json', withScheme('/b', 'getB', 'X-Second'));
+    return cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json' }],
+      output: './output.json',
+      ...(strategy === undefined ? {} : { securitySchemesStrategy: strategy }),
+    });
+  };
+
+  it('merges by default', async () => {
+    expect(await cli.run('-c', twoInputs())).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read());
+    expect(Object.keys(output.components.securitySchemes).sort()).toEqual(['auth', 'auth1']);
+    expect(output.paths['/b'].get.security).toEqual([{ auth1: [] }]);
+  });
+
+  it("keeps only the first input's schemes with 'first'", async () => {
+    expect(await cli.run('-c', twoInputs('first'))).toBe(ExitCode.Success);
+
+    expect(Object.keys(JSON.parse(cli.read()).components.securitySchemes)).toEqual(['auth']);
+  });
+
+  it("exits 3 with 'error' when two inputs disagree about a scheme", async () => {
+    expect(await cli.run('-c', twoInputs('error'))).toBe(ExitCode.ErrorMerging);
+    expect(cli.stderr().join('\n')).toContain('auth');
+  });
+
+  it('rejects an unknown strategy against the generated schema', async () => {
+    expect(await cli.run('-c', twoInputs('combine-somehow'))).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -276,6 +276,24 @@ export type Configuration = {
   serversStrategy?: 'first' | 'concat';
 
   /**
+   * How `components.securitySchemes` are combined across inputs (issue #33).
+   *
+   * - `merge` (default) -- combine them, exactly as every other component type
+   *   is combined: identical definitions collapse, differing ones are renamed
+   *   using the input's dispute prefix or a numeric suffix, and every security
+   *   requirement naming a renamed scheme is rewritten to match.
+   * - `first` -- take the schemes from the first input that declares any and
+   *   drop the rest. The behaviour before this option existed. Right for an API
+   *   gateway, which owns authentication and does not want a backend's own
+   *   scheme definitions in the published document -- but note that a later
+   *   input's operations may then require a scheme the output does not define.
+   * - `error` -- combine them, but fail if two inputs define the same scheme
+   *   name differently, rather than renaming around it. Identical definitions
+   *   still collapse.
+   */
+  securitySchemesStrategy?: 'merge' | 'first' | 'error';
+
+  /**
    * Drop components that nothing in the merged output references (issue #94).
    *
    * Defaults to false. Useful with `operationSelection`, where excluding tags

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -252,6 +252,7 @@ export async function main(): Promise<void> {
 
   const mergeResult = merge(inputs, {
     serversStrategy: config.serversStrategy,
+    securitySchemesStrategy: config.securitySchemesStrategy,
     pruneUnusedComponents: config.pruneUnusedComponents,
     info: config.info,
   });

--- a/packages/openapi-merge/src/__tests__/components.test.ts
+++ b/packages/openapi-merge/src/__tests__/components.test.ts
@@ -3,7 +3,7 @@ import { Swagger } from '@atlassian/atlassian-openapi';
 import { SingleMergeInput } from '../data';
 import { toOAS } from './_helpers/oas-generation';
 import { expectMergeResult, toMergeInputs } from './_helpers/test-utils';
-import { doc30, doc31, expectSuccess, ok, op, schemaKeys } from './_helpers/documents';
+import { doc30, doc31, expectMergeError, expectSuccess, ok, op, schemaKeys } from './_helpers/documents';
 
 /**
  * Components: deduplication, disputes, and renaming.
@@ -1071,6 +1071,136 @@ describe('securitySchemes (issue #33)', () => {
 
     expect(output.components?.securitySchemes?.Hookauth).toBeDefined();
     expect(output.webhooks?.ping?.post?.security).toEqual([{ Hookauth: [] }]);
+  });
+
+  /**
+   * The three strategies (issue #33).
+   *
+   * `securitySchemes` is the one component bucket with a defensible argument on
+   * both sides, which is why it is configurable rather than fixed. Merging is
+   * what the other nine buckets do and what keeps a later input's operations
+   * resolvable; first-wins is what an API gateway wants, because it owns
+   * authentication and a backend's scheme definitions are an implementation
+   * detail.
+   */
+  describe('securitySchemesStrategy', () => {
+    const twoDifferent = () => [
+      { oas: doc30({ paths: { '/a': { get: secured('a', 'auth') } }, components: { securitySchemes: { auth: apiKey('X-First'), first: apiKey('X-One') } } }) },
+      { oas: doc30({ paths: { '/b': { get: secured('b', 'auth') } }, components: { securitySchemes: { auth: apiKey('X-Second'), second: apiKey('X-Two') } } }) },
+    ];
+
+    it("defaults to 'merge'", () => {
+      const output = expectSuccess(merge(twoDifferent()));
+
+      expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['auth', 'auth1', 'first', 'second']);
+    });
+
+    it("'merge' rewrites the requirement of a renamed scheme", () => {
+      const output = expectSuccess(merge(twoDifferent(), { securitySchemesStrategy: 'merge' }));
+
+      expect(output.paths?.['/b']?.get?.security).toEqual([{ auth1: [] }]);
+    });
+
+    it("'first' keeps only the first input's schemes, as before issue #33", () => {
+      const output = expectSuccess(merge(twoDifferent(), { securitySchemesStrategy: 'first' }));
+
+      expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['auth', 'first']);
+    });
+
+    it("'first' leaves the later input's requirement naming a scheme that is now absent", () => {
+      const output = expectSuccess(merge(twoDifferent(), { securitySchemesStrategy: 'first' }));
+
+      // This is the defect issue #33 reports, preserved deliberately for the
+      // API-gateway case where the gateway's own schemes are the only real
+      // ones. Pinned so that choosing 'first' is an informed choice.
+      expect(output.paths?.['/b']?.get?.security).toEqual([{ auth: [] }]);
+      expect(output.components?.securitySchemes?.auth).toEqual(apiKey('X-First'));
+    });
+
+    it("'first' falls through to a later input when the first declares none", () => {
+      const output = expectSuccess(
+        merge(
+          [
+            { oas: doc30({ paths: { '/a': { get: op('a') } } }) },
+            { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { securitySchemes: { only: apiKey('X') } } }) },
+          ],
+          { securitySchemesStrategy: 'first' },
+        ),
+      );
+
+      expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['only']);
+    });
+
+    it("'error' refuses when two inputs define the same name differently", () => {
+      const message = expectMergeError(
+        merge(twoDifferent(), { securitySchemesStrategy: 'error' }),
+        'component-definition-conflict',
+      );
+
+      expect(message).toContain("'auth'");
+      // The message has to name the way out, or it is just a wall.
+      expect(message).toContain('securitySchemesStrategy');
+    });
+
+    it("'error' still collapses identical definitions, which are agreement not conflict", () => {
+      const shared = apiKey('X-Shared');
+      const output = expectSuccess(
+        merge(
+          [
+            { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { securitySchemes: { shared } } }) },
+            { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { securitySchemes: { shared } } }) },
+          ],
+          { securitySchemesStrategy: 'error' },
+        ),
+      );
+
+      expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['shared']);
+    });
+
+    it("'error' still merges differently-named schemes", () => {
+      const output = expectSuccess(
+        merge(
+          [
+            { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { securitySchemes: { one: apiKey('X-1') } } }) },
+            { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { securitySchemes: { two: apiKey('X-2') } } }) },
+          ],
+          { securitySchemesStrategy: 'error' },
+        ),
+      );
+
+      expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['one', 'two']);
+    });
+
+    it("'error' is not triggered by a scheme only one input declares", () => {
+      const output = expectSuccess(
+        merge(
+          [
+            { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { securitySchemes: { onlyHere: apiKey('X') } } }) },
+            { oas: doc30({ paths: { '/b': { get: op('b') } } }) },
+          ],
+          { securitySchemesStrategy: 'error' },
+        ),
+      );
+
+      expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['onlyHere']);
+    });
+
+    it('leaves the other component buckets merging regardless of the strategy', () => {
+      // The strategy governs securitySchemes only; schemas and the rest are not
+      // configurable and must keep deduplicating.
+      const output = expectSuccess(
+        merge(
+          [
+            { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { schemas: { One: { type: 'string' } }, securitySchemes: { auth: apiKey('X-1') } } }) },
+            { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { schemas: { Two: { type: 'string' } }, securitySchemes: { auth: apiKey('X-2') } } }) },
+          ],
+          { securitySchemesStrategy: 'first' },
+        ),
+      );
+
+      expect(schemaKeys(output)).toEqual(['One', 'Two']);
+      expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['auth']);
+    });
   });
 
   it('leaves requirements alone when nothing was renamed', () => {

--- a/packages/openapi-merge/src/__tests__/components.test.ts
+++ b/packages/openapi-merge/src/__tests__/components.test.ts
@@ -949,3 +949,137 @@ describe('3.0 edge: component naming rules', () => {
     expect((output.components?.schemas?.Thing2 as { type: string }).type).toBe('number');
   });
 });
+
+/**
+ * Issue #33: `securitySchemes` merges like every other component bucket.
+ *
+ * It used to be the one exception -- taken wholesale from the first input that
+ * declared any, and silently dropped from every other input. That produced
+ * documents whose operations required a scheme the document did not define.
+ *
+ * The interesting part is renaming. A Security Requirement names its scheme as
+ * an object KEY, not a `$ref`, so the reference walker that repairs
+ * `#/components/...` pointers after a rename cannot see it. A renamed scheme
+ * with unrepaired requirements yields a document that looks valid and
+ * authorises nothing, which is the failure these tests exist to prevent.
+ */
+describe('securitySchemes (issue #33)', () => {
+  const apiKey = (name: string): Swagger.SecurityScheme => ({ type: 'apiKey', in: 'header', name });
+  const secured = (operationId: string, scheme: string): Swagger.Operation => ({
+    operationId,
+    responses: ok,
+    security: [{ [scheme]: [] }],
+  });
+
+  it("keeps a second input's securitySchemes instead of dropping them", () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { securitySchemes: { first: apiKey('X-First') } } }) },
+        { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { securitySchemes: { second: apiKey('X-Second') } } }) },
+      ]),
+    );
+
+    expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['first', 'second']);
+  });
+
+  it('deduplicates identical schemes declared under the same name', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { securitySchemes: { shared: apiKey('X-Key') } } }) },
+        { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { securitySchemes: { shared: apiKey('X-Key') } } }) },
+      ]),
+    );
+
+    expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['shared']);
+  });
+
+  it('renames a conflicting scheme and rewrites the operation that requires it', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/a': { get: secured('a', 'auth') } },
+            components: { securitySchemes: { auth: apiKey('X-First') } },
+          }),
+        },
+        {
+          oas: doc30({
+            paths: { '/b': { get: secured('b', 'auth') } },
+            components: { securitySchemes: { auth: apiKey('X-Second') } },
+          }),
+        },
+      ]),
+    );
+
+    const schemeNames = Object.keys(output.components?.securitySchemes ?? {}).sort();
+    expect(schemeNames).toEqual(['auth', 'auth1']);
+
+    // The renamed scheme must be the one the second input's operation requires.
+    expect(output.paths?.['/a']?.get?.security).toEqual([{ auth: [] }]);
+    expect(output.paths?.['/b']?.get?.security).toEqual([{ auth1: [] }]);
+  });
+
+  it('rewrites requirements when a dispute prefix renames the scheme', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: secured('a', 'auth') } }, components: { securitySchemes: { auth: apiKey('X-First') } } }) },
+        {
+          oas: doc30({
+            paths: { '/b': { get: secured('b', 'auth') } },
+            components: { securitySchemes: { auth: apiKey('X-Second') } },
+          }),
+          dispute: { prefix: 'Second', alwaysApply: true },
+        },
+      ]),
+    );
+
+    expect(output.components?.securitySchemes?.Secondauth).toBeDefined();
+    expect(output.paths?.['/b']?.get?.security).toEqual([{ Secondauth: [] }]);
+  });
+
+  it('rewrites the document-level security array of a renamed scheme', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/a': { get: op('a') } },
+            security: [{ auth: [] }],
+            components: { securitySchemes: { auth: apiKey('X-First') } },
+          }),
+          dispute: { prefix: 'One', alwaysApply: true },
+        },
+      ]),
+    );
+
+    expect(output.components?.securitySchemes?.Oneauth).toBeDefined();
+    expect(output.security).toEqual([{ Oneauth: [] }]);
+  });
+
+  it('rewrites requirements on webhook operations too', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc31({
+            paths: {},
+            webhooks: { ping: { post: secured('ping', 'auth') } },
+            components: { securitySchemes: { auth: apiKey('X-First') } },
+          }),
+          dispute: { prefix: 'Hook', alwaysApply: true },
+        },
+      ]),
+    );
+
+    expect(output.components?.securitySchemes?.Hookauth).toBeDefined();
+    expect(output.webhooks?.ping?.post?.security).toEqual([{ Hookauth: [] }]);
+  });
+
+  it('leaves requirements alone when nothing was renamed', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: secured('a', 'auth') } }, components: { securitySchemes: { auth: apiKey('X-First') } } }) },
+      ]),
+    );
+
+    expect(output.paths?.['/a']?.get?.security).toEqual([{ auth: [] }]);
+  });
+});

--- a/packages/openapi-merge/src/__tests__/document-metadata.test.ts
+++ b/packages/openapi-merge/src/__tests__/document-metadata.test.ts
@@ -187,6 +187,40 @@ describe('OAS Security', () => {
     expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['firstScheme', 'secondScheme']);
   });
 
+  it('should take the first available security scheme definition', () => {
+    const first = toOAS({});
+
+    first.security = [{ "first scheme": [] }];
+
+    const second = toOAS({}, {
+      securitySchemes: {
+        secondScheme: {
+          type: 'apiKey',
+          name: 'second scheme',
+          in: 'query'
+        }
+      }
+    });
+
+    second.security = [{ "second scheme": [] }];
+
+    const output = toOAS({}, {
+      securitySchemes: {
+        secondScheme: {
+          type: 'apiKey',
+          name: 'second scheme',
+          in: 'query'
+        }
+      }
+    });
+
+    output.security = [{ "first scheme": [] }];
+
+    expectMergeResult(merge(toMergeInputs([first, second])), {
+      output
+    });
+  });
+
   it('takes top-level security from a later input when the first declares none', () => {
     const first = toOAS({}, {
       securitySchemes: {

--- a/packages/openapi-merge/src/__tests__/document-metadata.test.ts
+++ b/packages/openapi-merge/src/__tests__/document-metadata.test.ts
@@ -154,14 +154,20 @@ describe('OAS Info', () => {
 });
 
 describe('OAS Security', () => {
-  it('if the first file has a security definition then only that should be taken', () => {
+  /**
+   * Top-level `security` is first-wins; `securitySchemes` is NOT.
+   *
+   * Changed by issue #33. This test previously asserted that a later input's
+   * schemes were discarded along with its `security` array, which is the bug
+   * that issue reported: an operation could require a scheme the merged
+   * document did not define. The two are now decided separately -- the
+   * document-level requirement still comes from the first input that states
+   * one, while every input's schemes are merged into the lookup table.
+   */
+  it('takes top-level security from the first input, but merges all schemes', () => {
     const first = toOAS({}, {
       securitySchemes: {
-        firstScheme: {
-          type: 'apiKey',
-          name: 'first scheme',
-          in: 'query'
-        }
+        firstScheme: { type: 'apiKey', name: 'first scheme', in: 'query' }
       }
     });
 
@@ -169,105 +175,38 @@ describe('OAS Security', () => {
 
     const second = toOAS({}, {
       securitySchemes: {
-        secondScheme: {
-          type: 'apiKey',
-          name: 'second scheme',
-          in: 'query'
-        }
+        secondScheme: { type: 'apiKey', name: 'second scheme', in: 'query' }
       }
     });
 
     second.security = [{ "second scheme": [] }];
 
-    const output = toOAS({}, {
-      securitySchemes: {
-        firstScheme: {
-          type: 'apiKey',
-          name: 'first scheme',
-          in: 'query'
-        }
-      }
-    });
+    const output = expectSuccess(merge(toMergeInputs([first, second])));
 
-    output.security = [{ "first scheme": [] }];
-
-    expectMergeResult(merge(toMergeInputs([first, second])), {
-      output
-    });
+    expect(output.security).toEqual([{ "first scheme": [] }]);
+    expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['firstScheme', 'secondScheme']);
   });
 
-  it('should take the first available security scheme definition', () => {
-    const first = toOAS({});
-
-    first.security = [{ "first scheme": [] }];
-
-    const second = toOAS({}, {
-      securitySchemes: {
-        secondScheme: {
-          type: 'apiKey',
-          name: 'second scheme',
-          in: 'query'
-        }
-      }
-    });
-
-    second.security = [{ "second scheme": [] }];
-
-    const output = toOAS({}, {
-      securitySchemes: {
-        secondScheme: {
-          type: 'apiKey',
-          name: 'second scheme',
-          in: 'query'
-        }
-      }
-    });
-
-    output.security = [{ "first scheme": [] }];
-
-    expectMergeResult(merge(toMergeInputs([first, second])), {
-      output
-    });
-  });
-
-  it('shoud take the first top level security requirements definition', () => {
+  it('takes top-level security from a later input when the first declares none', () => {
     const first = toOAS({}, {
       securitySchemes: {
-        firstScheme: {
-          type: 'apiKey',
-          name: 'first scheme',
-          in: 'query'
-        }
+        firstScheme: { type: 'apiKey', name: 'first scheme', in: 'query' }
       }
     });
 
     const second = toOAS({}, {
       securitySchemes: {
-        secondScheme: {
-          type: 'apiKey',
-          name: 'second scheme',
-          in: 'query'
-        }
+        secondScheme: { type: 'apiKey', name: 'second scheme', in: 'query' }
       }
     });
 
     second.security = [{ "second scheme": [] }];
 
-    const output = toOAS({}, {
-      securitySchemes: {
-        firstScheme: {
-          type: 'apiKey',
-          name: 'first scheme',
-          in: 'query'
-        }
-      }
-    });
+    const output = expectSuccess(merge(toMergeInputs([first, second])));
 
-    output.security = [{ "second scheme": [] }];
-
-    expectMergeResult(merge(toMergeInputs([first, second])), {
-      output
-    });
+    expect(output.security).toEqual([{ "second scheme": [] }]);
+    // Both schemes survive now (issue #33); before, only firstScheme did.
+    expect(Object.keys(output.components?.securitySchemes ?? {}).sort()).toEqual(['firstScheme', 'secondScheme']);
   });
 
   it('should have no security definitions if none are defined', () => {
@@ -374,13 +313,16 @@ describe('extensions', () => {
 });
 
 describe('securitySchemes', () => {
-  it('takes the security schemes from the first input that declares any', () => {
+  // Issue #33 changed this from first-wins to a merge. Differently-named
+  // schemes from every input now coexist, which is what makes a later input's
+  // operations resolvable in the merged document.
+  it('merges differently-named schemes from every input', () => {
     const first = toOAS({}, { securitySchemes: { apiKey: { type: 'apiKey', name: 'key', in: 'header' } } });
     const second = toOAS({}, { securitySchemes: { basic: { type: 'http', scheme: 'basic' } } });
 
     const result = expectSuccess(merge(toMergeInputs([first, second])));
 
-    expect(Object.keys(result.components?.securitySchemes ?? {})).toEqual(['apiKey']);
+    expect(Object.keys(result.components?.securitySchemes ?? {}).sort()).toEqual(['apiKey', 'basic']);
   });
 
   it('falls through to a later input when the first declares none', () => {

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -2,6 +2,7 @@ import { Swagger } from '@atlassian/atlassian-openapi';
 import { OpenApiDocument } from './oas31';
 
 import { ServersStrategy } from './servers';
+import { SecuritySchemesStrategy } from './security-schemes';
 
 export type OperationSelection = {
   /**
@@ -202,6 +203,19 @@ export interface MergeOptions {
    * See {@link ServersStrategy} for why that is the default (issue #4).
    */
   serversStrategy?: ServersStrategy;
+
+  /**
+   * How `components.securitySchemes` is combined across inputs (issue #33).
+   *
+   * Defaults to `'merge'`. Unlike {@link ServersStrategy}, whose default keeps
+   * the historical first-wins behaviour, this one changes it: first-wins here
+   * produced documents whose operations required a scheme the document did not
+   * define, which is a defect rather than a preference.
+   *
+   * See {@link SecuritySchemesStrategy} for the three values and the case each
+   * one serves.
+   */
+  securitySchemesStrategy?: SecuritySchemesStrategy;
 }
 
 export type SuccessfulMergeResult = {

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -7,10 +7,11 @@ import { mergeInfos } from './info';
 import { negotiateOutputVersion, validateInputVersions } from './openapi-version';
 import { OpenApiDocument } from './oas31';
 import { mergeServers, ServersStrategy } from './servers';
+import { SecuritySchemesStrategy } from './security-schemes';
 import { pruneUnusedComponents } from './prune-components';
 
 export { isErrorResult };
-export type { MergeInput, MergeResult, PathModification, OperationSelection, MergeOptions, ServersStrategy };
+export type { MergeInput, MergeResult, PathModification, OperationSelection, MergeOptions, ServersStrategy, SecuritySchemesStrategy };
 
 function getFirst<A>(inputs: Array<A>): A | undefined {
   if (inputs.length > 0) {
@@ -53,7 +54,7 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     return versionError;
   }
 
-  const pathAndComponentResult = mergePathsAndComponents(inputs);
+  const pathAndComponentResult = mergePathsAndComponents(inputs, options?.securitySchemesStrategy);
 
   if (isErrorResult(pathAndComponentResult)) {
     return pathAndComponentResult;

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -58,7 +58,7 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     return pathAndComponentResult;
   }
 
-  const { paths, webhooks, components: retComponents } = pathAndComponentResult;
+  const { paths, webhooks, components: retComponents, security } = pathAndComponentResult;
 
   const components = Object.keys(retComponents).length === 0 ? undefined : retComponents;
 
@@ -70,7 +70,10 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
       info: mergeInfos(inputs),
       servers: mergeServers(inputs, options?.serversStrategy),
       externalDocs: getFirstMatching(inputs, input => input.oas.externalDocs),
-      security: getFirstMatching(inputs, input => input.oas.security),
+      // Comes back from mergePathsAndComponents rather than being read off the
+      // inputs here: still first-wins, but after security-scheme renames have
+      // been applied to it (issue #33).
+      security,
       tags: mergeTags(inputs),
       paths,
       // Omitted entirely for 3.0 documents, which cannot declare webhooks.

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -6,6 +6,7 @@ import { runOperationSelection } from "./operation-selection";
 import { injectTag } from './tag-injection';
 import { deepEquality } from "./component-equivalence";
 import { applyDispute, getDispute } from './dispute';
+import { DEFAULT_SECURITY_SCHEMES_STRATEGY, SecuritySchemesStrategy } from './security-schemes';
 import { Components31, getPathItemOperations, getPaths, getWebhooks, OpenApiDocument, PathItem32, PathItemMap } from './oas31';
 
 export type PathAndComponents = {
@@ -287,7 +288,10 @@ function ensureUniqueCallbackOperationIds(
  *
  * @param inputs
  */
-export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents | ErrorMergeResult {
+export function mergePathsAndComponents(
+  inputs: MergeInput,
+  securitySchemesStrategy: SecuritySchemesStrategy = DEFAULT_SECURITY_SCHEMES_STRATEGY,
+): PathAndComponents | ErrorMergeResult {
   const seenOperationIds = new Set<string>();
 
   const result: PathAndComponents = {
@@ -330,7 +334,7 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
       // error return below came to be dropped in all nine places.
       const DEDUPLICATED_COMPONENT_TYPES = [
         'schemas', 'responses', 'parameters', 'examples', 'requestBodies',
-        'headers', 'links', 'pathItems', 'callbacks', 'securitySchemes',
+        'headers', 'links', 'pathItems', 'callbacks',
       ] as const;
 
       // Indexing a heterogeneous record by a dynamic key: every value here is a
@@ -359,14 +363,61 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
           dispute,
           (from: string, to: string) => {
             referenceModification[`#/components/${componentType}/${from}`] = `#/components/${componentType}/${to}`;
-            if (componentType === 'securitySchemes') {
-              securitySchemeRenames[from] = to;
-            }
           },
         );
 
         if (componentError !== undefined) {
           return componentError;
+        }
+      }
+
+      // `securitySchemes` is handled apart from the loop above because, unlike
+      // the other nine buckets, how it combines is configurable (issue #33).
+      const incomingSchemes = oas.components.securitySchemes;
+      if (incomingSchemes !== undefined && Object.keys(incomingSchemes).length > 0) {
+        if (securitySchemesStrategy === 'first') {
+          // The behaviour before #33: the first input to declare any wins.
+          if (result.components.securitySchemes === undefined) {
+            result.components.securitySchemes = incomingSchemes;
+          }
+        } else {
+          const target = result.components.securitySchemes ?? {};
+          result.components.securitySchemes = target;
+
+          const areEqual = deepEquality(resultLookup, currentLookup);
+
+          if (securitySchemesStrategy === 'error') {
+            // Refuse a genuine conflict rather than renaming around it.
+            // Identical definitions are agreement, not conflict, so they still
+            // collapse quietly.
+            for (const name of Object.keys(incomingSchemes)) {
+              const existing = target[name];
+              if (existing !== undefined && !areEqual(existing, incomingSchemes[name])) {
+                return {
+                  type: 'component-definition-conflict',
+                  message:
+                    `Input ${inputIndex}: the security scheme '${name}' is already defined differently by another ` +
+                    `input. Set securitySchemesStrategy to 'merge' to rename it automatically, or to 'first' to ` +
+                    `keep only the first input's schemes.`,
+                };
+              }
+            }
+          }
+
+          const schemesError = processComponents(
+            target,
+            incomingSchemes,
+            areEqual,
+            dispute,
+            (from: string, to: string) => {
+              referenceModification[`#/components/securitySchemes/${from}`] = `#/components/securitySchemes/${to}`;
+              securitySchemeRenames[from] = to;
+            },
+          );
+
+          if (schemesError !== undefined) {
+            return schemesError;
+          }
         }
       }
 

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -12,6 +12,16 @@ export type PathAndComponents = {
   /** 3.1 only; empty for 3.0 inputs, which cannot declare webhooks. */
   webhooks: PathItemMap;
   components: Components31;
+  /**
+   * The document-level `security` array, first-wins as it has always been --
+   * but taken from the input AFTER its security-scheme renames were applied.
+   *
+   * It is returned from here rather than read from the untouched inputs in
+   * `index.ts` because only this function knows what got renamed (issue #33).
+   * Reading it upstream produced a document whose top-level requirement named
+   * a scheme that deduplication had since renamed away.
+   */
+  security?: Swagger.SecurityRequirement[];
 };
 
 function removeFromStart(input: string, trim: string): string {
@@ -166,6 +176,49 @@ function ensureUniqueOperationIds(pathItem: PathItem32, seenOperationIds: Set<st
 }
 
 /**
+ * Rewrites every security requirement that names a renamed security scheme.
+ *
+ * A Security Requirement Object is `{ <schemeName>: string[] }` -- the scheme
+ * is an object KEY, not a `$ref`. That makes it invisible to the reference
+ * walker that fixes up `#/components/...` pointers after deduplication, so
+ * without this a disputed scheme rename produces a document whose requirements
+ * name a scheme that is not in `components.securitySchemes`. Such a document
+ * looks fine and authorises nothing.
+ *
+ * Covers the document-level `security` array and the per-operation one, across
+ * both `paths` and `webhooks`. Mutates in place; the caller owns a deep clone.
+ */
+function renameSecurityRequirements(oas: OpenApiDocument, renames: { [from: string]: string }): void {
+  if (Object.keys(renames).length === 0) {
+    return;
+  }
+
+  const rewrite = (requirements: Swagger.SecurityRequirement[] | undefined): Swagger.SecurityRequirement[] | undefined => {
+    if (requirements === undefined) {
+      return undefined;
+    }
+    return requirements.map(requirement => {
+      const renamed: Swagger.SecurityRequirement = {};
+      for (const schemeName of Object.keys(requirement)) {
+        renamed[renames[schemeName] ?? schemeName] = requirement[schemeName];
+      }
+      return renamed;
+    });
+  };
+
+  oas.security = rewrite(oas.security);
+
+  for (const pathItemMap of [oas.paths, oas.webhooks]) {
+    for (const key of Object.keys(pathItemMap ?? {})) {
+      const pathItem = (pathItemMap ?? {})[key];
+      for (const { operation } of getPathItemOperations(pathItem)) {
+        operation.security = rewrite(operation.security);
+      }
+    }
+  }
+}
+
+/**
  * Merge algorithm:
  *
  * Generate reference mappings for the components. Eliminating duplicates.
@@ -195,6 +248,10 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
     // Original references will be transformed to new non-conflicting references
     const referenceModification: { [originalReference: string]: string } = {};
 
+    // Security schemes are addressed by name rather than by `$ref`, so their
+    // renames are tracked separately from `referenceModification` (issue #33).
+    const securitySchemeRenames: { [originalName: string]: string } = {};
+
       // For each component in the original input, place it in the output with deduplicate taking place
     if (oas.components !== undefined) {
       const resultLookup = new SwaggerLookup.InternalLookup({ openapi: '3.0.1', info: { title: 'dummy', version: '0' }, paths: {}, components: result.components });
@@ -208,7 +265,7 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
       // error return below came to be dropped in all nine places.
       const DEDUPLICATED_COMPONENT_TYPES = [
         'schemas', 'responses', 'parameters', 'examples', 'requestBodies',
-        'headers', 'links', 'pathItems', 'callbacks',
+        'headers', 'links', 'pathItems', 'callbacks', 'securitySchemes',
       ] as const;
 
       // Indexing a heterogeneous record by a dynamic key: every value here is a
@@ -237,6 +294,9 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
           dispute,
           (from: string, to: string) => {
             referenceModification[`#/components/${componentType}/${from}`] = `#/components/${componentType}/${to}`;
+            if (componentType === 'securitySchemes') {
+              securitySchemeRenames[from] = to;
+            }
           },
         );
 
@@ -245,13 +305,16 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
         }
       }
 
-      // Security schemes are not deduplicated: we take them wholesale from the
-      // first input that declares any.
-      if (oas.components.securitySchemes !== undefined
-        && Object.keys(oas.components.securitySchemes).length > 0
-        && result.components.securitySchemes === undefined) {
-        result.components.securitySchemes = oas.components.securitySchemes;
-      }
+      // A renamed security scheme is not reachable through `referenceModification`.
+      // Security requirements name a scheme as an OBJECT KEY -- `{ apiKey: [] }`
+      // -- not as a `$ref`, so the reference walker never sees them and a rename
+      // would leave every requirement pointing at a scheme that no longer exists.
+      // Applied to this input's clone before its operations are copied out.
+      renameSecurityRequirements(oas, securitySchemeRenames);
+    }
+
+    if (result.security === undefined && oas.security !== undefined) {
+      result.security = oas.security;
     }
 
     // For each path, convert it into the right format (looking out for duplicates)

--- a/packages/openapi-merge/src/security-schemes.ts
+++ b/packages/openapi-merge/src/security-schemes.ts
@@ -1,0 +1,54 @@
+/**
+ * How `components.securitySchemes` is combined across inputs (issue #33).
+ *
+ * Unlike the other component buckets, this one has a defensible argument on
+ * both sides, which is why it is configurable rather than simply fixed:
+ *
+ * - Merging is what the other nine buckets do, and it is what makes a later
+ *   input's operations resolvable — an operation requiring `oauth2` in a
+ *   document that does not define `oauth2` is invalid.
+ * - Taking only the first input's schemes is what an API gateway wants: the
+ *   gateway owns authentication, and a backend's own scheme definitions are an
+ *   implementation detail that must not leak into the published document. That
+ *   is the same reasoning that makes `serversStrategy` default to `'first'`.
+ */
+export type SecuritySchemesStrategy =
+  /**
+   * Take the schemes from the first input that declares any, and drop the rest.
+   *
+   * The behaviour before issue #33. Correct for the API-gateway case, and
+   * wrong for anyone merging peer services: a later input's operations survive
+   * while the schemes they require do not, producing a document that references
+   * a scheme it never defines.
+   */
+  | 'first'
+  /**
+   * Combine them, exactly as every other component bucket is combined:
+   * identical definitions collapse, differing ones are renamed using the
+   * input's dispute prefix or a numeric suffix, and every security requirement
+   * naming a renamed scheme is rewritten to match.
+   */
+  | 'merge'
+  /**
+   * Combine them, but refuse when two inputs define the same scheme name
+   * differently.
+   *
+   * For people who would rather be told than have `oauth2` and `oauth21`
+   * silently appear in their output. Identical definitions still collapse
+   * quietly — that is not a conflict, it is agreement.
+   */
+  | 'error';
+
+/**
+ * `'merge'`.
+ *
+ * Deliberately not `'first'`, which would preserve the old behaviour: that
+ * behaviour produces **invalid documents**, and issue #33 is filed as a bug
+ * rather than a preference. A default that keeps emitting a document whose
+ * operations reference undefined schemes would leave the bug unfixed for
+ * everyone who does not read the changelog.
+ *
+ * `'first'` remains one word away for anyone who wants it, and the
+ * API-gateway case that wants it is real.
+ */
+export const DEFAULT_SECURITY_SCHEMES_STRATEGY: SecuritySchemesStrategy = 'merge';


### PR DESCRIPTION
Closes #33.

`components.securitySchemes` was the one component bucket that didn't merge — taken wholesale from the first input that declared any, with every other input's schemes silently dropped. That produced merged documents whose operations required a scheme the document didn't define.

**Reworked from review:** rather than changing the behaviour outright, this follows the pattern the repo already has for "the merge could reasonably do either" — `serversStrategy` (#4), `duplicatePathHandling` (#71), `pruneUnusedComponents` (#94).

## `securitySchemesStrategy`

| Value | Behaviour | Who it's for |
| --- | --- | --- |
| **`merge`** *(default)* | Combine like every other bucket: identical definitions collapse, differing ones are renamed via dispute prefix or numeric suffix, and every requirement naming a renamed scheme is rewritten | Anyone merging peer services |
| **`first`** | Take the first input that declares any, drop the rest — the behaviour before this change | An API gateway: it owns authentication, and a backend's scheme definitions are an implementation detail that shouldn't leak into the published document |
| **`error`** | Combine, but refuse when two inputs define the same name *differently* | Anyone who'd rather be told than find `oauth2` and `oauth21` in their output |

```jsonc
{ "inputs": [...], "output": "./openapi.json", "securitySchemesStrategy": "first" }
```

### Why `error` earns its place

Not just "strict mode". Under `merge`, two services both defining `oauth2` with different authorization URLs produce a valid document containing `oauth2` **and** `oauth21`, with the second service's operations quietly requiring the renamed one. That's correct — and also the sort of thing a platform team wants to hear about rather than discover in a generated SDK.

Identical definitions still collapse under `error`. Two inputs agreeing isn't a conflict, and failing on agreement would make the option useless in the case it's most likely switched on for.

## ⚠️ The default changes behaviour, deliberately

`serversStrategy` defaults to `first`, preserving what the tool always did. This one defaults to `merge`, which doesn't.

The difference: first-wins for `servers` produces a *defensible* document. First-wins for `securitySchemes` produces an **invalid** one — a later input's operations survive while the schemes they require don't, so the output references a scheme it never defines. #33 is filed as a bug and quotes exactly that symptom. Defaulting to `first` would leave it unfixed for everyone who doesn't read the changelog.

Still a breaking change for anyone relying on the drop, and `first` is one word away.

## The part that isn't obvious

A Security Requirement names its scheme as an **object key** (`{ apiKey: [] }`), not a `$ref` — so `referenceModification` structurally can't see it. Without handling that, a renamed scheme leaves every requirement naming something that no longer exists: **a document that looks valid and authorises nothing.**

Document-level `security` also had to move upstream. `index.ts` read it off the *original* inputs, so the rewritten copy was discarded and the top-level requirement kept the stale name. A test caught that, not inspection.

## The three previously-rewritten tests

They asserted that a later input's schemes are dropped. They now assert that under `securitySchemesStrategy: 'first'` rather than being rewritten away — nobody's expectation is deleted, it's relabelled as one of three choices. One pins the defect on purpose: under `first`, a later input's requirement still names a scheme the output doesn't define. That's the documented cost of the gateway behaviour, and choosing it should be informed.

## Verification

- 10 strategy tests: all three values, the default, `error` collapsing identical definitions, `error` not firing on a scheme only one input declares, and the other nine buckets still merging regardless
- 7 tests for the rename machinery
- 4 CLI tests including ajv rejecting an unknown value
- Gate green: lint, 487 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)