### PR TITLE
fix(merge): honour dispute.alwaysApply on operationIds (#40)

### DIFF
--- a/ai-planning/issues/06-proposal-40-dispute-operationid.md
+++ b/ai-planning/issues/06-proposal-40-dispute-operationid.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#40 — dispute.alwaysApply ineffective on operationIds](https://github.com/robertmassaioli/openapi-merge/issues/40)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 | **Effort:** 2 | **ROI:** High
 
@@ -436,3 +436,45 @@ This fix is part of the **"Dispute Completeness"** cluster identified in the tri
 5. [ ] Update `CHANGELOG.md` (or release notes) to document the fix.
 6. [ ] Bump the `version` field in `packages/openapi-merge/package.json` to a new minor (e.g., `1.3.0`).
 7. [ ] Commit and push to `origin/main`; the `npm-publish.yml` workflow handles publication.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/40-dispute-operationid`. The diagnosis in §2 was exactly right;
+the fix is shaped differently.
+
+### 10.1 Simpler than §3's branch structure
+
+§3 proposes an `if (alwaysApply) … else if (!seen) …` split with the dispute
+attempted again in the conflict path. That has three branches that must agree
+about which form was already tried. Instead, `findUniqueOperationId` now opens
+with the same call component names use:
+
+```ts
+const candidate = applyDispute(dispute, operationId, 'undisputed');
+if (!seenOperationIds.has(candidate)) { return candidate; }
+```
+
+`applyDispute` already consults `alwaysApply`, so nothing here needs to. That
+was the actual defect — the caller short-circuited before `dispute` was ever
+consulted — and letting the same function decide for both paths is what makes
+them symmetrical rather than merely equivalent.
+
+### 10.2 The numeric fallback had to change too
+
+Not mentioned in the proposal. The fallback built `${operationId}${n}` from the
+*original* id. Under `alwaysApply`, a collision on the prefixed form would then
+fall back to an unprefixed `op1`, silently undoing the rename the user asked
+for. It is now built from `candidate`, so `Serviceop` colliding yields
+`Serviceop1`. There is a test for precisely this.
+
+### 10.3 Verification
+
+- 6 tests in `operation-ids.test.ts`, the suite that owns this. **5 fail
+  against `origin/main`**, confirmed in a detached worktree. The sixth asserts
+  that a dispute *without* `alwaysApply` still leaves a non-conflicting id
+  alone — a regression guard for the behaviour that must not change.
+- Covers prefix and suffix disputes, webhooks, and the §10.2 collision case.
+- Gate green: lint, 390 tests, 48 artifact checks.

--- a/packages/openapi-merge/src/__tests__/operation-ids.test.ts
+++ b/packages/openapi-merge/src/__tests__/operation-ids.test.ts
@@ -3,7 +3,7 @@ import { Swagger } from '@atlassian/atlassian-openapi';
 import { SingleMergeInput } from '../data';
 import { toOAS } from './_helpers/oas-generation';
 import { toMergeInputs } from './_helpers/test-utils';
-import { doc30, doc32, expectSuccess, ok, op, pathKeys } from './_helpers/documents';
+import { doc30, doc31, doc32, expectSuccess, ok, op, pathKeys } from './_helpers/documents';
 
 /**
  * operationId uniqueness.
@@ -100,5 +100,102 @@ describe('3.0 edge: operationId uniqueness', () => {
     ]));
 
     expect(pathKeys(output)).toEqual(['/a', '/b']);
+  });
+});
+
+/**
+ * Issue #40: `alwaysApply` renames operationIds too.
+ *
+ * The dispute machinery had two halves that disagreed. Component names went
+ * through `applyDispute(..., 'undisputed')`, which honours `alwaysApply`
+ * whether or not anything collided. Operation IDs returned early whenever there
+ * was no collision, so `dispute` was never consulted -- one configuration
+ * renamed schemas but not operationIds, and *which* operationIds got renamed
+ * depended on the order of the inputs.
+ */
+describe('dispute.alwaysApply on operationIds (issue #40)', () => {
+  it('renames a non-conflicting operationId when alwaysApply is set', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: op('getThing') } } }),
+          dispute: { prefix: 'Service', alwaysApply: true },
+        },
+      ]),
+    );
+
+    expect(output.paths?.['/a']?.get?.operationId).toBe('ServicegetThing');
+  });
+
+  it('leaves a non-conflicting operationId alone when alwaysApply is not set', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: op('getThing') } } }),
+          dispute: { prefix: 'Service' },
+        },
+      ]),
+    );
+
+    expect(output.paths?.['/a']?.get?.operationId).toBe('getThing');
+  });
+
+  it('renames every operationId consistently, not just the colliding ones', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('shared') } } }) },
+        {
+          oas: doc30({ paths: { '/b': { get: op('shared') }, '/c': { get: op('unique') } } }),
+          dispute: { prefix: 'Second', alwaysApply: true },
+        },
+      ]),
+    );
+
+    // Both of the second input's operations carry the prefix -- previously only
+    // `shared` did, because only it collided.
+    expect(output.paths?.['/b']?.get?.operationId).toBe('Secondshared');
+    expect(output.paths?.['/c']?.get?.operationId).toBe('Secondunique');
+  });
+
+  it('keeps the prefix when the prefixed id itself collides', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('Serviceop') } } }) },
+        {
+          oas: doc30({ paths: { '/b': { get: op('op') } } }),
+          dispute: { prefix: 'Service', alwaysApply: true },
+        },
+      ]),
+    );
+
+    // Must not fall back to `op1`: that would silently undo the rename the
+    // user asked for.
+    expect(output.paths?.['/b']?.get?.operationId).toBe('Serviceop1');
+  });
+
+  it('applies a suffix dispute to operationIds as well', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: op('getThing') } } }),
+          dispute: { suffix: 'V2', alwaysApply: true },
+        },
+      ]),
+    );
+
+    expect(output.paths?.['/a']?.get?.operationId).toBe('getThingV2');
+  });
+
+  it('renames operationIds inside webhooks under alwaysApply', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc31({ paths: {}, webhooks: { ping: { post: op('onPing') } } }),
+          dispute: { prefix: 'Hook', alwaysApply: true },
+        },
+      ]),
+    );
+
+    expect(output.webhooks?.ping?.post?.operationId).toBe('HookonPing');
   });
 });

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -115,11 +115,23 @@ function dropPathItemsWithNoOperations(originalOas: OpenApiDocument): OpenApiDoc
 }
 
 function findUniqueOperationId(operationId: string, seenOperationIds: Set<string>, dispute: Dispute | undefined): string | ErrorMergeResult {
-  if (!seenOperationIds.has(operationId)) {
-    return operationId;
+  // Ask `applyDispute` first rather than short-circuiting on "no conflict".
+  //
+  // This is the whole of issue #40. Component names are renamed by calling
+  // `applyDispute(..., 'undisputed')` and letting it decide, so `alwaysApply`
+  // is honoured whether or not anything actually collided. Operation IDs used
+  // to return early when there was no collision, so `dispute` was never
+  // consulted and `alwaysApply` did nothing -- the same configuration renamed
+  // schemas but not operationIds, and which operationIds got renamed depended
+  // on input order. Deciding here keeps the two paths symmetrical.
+  const candidate = applyDispute(dispute, operationId, 'undisputed');
+
+  if (!seenOperationIds.has(candidate)) {
+    return candidate;
   }
 
-  // Try the dispute prefix
+  // Try the dispute prefix. A no-op when `alwaysApply` already applied it
+  // above, which is why the numeric fallback below is what resolves that case.
   if (dispute !== undefined) {
     const disputeOpId = applyDispute(dispute, operationId, 'disputed');
     if (!seenOperationIds.has(disputeOpId)) {
@@ -127,9 +139,11 @@ function findUniqueOperationId(operationId: string, seenOperationIds: Set<string
     }
   }
 
-  // Incrementally find the right prefix
+  // Incrementally find the right suffix. Built on `candidate`, not on the
+  // original: under `alwaysApply` the fallback must keep the prefix, otherwise
+  // a collision would silently undo the rename the user asked for.
   for (let antiConflict = 1; antiConflict < 1000; antiConflict++) {
-    const tryOpId = `${operationId}${antiConflict}`;
+    const tryOpId = `${candidate}${antiConflict}`;
     if (!seenOperationIds.has(tryOpId)) {
       return tryOpId;
     }


### PR DESCRIPTION
Closes #40.

The dispute machinery had two halves that disagreed:

- **Component names** go through `applyDispute(..., 'undisputed')`, which honours `alwaysApply` whether or not anything collided.
- **Operation IDs** returned early whenever there was no collision, so `dispute` was never consulted at all.

The result: one configuration renamed schemas but not operationIds, and *which* operationIds got renamed depended on the order of the inputs.

`findUniqueOperationId` now opens with the same `applyDispute` call the component path uses and lets it decide. Simpler than the proposal's three-branch version, and symmetrical rather than merely equivalent.

### The bit the proposal missed

The numeric fallback built `${operationId}${n}` from the **original** id. Under `alwaysApply`, a collision on the prefixed form fell back to an unprefixed `op1` — silently undoing the rename the user asked for. It now builds on the disputed form, so `Serviceop` colliding yields `Serviceop1`. There's a test for exactly that.

### Verification

- 6 tests in `operation-ids.test.ts`; **5 fail against `origin/main`**, confirmed in a detached worktree
- The sixth is a regression guard: a dispute *without* `alwaysApply` must still leave a non-conflicting id alone
- Covers prefix and suffix disputes, webhooks, and the fallback collision case
- Gate green: `bun run lint`, `bun run test` (390), `./scripts/verify-node-runtime.sh` (48 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)