### PR TITLE
feat(merge): concatenate x-tagGroups across inputs (#60)

### DIFF
--- a/ai-planning/issues/12-proposal-60-x-tag-groups.md
+++ b/ai-planning/issues/12-proposal-60-x-tag-groups.md
@@ -1,6 +1,6 @@
 # Implementation Proposal: Issue #60 — Concatenate `x-tagGroups` Across Inputs
 
-**Status:** Proposal  
+**Status:** ✅ Implemented — see §10  
 **Value:** 3/5 — useful for ReDoc users who compose multiple specs with tag groups.  
 **Effort:** 2/5 — localized change to extension merge; no API changes required.
 
@@ -467,3 +467,52 @@ describe('x-tagGroups', () => {
 - Write and run tests: ~30 min.
 - **Total:** ~1.5 hours.
 
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/60-x-tag-groups`. §5's concatenation semantics implemented as
+written. Two deliberate departures from §4.
+
+### 10.1 Option A, not the recommended Option C
+
+§4 recommends shipping the `x-tagGroups` special case **and** a configurable
+`extensionMergeStrategies` map. Only the special case was built.
+
+The configurable half is speculative generality: no second extension has been
+asked for, it is public API that then has to be supported indefinitely, and it
+would collide with the `MergeOptions` bag #4 introduces. If a second ReDoc-style
+extension ever needs it, adding the mechanism at that point is no harder than
+adding it now — and by then its shape will be informed by two real cases rather
+than one hypothetical.
+
+Every other `x-` extension stays first-wins, which §3 already argues for:
+opaque semantics mean concatenation could corrupt a vendor's data in ways this
+library cannot detect.
+
+### 10.2 An unrecognised shape is left alone
+
+Not in the proposal. If any input's `x-tagGroups` is not an array of
+`{ name }` objects, the merge does not touch it and first-wins applies. Guessing
+at a structure we do not recognise is how a merge tool corrupts data it was only
+asked to carry through. Tested.
+
+### 10.3 §5.4 (tag filtering) deliberately not implemented
+
+§5.4 says a tag removed by `excludeTags` should also be removed from
+`x-tagGroups`. Left out on purpose. The obvious implementation — drop group
+entries whose tag is not in the merged top-level `tags` — would corrupt valid
+documents, because the specification does not require an operation's tag to be
+declared in `tags` at all. Doing it correctly means tracking which tags
+`operationSelection` actually removed, which is the same reachability problem as
+issue #94 (orphaned components after tag exclusion) and belongs with it.
+
+### 10.4 Verification
+
+- 8 tests in `document-metadata.test.ts`, which owns top-level document
+  metadata. **6 fail against `origin/main`**, confirmed in a detached worktree.
+- The other two are the guards that matter: other `x-` extensions stay
+  first-wins, and an unrecognised `x-tagGroups` shape is untouched.
+- Gate green: lint, 392 tests, 48 artifact checks.

--- a/packages/openapi-merge/src/__tests__/document-metadata.test.ts
+++ b/packages/openapi-merge/src/__tests__/document-metadata.test.ts
@@ -792,3 +792,114 @@ describe('servers strategy (issue #4)', () => {
     expect(inputs[1].oas.servers).toEqual([{ url: 'https://second.example.com' }]);
   });
 });
+
+/**
+ * Issue #60: `x-tagGroups` concatenates across inputs.
+ *
+ * Every other `x-` extension stays first-wins because its semantics are opaque
+ * -- concatenating a vendor extension this library does not understand could
+ * corrupt it. `x-tagGroups` is the exception: its shape is fixed
+ * (`{ name, tags }`), widely relied on by ReDoc, and concatenation loses
+ * nothing.
+ *
+ * The inconsistency this fixes: tags from later inputs were already merged into
+ * the top-level `tags` array while their groups were dropped, so a ReDoc
+ * sidebar lost the structure for tags that were present in the document.
+ */
+describe('x-tagGroups (issue #60)', () => {
+  const withGroups = (pathName: string, groups: unknown) => ({
+    oas: {
+      ...doc30({ paths: { [pathName]: { get: op(pathName.slice(1)) } } }),
+      'x-tagGroups': groups,
+    } as OpenApiDocument,
+  });
+
+  it('concatenates groups from every input', () => {
+    const output = expectSuccess(
+      merge([
+        withGroups('/a', [{ name: 'User', tags: ['get-user'] }]),
+        withGroups('/b', [{ name: 'Admin', tags: ['admin-only'] }]),
+      ]),
+    );
+
+    expect(at(output, 'x-tagGroups')).toEqual([
+      { name: 'User', tags: ['get-user'] },
+      { name: 'Admin', tags: ['admin-only'] },
+    ]);
+  });
+
+  it('combines the tags of groups that share a name', () => {
+    const output = expectSuccess(
+      merge([
+        withGroups('/a', [{ name: 'User', tags: ['get-user', 'put-user'] }]),
+        withGroups('/b', [{ name: 'User', tags: ['delete-user'] }]),
+      ]),
+    );
+
+    expect(at(output, 'x-tagGroups')).toEqual([
+      { name: 'User', tags: ['get-user', 'put-user', 'delete-user'] },
+    ]);
+  });
+
+  it('deduplicates a tag listed by two inputs under the same group', () => {
+    const output = expectSuccess(
+      merge([
+        withGroups('/a', [{ name: 'User', tags: ['shared', 'a-only'] }]),
+        withGroups('/b', [{ name: 'User', tags: ['shared', 'b-only'] }]),
+      ]),
+    );
+
+    expect(at(output, 'x-tagGroups')).toEqual([
+      { name: 'User', tags: ['shared', 'a-only', 'b-only'] },
+    ]);
+  });
+
+  it('keeps the order in which groups were first seen', () => {
+    const output = expectSuccess(
+      merge([
+        withGroups('/a', [{ name: 'Second', tags: ['x'] }]),
+        withGroups('/b', [{ name: 'First', tags: ['y'] }, { name: 'Second', tags: ['z'] }]),
+      ]),
+    );
+
+    expect((at(output, 'x-tagGroups') as Array<{ name: string }>).map(g => g.name)).toEqual(['Second', 'First']);
+  });
+
+  it('drops a group that ends up with no tags', () => {
+    const output = expectSuccess(merge([withGroups('/a', [{ name: 'Empty', tags: [] }])]));
+
+    // An empty group renders as an empty heading in the ReDoc sidebar.
+    expect(at(output, 'x-tagGroups')).toBeUndefined();
+  });
+
+  it('leaves other x- extensions first-wins', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: { ...doc30({ paths: { '/a': { get: op('a') } } }), 'x-vendor': { a: 1 } } as OpenApiDocument },
+        { oas: { ...doc30({ paths: { '/b': { get: op('b') } } }), 'x-vendor': { b: 2 } } as OpenApiDocument },
+      ]),
+    );
+
+    expect(at(output, 'x-vendor')).toEqual({ a: 1 });
+  });
+
+  it('does not touch x-tagGroups of an unrecognised shape', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: { ...doc30({ paths: { '/a': { get: op('a') } } }), 'x-tagGroups': 'not-an-array' } as OpenApiDocument },
+        withGroups('/b', [{ name: 'User', tags: ['x'] }]),
+      ]),
+    );
+
+    // First-wins on something we do not understand beats mangling it.
+    expect(at(output, 'x-tagGroups')).toBe('not-an-array');
+  });
+
+  it('merges groups sharing a name within a single input', () => {
+    const output = expectSuccess(
+      merge([withGroups('/a', [{ name: 'User', tags: ['one'] }, { name: 'User', tags: ['two'] }])]),
+    );
+
+    expect(at(output, 'x-tagGroups')).toEqual([{ name: 'User', tags: ['one', 'two'] }]);
+  });
+});

--- a/packages/openapi-merge/src/extensions.ts
+++ b/packages/openapi-merge/src/extensions.ts
@@ -18,13 +18,71 @@ function extractExtensions(input: OpenApiDocument): Extensions {
   return result;
 }
 
+/**
+ * A ReDoc tag group: `{ name, tags }`.
+ *
+ * Not part of the OpenAPI specification, but the structure is fixed and widely
+ * relied upon, which is what makes it safe to merge rather than guess at.
+ */
+type TagGroup = { name: string; tags?: string[] };
+
+const TAG_GROUPS = 'x-tagGroups';
+
+function isTagGroupArray(value: unknown): value is TagGroup[] {
+  return Array.isArray(value) && value.every(entry =>
+    typeof entry === 'object' && entry !== null && typeof (entry as TagGroup).name === 'string');
+}
+
+/**
+ * Concatenates `x-tagGroups` across inputs, combining groups that share a name
+ * (issue #60).
+ *
+ * Every other `x-` extension stays first-wins, and deliberately so: their
+ * semantics are opaque, so concatenating or deep-merging them could corrupt a
+ * vendor's data in ways this library cannot detect. `x-tagGroups` is the
+ * exception because its shape is known and concatenation is information
+ * preserving.
+ *
+ * The inconsistency this fixes: tags from later inputs were already merged into
+ * the top-level `tags` array, but their groups were dropped, so a ReDoc sidebar
+ * lost the structure for tags that were present.
+ */
+function mergeTagGroups(values: unknown[]): unknown {
+  const present = values.filter(isTagGroupArray);
+
+  // If any input declares `x-tagGroups` in an unrecognised shape, do not touch
+  // it. First-wins on something we do not understand beats mangling it.
+  if (present.length !== values.length) {
+    return values[0];
+  }
+
+  const byName = new Map<string, string[]>();
+
+  for (const groups of present) {
+    for (const group of groups) {
+      const existing = byName.get(group.name) ?? [];
+      for (const tag of group.tags ?? []) {
+        if (!existing.includes(tag)) {
+          existing.push(tag);
+        }
+      }
+      byName.set(group.name, existing);
+    }
+  }
+
+  // Groups are emitted in the order they were first seen, across all inputs.
+  // A group that ends up with no tags is dropped -- it would render as an empty
+  // heading in the sidebar.
+  const merged = [...byName.entries()]
+    .filter(([, tags]) => tags.length > 0)
+    .map(([name, tags]) => ({ name, tags }));
+
+  return merged.length === 0 ? undefined : merged;
+}
+
 function mergeExtensionsHelper(extensions: Extensions[]): Extensions {
   if (extensions.length === 0) {
     return {};
-  }
-
-  if (extensions.length === 1) {
-    return extensions[0];
   }
 
   const result = { ...extensions[0] };
@@ -37,6 +95,19 @@ function mergeExtensionsHelper(extensions: Extensions[]): Extensions {
       if (result[extensionKey] === undefined && ext.hasOwnProperty(extensionKey)) {
         result[extensionKey] = ext[extensionKey];
       }
+    }
+  }
+
+  // Applied after first-wins so it overrides it for this one key. Runs even for
+  // a single input, because deduplicating groups that share a name within one
+  // document is the same operation.
+  const tagGroupValues = extensions.map(ext => ext[TAG_GROUPS]).filter(value => value !== undefined);
+  if (tagGroupValues.length > 0) {
+    const mergedGroups = mergeTagGroups(tagGroupValues);
+    if (mergedGroups === undefined) {
+      delete result[TAG_GROUPS];
+    } else {
+      result[TAG_GROUPS] = mergedGroups;
     }
   }
 


### PR DESCRIPTION
Closes #60.

Tags from later inputs were already merged into the top-level `tags` array while their `x-tagGroups` entries were dropped by first-wins — so a ReDoc sidebar lost the grouping for tags that *were* present in the document.

Groups now concatenate: entries sharing a name have their tags combined (first-seen order, deduplicated), groups appear in the order first seen, and a group left with no tags is dropped rather than rendering as an empty heading.

### Two departures from the proposal

- **Option A, not the recommended Option C.** The proposal also wanted a configurable `extensionMergeStrategies` map. That's speculative generality: no second extension has been asked for, it's public API that must then be supported forever, and it collides with the `MergeOptions` bag #4 introduces. Adding it later is no harder — and by then its shape would be informed by two real cases instead of one hypothetical.
- **§5.4 (tag filtering) deliberately not implemented.** The obvious version — drop group entries absent from the merged `tags` array — would *corrupt valid documents*, because the spec doesn't require an operation's tag to be declared in `tags`. Doing it properly means tracking what `operationSelection` actually removed, which is the same reachability problem as #94 and belongs with it.

Every other `x-` extension stays first-wins: opaque semantics mean concatenation could corrupt a vendor's data undetectably. An `x-tagGroups` of an unrecognised shape is likewise left alone rather than guessed at.

### Verification

- 8 tests in `document-metadata.test.ts`; **6 fail against `origin/main`**, confirmed in a detached worktree
- The other two are the guards that matter: other `x-` extensions stay first-wins, and an unrecognised shape is untouched
- Gate green: lint, 392 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)