### PR TITLE
feat(cli): authorization headers for inputURL (#61)

### DIFF
--- a/ai-planning/issues/17-proposal-61-input-url-auth.md
+++ b/ai-planning/issues/17-proposal-61-input-url-auth.md
@@ -1,6 +1,6 @@
 # Implementation Proposal: Issue #61 — Authorization config for inputURL
 
-**Status:** Proposal  
+**Status:** ✅ Implemented (headers only) — see §10  
 **Value:** 3 | **Effort:** 2 | **ROI:** 4 (Quick Win)
 
 **Issue:** [robertmassaioli/openapi-merge#61](https://github.com/robertmassaioli/openapi-merge/issues/61)
@@ -426,3 +426,56 @@ A dedicated `--header` CLI flag (e.g., `-H "Authorization: Bearer ..."`) is defe
 - **Related proposal #93:** `ai-planning/issues/03-proposal-93-absolute-paths.md` (security model, threat analysis)
 - **Related proposal #45:** No-config mode (deferred CLI flag work)
 - **Issue #61:** https://github.com/robertmassaioli/openapi-merge/issues/61
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/61-input-url-auth`. §3.1's `headers` map and the `${VAR}`
+interpolation, built as specified. §3.2's reasoning for a generic map over a
+`bearer`/`basic` union holds and is unchanged.
+
+### 10.1 `allowPrivateUrls` deliberately not implemented
+
+§3.1 also proposes an `allowPrivateUrls` flag defaulting to `false`, rejecting
+RFC1918, loopback and link-local addresses as SSRF defence.
+
+Not built, because the default is a breaking change aimed at the wrong threat
+model. Merging from `http://localhost:8080/openapi.json` — a service running in
+the same CI job, or a dev server — is an ordinary use of this tool, and that
+default silently breaks it. SSRF matters when an attacker controls the URL; here
+the URL comes from a configuration file the user wrote. Where that file is
+untrusted, `outputRoot` already exists for exactly that situation and a URL
+allowlist would belong beside it as an opt-in, not as a default that penalises
+everyone else.
+
+### 10.2 A missing variable fails, and does not substitute empty
+
+The proposal says configuration loading "fails with a clear error"; worth
+stating why that is the right call rather than an empty string. An empty
+`Authorization: Bearer ` produces a 401 that reads as the server rejecting valid
+credentials, sending the user to look at the wrong system entirely. Every
+missing variable is reported at once, so three unset tokens are learned in one
+run rather than three.
+
+### 10.3 It exits `ErrorLoadingConfig`, not `ErrorLoadingInputs`
+
+Not specified. An unset `${VAR}` is a fault in the configuration, not in the
+input it points at — the request is never made. Reporting it as an input
+failure would send someone to investigate a remote service that was never
+contacted.
+
+An empty-string variable counts as set, deliberately: someone may legitimately
+export one, and overriding that would be second-guessing them.
+
+### 10.4 Verification
+
+- 9 unit tests in `interpolate-headers.test.ts`.
+- 6 CLI tests in `cli-remote-inputs.test.ts`, driven against the real
+  in-process HTTP server that suite already uses, asserting on the headers the
+  server actually **received** — so they prove the values reach the wire, not
+  merely that a function returned them. **5 fail against `origin/main`**; the
+  sixth is the regression guard that an input with no `headers` key still makes
+  a well-formed request.
+- Gate green: lint, 399 tests, 48 artifact checks.

--- a/packages/openapi-merge-cli/src/__tests__/cli-remote-inputs.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-remote-inputs.test.ts
@@ -182,3 +182,108 @@ describe('main - inputURL', () => {
     expect(cli.stderr().join('\n')).toContain('Input 1');
   });
 });
+
+/**
+ * Issue #61: authorization headers for `inputURL`.
+ *
+ * Driven against a real server that inspects what arrived, so these prove the
+ * headers reach the wire rather than merely that a function returned them.
+ */
+describe('main - inputURL headers (issue #61)', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let received: http.IncomingHttpHeaders = {};
+
+  beforeEach(async () => {
+    received = {};
+    server = http.createServer((req, res) => {
+      received = req.headers;
+      if (req.headers.authorization !== 'Bearer secret-token') {
+        res.writeHead(401);
+        res.end('unauthorized');
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(oas({ '/remote': getPath('getRemote') })));
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    baseUrl = `http://127.0.0.1:${typeof address === 'object' && address !== null ? address.port : 0}`;
+  });
+
+  afterEach(async () => {
+    delete process.env.TEST_API_TOKEN;
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it('sends a literal header value', async () => {
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputURL: `${baseUrl}/spec.json`, headers: { Authorization: 'Bearer secret-token' } }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(received.authorization).toBe('Bearer secret-token');
+  });
+
+  it('interpolates a header value from the environment', async () => {
+    process.env.TEST_API_TOKEN = 'secret-token';
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputURL: `${baseUrl}/spec.json`, headers: { Authorization: 'Bearer ${TEST_API_TOKEN}' } }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(received.authorization).toBe('Bearer secret-token');
+    expect(Object.keys(JSON.parse(cli.read()).paths)).toEqual(['/remote']);
+  });
+
+  it('sends several headers', async () => {
+    process.env.TEST_API_TOKEN = 'secret-token';
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [
+        {
+          inputURL: `${baseUrl}/spec.json`,
+          headers: { Authorization: 'Bearer ${TEST_API_TOKEN}', 'X-Trace-Id': 'abc' },
+        },
+      ],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(received['x-trace-id']).toBe('abc');
+  });
+
+  it('fails with a config error, naming the variable, when it is unset', async () => {
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputURL: `${baseUrl}/spec.json`, headers: { Authorization: 'Bearer ${TEST_API_TOKEN}' } }],
+      output: './output.json',
+    });
+
+    // ErrorLoadingConfig, not ErrorLoadingInputs: the request was never made,
+    // so pointing at the remote service would send someone to the wrong place.
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+    expect(cli.stderr().join('\n')).toContain('TEST_API_TOKEN');
+  });
+
+  it('surfaces a 401 as a 4xx exit code when the header is wrong', async () => {
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputURL: `${baseUrl}/spec.json`, headers: { Authorization: 'Bearer wrong' } }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorInputUrlClientStatus);
+  });
+
+  it('still works with no headers at all', async () => {
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputURL: `${baseUrl}/spec.json` }],
+      output: './output.json',
+    });
+
+    // The server requires auth, so this is a 401 -- the point is that an input
+    // without a `headers` key still makes a well-formed request.
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorInputUrlClientStatus);
+    expect(received.authorization).toBeUndefined();
+  });
+});

--- a/packages/openapi-merge-cli/src/__tests__/interpolate-headers.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/interpolate-headers.test.ts
@@ -1,0 +1,77 @@
+import { interpolateHeaders, MissingEnvironmentVariableError } from '../interpolate-headers';
+
+/**
+ * Environment interpolation for inputURL headers (issue #61).
+ *
+ * The point of the feature is that a credential never has to be committed, so
+ * the behaviour that matters most is what happens when a referenced variable is
+ * absent: it must fail loudly. Substituting an empty string would send
+ * `Authorization: Bearer ` and surface as a 401 that looks like the server
+ * rejecting valid credentials.
+ */
+describe('interpolateHeaders (issue #61)', () => {
+  it('substitutes a single variable', () => {
+    const result = interpolateHeaders({ Authorization: 'Bearer ${TOKEN}' }, { TOKEN: 'abc123' });
+
+    expect(result).toEqual({ Authorization: 'Bearer abc123' });
+  });
+
+  it('substitutes several variables across several headers', () => {
+    const result = interpolateHeaders(
+      { Authorization: 'Bearer ${TOKEN}', 'X-API-Key': '${KEY}', Accept: 'application/json' },
+      { TOKEN: 't', KEY: 'k' },
+    );
+
+    expect(result).toEqual({ Authorization: 'Bearer t', 'X-API-Key': 'k', Accept: 'application/json' });
+  });
+
+  it('substitutes the same variable more than once in one value', () => {
+    const result = interpolateHeaders({ 'X-Pair': '${A}:${A}' }, { A: 'x' });
+
+    expect(result).toEqual({ 'X-Pair': 'x:x' });
+  });
+
+  it('leaves headers with no references untouched', () => {
+    const result = interpolateHeaders({ Accept: 'application/json' }, {});
+
+    expect(result).toEqual({ Accept: 'application/json' });
+  });
+
+  it('throws when a referenced variable is unset, rather than sending an empty value', () => {
+    expect(() => interpolateHeaders({ Authorization: 'Bearer ${NOPE}' }, {})).toThrow(
+      MissingEnvironmentVariableError,
+    );
+  });
+
+  it('names every missing variable at once', () => {
+    // Three unset tokens should be learned on the first run, not one per run.
+    try {
+      interpolateHeaders({ A: '${ONE}', B: '${TWO}', C: '${THREE}' }, {});
+      throw new Error('expected interpolateHeaders to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingEnvironmentVariableError);
+      expect((e as MissingEnvironmentVariableError).variableNames.sort()).toEqual(['ONE', 'THREE', 'TWO']);
+    }
+  });
+
+  it('treats an empty-string variable as set', () => {
+    // Deliberately distinct from unset: someone may legitimately export an
+    // empty value, and second-guessing that would be worse than honouring it.
+    const result = interpolateHeaders({ 'X-Thing': '[${EMPTY}]' }, { EMPTY: '' });
+
+    expect(result).toEqual({ 'X-Thing': '[]' });
+  });
+
+  it('ignores text that merely looks like a reference', () => {
+    const result = interpolateHeaders({ 'X-Literal': '$NOTAREF and ${ }' }, {});
+
+    expect(result).toEqual({ 'X-Literal': '$NOTAREF and ${ }' });
+  });
+
+  it('does not mutate the headers it was given', () => {
+    const headers = { Authorization: 'Bearer ${TOKEN}' };
+    interpolateHeaders(headers, { TOKEN: 'abc' });
+
+    expect(headers).toEqual({ Authorization: 'Bearer ${TOKEN}' });
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -168,6 +168,23 @@ export interface ConfigurationInputFromUrl extends ConfigurationInputBase {
    * @pattern ^https?://
    */
   inputURL: string;
+
+  /**
+   * HTTP headers to send when fetching `inputURL` (issue #61).
+   *
+   * Values support environment-variable interpolation with `${VAR}`, so a
+   * credential never has to be written into a file that gets committed. A
+   * referenced variable that is not set fails the run with a message naming it,
+   * rather than sending an empty header and reporting the resulting 401 as if
+   * the server had rejected valid credentials.
+   *
+   * A generic map rather than a `bearer`/`basic` union: users need
+   * `X-API-Key` and similar just as often as `Authorization`, and one map
+   * covers every scheme without a new option per scheme.
+   *
+   * @examples require('./examples-for-schema.ts').InputUrlHeadersExamples
+   */
+  headers?: { [headerName: string]: string };
 }
 
 /**

--- a/packages/openapi-merge-cli/src/examples-for-schema.ts
+++ b/packages/openapi-merge-cli/src/examples-for-schema.ts
@@ -117,3 +117,11 @@ export const ConfigurationInputExamples: Array<Array<ConfigurationInput>> = [
     }
   ]
 ];
+/**
+ * Headers for an `inputURL` request (issue #61). `${VAR}` is resolved from the
+ * environment at load time, so a token never has to live in the config file.
+ */
+export const InputUrlHeadersExamples: Array<{ [headerName: string]: string }> = [
+  { Authorization: 'Bearer ${API_TOKEN}' },
+  { 'X-API-Key': '${SERVICE_A_KEY}', Accept: 'application/json' },
+];

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -1,5 +1,6 @@
 import { ConfigurationInput, isConfigurationInputFromFile } from "./data";
 import { loadConfiguration } from "./load-configuration";
+import { interpolateHeaders, MissingEnvironmentVariableError } from "./interpolate-headers";
 import { Command } from 'commander';
 // package.json sits outside tsconfig's rootDir, so it cannot be imported as a
 // module without widening the compilation. require() is the pragmatic option.
@@ -128,7 +129,10 @@ async function loadOasForInput(basePath: string, input: ConfigurationInput, inpu
     return (await readYamlOrJSON(await readFileAsString(fullPath))) as Swagger.SwaggerV3;
   } else {
     logger.log(`## Loading input ${inputIndex} from URL: ${input.inputURL}`);
-    const response = await fetch(input.inputURL);
+    // Resolved per request rather than once at load time so that the error, if
+    // a variable is unset, names the input it belongs to.
+    const headers = input.headers === undefined ? undefined : interpolateHeaders(input.headers);
+    const response = await fetch(input.inputURL, headers === undefined ? undefined : { headers });
     if (!response.ok) {
       throw new InputUrlStatusError(input.inputURL, response.status, response.statusText);
     }
@@ -183,9 +187,15 @@ async function convertInputs(basePath: string, configInputs: ConfigurationInput[
     } catch (e) {
       return {
         message: `Input ${inputIndex}: could not load configuration file. ${e}`,
+        // An unset ${VAR} in a header is a fault in the configuration, not in
+        // the input the configuration points at -- the request was never made.
+        // Reporting it as ErrorLoadingInputs would send someone looking at the
+        // remote service instead of at their own environment.
         exitCode: e instanceof InputUrlStatusError
           ? e.exitCode
-          : ExitCode.ErrorLoadingInputs,
+          : e instanceof MissingEnvironmentVariableError
+            ? ExitCode.ErrorLoadingConfig
+            : ExitCode.ErrorLoadingInputs,
       };
     }
   }));

--- a/packages/openapi-merge-cli/src/interpolate-headers.ts
+++ b/packages/openapi-merge-cli/src/interpolate-headers.ts
@@ -1,0 +1,56 @@
+/**
+ * Environment-variable interpolation for `inputURL` request headers (issue #61).
+ *
+ * A credential must not be written into a configuration file that gets
+ * committed, so header values may reference the environment as `${VAR}` and are
+ * resolved at load time.
+ */
+
+const ENV_REFERENCE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+export class MissingEnvironmentVariableError extends Error {
+  public constructor(public readonly variableNames: string[]) {
+    super(
+      `The following environment variable${variableNames.length === 1 ? ' is' : 's are'} referenced by input headers but not set: ` +
+        `${variableNames.join(', ')}. Set ${variableNames.length === 1 ? 'it' : 'them'} before running the merge.`,
+    );
+  }
+}
+
+/**
+ * Resolves every `${VAR}` in a header map against `env`.
+ *
+ * Throws when a referenced variable is unset, rather than substituting an empty
+ * string. An empty `Authorization: Bearer ` header produces a 401 that looks
+ * like a credentials problem on the server's side; failing here names the
+ * actual cause, which is a variable the caller forgot to export.
+ *
+ * Every missing variable is reported at once, so a caller with three unset
+ * tokens learns all three on the first run instead of one per attempt.
+ */
+export function interpolateHeaders(
+  headers: Record<string, string>,
+  env: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+  const missing = new Set<string>();
+
+  const resolved = Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      value.replace(ENV_REFERENCE, (_match, variableName: string) => {
+        const replacement = env[variableName];
+        if (replacement === undefined) {
+          missing.add(variableName);
+          return '';
+        }
+        return replacement;
+      }),
+    ]),
+  );
+
+  if (missing.size > 0) {
+    throw new MissingEnvironmentVariableError([...missing]);
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
Closes #61.

`inputURL` inputs were fetched with a bare `fetch` and no way to attach a header, so any spec behind auth was unreachable. Since the 4xx/5xx exit-code split landed, such a user got a clean exit 6 telling them they were unauthorised — with no way to do anything about it.

```jsonc
{
  "inputURL": "https://api.example.com/spec.json",
  "headers": { "Authorization": "Bearer ${API_TOKEN}" }
}
```

`${VAR}` is resolved from the environment, so a credential never has to be committed. A generic map rather than a bearer/basic union: `X-API-Key` is as common as `Authorization`.

### Failure behaviour, deliberately chosen

- **An unset variable fails the run** rather than substituting an empty string. `Authorization: Bearer ` produces a 401 that reads as the server rejecting valid credentials — sending the user to investigate entirely the wrong system.
- **All missing variables are named at once**, so three unset tokens are learned in one run rather than three.
- **Exit is `ErrorLoadingConfig`, not `ErrorLoadingInputs`.** The request is never made; the fault is in the configuration, not the service it points at.
- **An empty-string variable counts as set** — someone may legitimately export one.

### Not implemented: `allowPrivateUrls`

The proposal also wanted a flag defaulting to rejecting RFC1918/loopback as SSRF defence. That default breaks merging from a localhost dev server or a service in the same CI job — an ordinary use — and aims at the wrong threat model: SSRF matters when an attacker controls the URL, and here it comes from a file the user wrote. Where the config is untrusted, `outputRoot` already covers that shape of problem and a URL allowlist would belong beside it as opt-in. Reasoning in §10.1 of the proposal.

### Verification

- 9 unit tests in `interpolate-headers.test.ts`
- 6 CLI tests driven against the real in-process HTTP server, asserting on headers the server **actually received** — proving they reach the wire, not just that a function returned them. **5 fail against `origin/main`.**
- Gate green: lint, 399 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)