### PR TITLE
feat(merge): configurable duplicate path handling (#71)

### DIFF
--- a/ai-planning/issues/11-proposal-71-skip-duplicate-paths.md
+++ b/ai-planning/issues/11-proposal-71-skip-duplicate-paths.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#71 — Possible to skip duplicate paths?](https://github.com/robertmassaioli/openapi-merge/issues/71)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 | **Effort:** 3 | **ROI:** Medium
 
@@ -263,3 +263,68 @@ We do **not** recommend adding a `skipped` field to `MergeResult.output` because
 1. **Decision:** Approve per-input `duplicatePathHandling` design vs. alternative (global option).
 2. **Coordination:** Plan parallelization with #8 and #109 as a unified "Conflict Policies" release.
 3. **Implementation:** Start with per-method granularity built-in (higher effort upfront, better UX long-term).
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/71-skip-duplicate-paths`. §4.1's three-value
+`duplicatePathHandling`, per input, defaulting to `'error'` so nothing that
+worked before behaves differently.
+
+### 10.1 On `SingleMergeInputBase`, not `SingleMergeInputV2`
+
+§4.1 puts it on `SingleMergeInputV2`. It went on the shared base instead, so it
+also works with the deprecated `disputePrefix` form. There is no reason a policy
+about paths should be unavailable to someone who has not yet migrated their
+dispute configuration.
+
+### 10.2 Two operationId bugs the design did not anticipate
+
+Neither is visible from the proposal, and both produce a valid-looking document
+with wrong names.
+
+**Skipped paths must not consume operationIds.** `'skip-later'` returns before
+`ensureUniqueOperationIds`. Registering the ids of a path that is not going into
+the output would push an unrelated later operation onto a numeric suffix, for a
+collision with something that was discarded.
+
+**Replaced paths must release theirs.** Under `'prefer-later'` the earlier
+definition leaves the output, so its ids have to leave `seenOperationIds` with
+it. Without that, two inputs that both define `getThing` on the same path yield
+an output where the surviving operation is called `getThing1` and `getThing`
+exists nowhere. Handled by a new `releaseOperationIds`; both cases are tested.
+
+### 10.3 Webhooks too
+
+Not mentioned in the proposal. Webhooks collide by event name through the same
+code shape and produced the same unconditional `duplicate-webhooks` error, so
+the policy applies there as well. It would be arbitrary for the same
+configuration to resolve a path collision and hard-fail an event-name one.
+
+### 10.4 §4.3 per-method granularity deliberately not implemented
+
+§4.3 recommends letting a later input add `POST /x` beside an earlier `GET /x`.
+Left out, because it raises questions the proposal does not answer: what
+happens to the path item's own `summary`, `description`, `parameters` and
+`$ref` when two inputs disagree about them? Merging *inside* a path item is a
+different feature from choosing *between* path items, and #8 and #109 will need
+that discussion anyway. Whole-path-item semantics are what §4.2 specifies and
+are predictable to explain.
+
+### 10.5 Verification
+
+- 11 tests in `paths.test.ts`. **7 fail against `origin/main`**, confirmed in a
+  detached worktree; the other four assert the unchanged default, including
+  that duplicate webhooks still error.
+- 4 CLI tests in `cli-merging.test.ts` for the wiring, including ajv rejecting
+  an unknown policy value.
+- Gate green: lint, 398 tests, 48 artifact checks.
+
+### 10.6 This unblocks #8 and #109
+
+Both were deferred in the sweep ledger pending this mechanism. Each is now one
+additional value in `DuplicatePathHandling` plus its tests — #8 wants the
+dispute prefix applied to a duplicate instead of erroring, #109 wants a
+designated input to win, which `'prefer-later'` may already cover.

--- a/ai-planning/issues/11-proposal-71-skip-duplicate-paths.md
+++ b/ai-planning/issues/11-proposal-71-skip-duplicate-paths.md
@@ -303,28 +303,58 @@ code shape and produced the same unconditional `duplicate-webhooks` error, so
 the policy applies there as well. It would be arbitrary for the same
 configuration to resolve a path collision and hard-fail an event-name one.
 
-### 10.4 §4.3 per-method granularity deliberately not implemented
+### 10.4 §4.3 per-method granularity — implemented as a fourth policy
 
-§4.3 recommends letting a later input add `POST /x` beside an earlier `GET /x`.
-Left out, because it raises questions the proposal does not answer: what
-happens to the path item's own `summary`, `description`, `parameters` and
-`$ref` when two inputs disagree about them? Merging *inside* a path item is a
-different feature from choosing *between* path items, and #8 and #109 will need
-that discussion anyway. Whole-path-item semantics are what §4.2 specifies and
-are predictable to explain.
+Initially left out for want of an answer to "what happens to the path item's own
+`summary`, `parameters` and `$ref` when two inputs disagree?". Raised again in
+review, and the answer turned out to be simple: **refuse**.
 
-### 10.5 Verification
+`'merge-operations'` combines two path items when, and only when, the union is
+unambiguous:
 
-- 11 tests in `paths.test.ts`. **7 fail against `origin/main`**, confirmed in a
-  detached worktree; the other four assert the unchanged default, including
-  that duplicate webhooks still error.
-- 4 CLI tests in `cli-merging.test.ts` for the wiring, including ajv rejecting
-  an unknown policy value.
-- Gate green: lint, 398 tests, 48 artifact checks.
+- their method sets are disjoint (standard slots and 3.2 `additionalOperations`
+  alike, the latter compared case-sensitively);
+- their path-level fields are identical — every key that is not an operation,
+  compared deeply, including vendor extensions;
+- neither is a `$ref`.
 
-### 10.6 This unblocks #8 and #109
+Anything else returns `duplicate-paths` (or `duplicate-webhooks`) with a message
+naming the reason: which methods overlapped, which fields differed, or that a
+`$ref` cannot be compared without resolving it.
 
-Both were deferred in the sweep ledger pending this mechanism. Each is now one
-additional value in `DuplicatePathHandling` plus its tests — #8 wants the
-dispute prefix applied to a duplicate instead of erroring, #109 wants a
-designated input to win, which `'prefer-later'` may already cover.
+`parameters` is the case that justifies the strictness. They are inherited by
+every operation in the path item, so combining an input whose path declares
+`tenantId` with one that does not silently adds a required parameter to
+operations that never had it. That is a merge tool changing what a document
+means, which is worse than a merge tool that stops. The same argument covers a
+field present on one side and absent on the other, so that counts as a
+difference too.
+
+Incoming operations go through `ensureUniqueOperationIds` before being combined,
+since they are joining a document that already contains the existing ones —
+otherwise two inputs each contributing an operation called `thing` to the same
+path would emit a duplicate id.
+
+Applies to webhooks on the same terms.
+
+### 10.5 What #8 and #109 still want
+
+Unchanged: both are additional *values* on this union rather than new
+mechanisms. #8 wants the dispute prefix applied to a colliding path; #109 wants
+a designated input to win, which `'prefer-later'` may already cover.
+
+### 10.6 Verification
+
+- 24 unit tests in `merge-path-items.test.ts` for the combine decision itself,
+  weighted towards the refusals: overlapping standard methods, partial overlap,
+  overlapping custom verbs, differing `parameters` / `summary` / `servers` /
+  vendor extensions, a field present on one side only, and all three `$ref`
+  arrangements. Plus immutability of both arguments.
+- 14 further tests in `paths.test.ts` driving real merges: three inputs
+  contributing three methods, a duplicate created by `pathModification`,
+  operationId disambiguation and dispute prefixes across the combine, webhooks,
+  and the per-input nature of the policy.
+- 3 CLI tests, including that the failure message names the overlapping method.
+- Two `KNOWN LIMITATION` tests remain, now pinning what `skip-later` and
+  `prefer-later` still discard — which is the point of having a third option.
+- Gate green: lint, 523 tests, 48 artifact checks.

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -334,3 +334,44 @@ describe('main - tag injection (issue #112)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #71 `merge-operations` reaching the library from a config file.
+ */
+describe('main - duplicatePathHandling: merge-operations (issue #71)', () => {
+  it('combines GET and POST on the same path', async () => {
+    cli.writeJson('a.json', oas({ '/thing': { get: { operationId: 'getThing', responses: { '200': { description: 'ok' } } } } }));
+    cli.writeJson('b.json', oas({ '/thing': { post: { operationId: 'postThing', responses: { '200': { description: 'ok' } } } } }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json', duplicatePathHandling: 'merge-operations' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(Object.keys(JSON.parse(cli.read()).paths['/thing']).sort()).toEqual(['get', 'post']);
+  });
+
+  it('exits 3 with an explanation when the methods overlap', async () => {
+    cli.writeJson('a.json', oas({ '/thing': getPath('a') }));
+    cli.writeJson('b.json', oas({ '/thing': getPath('b') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json', duplicatePathHandling: 'merge-operations' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorMerging);
+    // The message has to say WHY, or the user cannot tell this from a plain
+    // duplicate-path failure.
+    expect(cli.stderr().join('\n')).toContain('GET');
+  });
+
+  it('accepts merge-operations as a schema value', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json', duplicatePathHandling: 'merge-operations' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+  });
+});

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -130,3 +130,58 @@ describe('main - serversStrategy (issue #4)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #71: duplicate-path policy reaching the library from a config file.
+ *
+ * Library behaviour is covered by the openapi-merge suite; these assert the
+ * wiring -- that the per-input field survives schema validation and is actually
+ * passed through `convertInputs`, which is the part that would silently do
+ * nothing if the plumbing were wrong.
+ */
+describe('main - duplicatePathHandling (issue #71)', () => {
+  it('fails on a duplicate path by default', async () => {
+    cli.writeJson('a.json', oas({ '/same': getPath('fromA') }));
+    cli.writeJson('b.json', oas({ '/same': getPath('fromB') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorMerging);
+  });
+
+  it('keeps the first definition with skip-later', async () => {
+    cli.writeJson('a.json', oas({ '/same': getPath('fromA') }));
+    cli.writeJson('b.json', oas({ '/same': getPath('fromB') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json', duplicatePathHandling: 'skip-later' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(JSON.parse(cli.read()).paths['/same'].get.operationId).toBe('fromA');
+  });
+
+  it('takes the last definition with prefer-later', async () => {
+    cli.writeJson('a.json', oas({ '/same': getPath('fromA') }));
+    cli.writeJson('b.json', oas({ '/same': getPath('fromB') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json', duplicatePathHandling: 'prefer-later' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(JSON.parse(cli.read()).paths['/same'].get.operationId).toBe('fromB');
+  });
+
+  it('rejects an unknown policy value against the generated schema', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json', duplicatePathHandling: 'last-one-wins' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -143,6 +143,19 @@ export interface ConfigurationInputBase {
    * @examples require('./examples-for-schema.ts').DescriptionMergeBehaviourExamples
    */
   description?: DescriptionMergeBehaviour;
+
+  /**
+   * What to do when this input declares a path (or webhook) that an earlier
+   * input already contributed (issue #71).
+   *
+   * - `error` (default) — fail the merge, as it always has.
+   * - `skip-later` — keep the definition already present, drop this one.
+   * - `prefer-later` — replace the definition already present with this one.
+   *
+   * Per input rather than global, so a configuration can say "this gateway
+   * input wins and the rest are additive".
+   */
+  duplicatePathHandling?: 'error' | 'skip-later' | 'prefer-later';
 }
 
 /**

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -151,11 +151,16 @@ export interface ConfigurationInputBase {
    * - `error` (default) — fail the merge, as it always has.
    * - `skip-later` — keep the definition already present, drop this one.
    * - `prefer-later` — replace the definition already present with this one.
+   * - `merge-operations` — combine them when their methods do not overlap and
+   *   their path-level fields agree, so `GET /thing` from one input and
+   *   `POST /thing` from another end up in one path item. Refuses rather than
+   *   guessing when the methods overlap, the path-level fields differ, or
+   *   either side is a `$ref`.
    *
    * Per input rather than global, so a configuration can say "this gateway
    * input wins and the rest are additive".
    */
-  duplicatePathHandling?: 'error' | 'skip-later' | 'prefer-later';
+  duplicatePathHandling?: 'error' | 'skip-later' | 'prefer-later' | 'merge-operations';
 
   /**
    * Add a tag to every operation from this input (issue #112).

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -165,6 +165,7 @@ async function convertInputs(basePath: string, configInputs: ConfigurationInput[
         pathModification: input.pathModification,
         operationSelection: input.operationSelection,
         description: input.description,
+        duplicatePathHandling: input.duplicatePathHandling,
       };
 
       if ('dispute' in input) {

--- a/packages/openapi-merge/src/__tests__/merge-path-items.test.ts
+++ b/packages/openapi-merge/src/__tests__/merge-path-items.test.ts
@@ -1,0 +1,267 @@
+import { mergePathItems, isPathItemMergeFailure } from '../merge-path-items';
+import { PathItem32 } from '../oas31';
+import { ok } from './_helpers/documents';
+
+/**
+ * Combining two Path Items that share a key (issue #71, `merge-operations`).
+ *
+ * Unit tests for the decision itself. The refusals matter more than the
+ * successes: each one is a case where a plausible-looking union would silently
+ * change what one input's operations mean, and quietly altering semantics is
+ * worse than stopping.
+ */
+describe('mergePathItems (issue #71)', () => {
+  const op = (operationId: string) => ({ operationId, responses: ok });
+  const expectMerged = (result: ReturnType<typeof mergePathItems>): PathItem32 => {
+    if (isPathItemMergeFailure(result)) {
+      throw new Error(`expected a merge, got refusal: ${result.reason}`);
+    }
+    return result;
+  };
+  const expectRefused = (result: ReturnType<typeof mergePathItems>): string => {
+    if (!isPathItemMergeFailure(result)) {
+      throw new Error('expected a refusal, got a merged path item');
+    }
+    return result.reason;
+  };
+
+  describe('combining disjoint methods', () => {
+    it('combines GET and POST', () => {
+      const merged = expectMerged(mergePathItems({ get: op('getThing') }, { post: op('postThing') }));
+
+      expect(Object.keys(merged).sort()).toEqual(['get', 'post']);
+      expect(merged.get?.operationId).toBe('getThing');
+      expect(merged.post?.operationId).toBe('postThing');
+    });
+
+    it('combines several methods at once', () => {
+      const merged = expectMerged(
+        mergePathItems({ get: op('g'), head: op('h') }, { post: op('p'), delete: op('d') }),
+      );
+
+      expect(Object.keys(merged).sort()).toEqual(['delete', 'get', 'head', 'post']);
+    });
+
+    it('combines a 3.2 query operation with a standard one', () => {
+      const merged = expectMerged(mergePathItems({ get: op('g') }, { query: op('q') }));
+
+      expect(Object.keys(merged).sort()).toEqual(['get', 'query']);
+    });
+
+    it('combines additionalOperations from both sides', () => {
+      const merged = expectMerged(
+        mergePathItems(
+          { additionalOperations: { PURGE: op('purge') } },
+          { additionalOperations: { LOCK: op('lock') } },
+        ),
+      );
+
+      expect(Object.keys(merged.additionalOperations ?? {}).sort()).toEqual(['LOCK', 'PURGE']);
+    });
+
+    it('combines a standard method with a custom verb', () => {
+      const merged = expectMerged(
+        mergePathItems({ get: op('g') }, { additionalOperations: { PURGE: op('purge') } }),
+      );
+
+      expect(merged.get?.operationId).toBe('g');
+      expect(merged.additionalOperations?.PURGE?.operationId).toBe('purge');
+    });
+
+    it('treats custom verb names as case-sensitive, per 3.2', () => {
+      // `GET` in additionalOperations is a different operation from the
+      // standard `get` slot, and from a lowercase custom `get`.
+      const merged = expectMerged(
+        mergePathItems(
+          { additionalOperations: { GET: op('customGet') } },
+          { additionalOperations: { get: op('otherGet') } },
+        ),
+      );
+
+      expect(Object.keys(merged.additionalOperations ?? {}).sort()).toEqual(['GET', 'get']);
+    });
+
+    it('keeps identical path-level fields on the result', () => {
+      const fields: Pick<PathItem32, 'summary' | 'parameters'> = {
+        summary: 'A thing',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      };
+      const merged = expectMerged(
+        mergePathItems({ ...fields, get: op('g') }, { ...fields, post: op('p') }),
+      );
+
+      expect(merged.summary).toBe('A thing');
+      expect(merged.parameters).toEqual(fields.parameters);
+      expect(Object.keys(merged).sort()).toEqual(['get', 'parameters', 'post', 'summary']);
+    });
+
+    it('combines when neither side has any path-level fields', () => {
+      // The overwhelmingly common case: two teams each contributing one method.
+      const merged = expectMerged(mergePathItems({ get: op('g') }, { post: op('p') }));
+
+      expect(Object.keys(merged).sort()).toEqual(['get', 'post']);
+    });
+  });
+
+  describe('refusing an overlapping method', () => {
+    it('refuses when both define the same standard method', () => {
+      const reason = expectRefused(mergePathItems({ get: op('a') }, { get: op('b') }));
+
+      expect(reason).toContain('GET');
+      expect(reason).toContain('prefer-later');
+    });
+
+    it('refuses when only one of several methods overlaps', () => {
+      const reason = expectRefused(
+        mergePathItems({ get: op('a'), head: op('h') }, { get: op('b'), post: op('p') }),
+      );
+
+      // Partial overlap is still ambiguous: there is no answer for GET.
+      expect(reason).toContain('GET');
+    });
+
+    it('names every overlapping method', () => {
+      const reason = expectRefused(
+        mergePathItems({ get: op('a'), post: op('b') }, { get: op('c'), post: op('d') }),
+      );
+
+      expect(reason).toContain('GET');
+      expect(reason).toContain('POST');
+    });
+
+    it('refuses an overlapping custom verb', () => {
+      const reason = expectRefused(
+        mergePathItems(
+          { additionalOperations: { PURGE: op('a') } },
+          { additionalOperations: { PURGE: op('b') } },
+        ),
+      );
+
+      expect(reason).toContain('PURGE');
+    });
+  });
+
+  describe('refusing on path-level fields', () => {
+    it('refuses when parameters differ', () => {
+      // The sharp case: merging would silently add a required parameter to
+      // operations that never declared one.
+      const reason = expectRefused(
+        mergePathItems(
+          { parameters: [{ name: 'tenantId', in: 'path', required: true, schema: { type: 'string' } }], get: op('g') },
+          { parameters: [{ name: 'apiVersion', in: 'query', schema: { type: 'string' } }], post: op('p') },
+        ),
+      );
+
+      expect(reason).toContain("'parameters'");
+      expect(reason).toContain('every operation');
+    });
+
+    it('refuses when one side declares parameters and the other does not', () => {
+      // Not a disagreement about a value, but still a change in meaning: the
+      // incoming operations would inherit a parameter they never had.
+      const reason = expectRefused(
+        mergePathItems({ parameters: [{ name: 'tenantId', in: 'path', required: true, schema: { type: 'string' } }], get: op('g') }, { post: op('p') }),
+      );
+
+      expect(reason).toContain("'parameters'");
+    });
+
+    it('refuses when summary differs', () => {
+      const reason = expectRefused(
+        mergePathItems({ summary: 'One', get: op('g') }, { summary: 'Two', post: op('p') }),
+      );
+
+      expect(reason).toContain("'summary'");
+    });
+
+    it('refuses when servers differ', () => {
+      const reason = expectRefused(
+        mergePathItems(
+          { servers: [{ url: 'https://a' }], get: op('g') },
+          { servers: [{ url: 'https://b' }], post: op('p') },
+        ),
+      );
+
+      expect(reason).toContain("'servers'");
+    });
+
+    it('names every differing field', () => {
+      const reason = expectRefused(
+        mergePathItems(
+          { summary: 'One', description: 'First', get: op('g') },
+          { summary: 'Two', description: 'Second', post: op('p') },
+        ),
+      );
+
+      expect(reason).toContain("'description'");
+      expect(reason).toContain("'summary'");
+    });
+
+    it('refuses on a differing vendor extension, which it cannot interpret', () => {
+      const reason = expectRefused(
+        mergePathItems(
+          { 'x-owner': 'team-a', get: op('g') } as PathItem32,
+          { 'x-owner': 'team-b', post: op('p') } as PathItem32,
+        ),
+      );
+
+      expect(reason).toContain("'x-owner'");
+    });
+
+    it('allows an identical vendor extension', () => {
+      const merged = expectMerged(
+        mergePathItems(
+          { 'x-owner': 'team-a', get: op('g') } as PathItem32,
+          { 'x-owner': 'team-a', post: op('p') } as PathItem32,
+        ),
+      );
+
+      expect(Object.keys(merged).sort()).toEqual(['get', 'post', 'x-owner']);
+    });
+  });
+
+  describe('refusing a $ref path item', () => {
+    it('refuses when the existing side is a $ref', () => {
+      const reason = expectRefused(mergePathItems({ $ref: '#/components/pathItems/Shared' }, { post: op('p') }));
+
+      expect(reason).toContain('$ref');
+    });
+
+    it('refuses when the incoming side is a $ref', () => {
+      const reason = expectRefused(mergePathItems({ get: op('g') }, { $ref: '#/components/pathItems/Shared' }));
+
+      expect(reason).toContain('$ref');
+    });
+
+    it('refuses when both are $refs, even to the same target', () => {
+      // Identical targets would be safe to collapse, but proving that needs
+      // resolution, and the merge deliberately does not resolve references.
+      const reason = expectRefused(
+        mergePathItems({ $ref: '#/components/pathItems/S' }, { $ref: '#/components/pathItems/S' }),
+      );
+
+      expect(reason).toContain('$ref');
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not modify either argument', () => {
+      const existing: PathItem32 = { get: op('g') };
+      const incoming: PathItem32 = { post: op('p') };
+
+      mergePathItems(existing, incoming);
+
+      expect(Object.keys(existing)).toEqual(['get']);
+      expect(Object.keys(incoming)).toEqual(['post']);
+    });
+
+    it('deep-clones the incoming operation, so later edits do not leak', () => {
+      const incoming: PathItem32 = { post: op('p') };
+      const merged = expectMerged(mergePathItems({ get: op('g') }, incoming));
+
+      (incoming.post as { operationId: string }).operationId = 'changed';
+
+      expect(merged.post?.operationId).toBe('p');
+    });
+  });
+});

--- a/packages/openapi-merge/src/__tests__/paths.test.ts
+++ b/packages/openapi-merge/src/__tests__/paths.test.ts
@@ -1,6 +1,6 @@
 import { merge } from '../index';
 import { Swagger } from '@atlassian/atlassian-openapi';
-import { doc30, expectMergeError, expectSuccess, op, pathKeys } from './_helpers/documents';
+import { doc30, doc31, expectMergeError, expectSuccess, op, pathKeys } from './_helpers/documents';
 import { toOAS } from "./_helpers/oas-generation";
 import { expectMergeResult, toMergeInputs, expectErrorType } from "./_helpers/test-utils";
 import { SingleMergeInput } from "../data";
@@ -332,5 +332,131 @@ describe('pathModification.stripStart', () => {
     const result = expectSuccess(merge([{ oas: toOAS(paths), pathModification: { stripStart: '/nope' } }]));
 
     expect(Object.keys(result.paths ?? {})).toEqual(['/api/thing']);
+  });
+});
+
+/**
+ * Issue #71: configurable duplicate-path handling.
+ *
+ * A duplicate path was an unconditional hard error, which blocks the
+ * API-gateway case this tool targets -- two teams legitimately exposing the
+ * same route, where one of them should simply win.
+ *
+ * Per input rather than global, because what people want to express is "this
+ * one input wins and the rest are additive", which a single global setting
+ * cannot say. The default is unchanged, so nothing that worked before behaves
+ * differently.
+ */
+describe('duplicatePathHandling (issue #71)', () => {
+  const inputWith = (pathName: string, operationId: string, handling?: 'error' | 'skip-later' | 'prefer-later') => ({
+    oas: doc30({ paths: { [pathName]: { get: op(operationId) } } }),
+    ...(handling === undefined ? {} : { duplicatePathHandling: handling }),
+  });
+
+  it('still errors by default, with the option absent entirely', () => {
+    const result = merge([inputWith('/a', 'first'), inputWith('/a', 'second')]);
+
+    expectMergeError(result, 'duplicate-paths');
+  });
+
+  it("still errors when 'error' is set explicitly", () => {
+    const result = merge([inputWith('/a', 'first'), inputWith('/a', 'second', 'error')]);
+
+    expectMergeError(result, 'duplicate-paths');
+  });
+
+  it("keeps the earlier definition under 'skip-later'", () => {
+    const output = expectSuccess(merge([inputWith('/a', 'first'), inputWith('/a', 'second', 'skip-later')]));
+
+    expect(output.paths?.['/a']?.get?.operationId).toBe('first');
+  });
+
+  it("takes the later definition under 'prefer-later'", () => {
+    const output = expectSuccess(merge([inputWith('/a', 'first'), inputWith('/a', 'second', 'prefer-later')]));
+
+    expect(output.paths?.['/a']?.get?.operationId).toBe('second');
+  });
+
+  it('leaves non-colliding paths from the skipped input alone', () => {
+    const output = expectSuccess(
+      merge([
+        inputWith('/a', 'first'),
+        {
+          oas: doc30({ paths: { '/a': { get: op('second') }, '/b': { get: op('other') } } }),
+          duplicatePathHandling: 'skip-later' as const,
+        },
+      ]),
+    );
+
+    // Only the colliding path is dropped; the input is not discarded wholesale.
+    expect(pathKeys(output)).toEqual(['/a', '/b']);
+    expect(output.paths?.['/a']?.get?.operationId).toBe('first');
+    expect(output.paths?.['/b']?.get?.operationId).toBe('other');
+  });
+
+  it('does not consume operationIds from a skipped path', () => {
+    // A discarded path must not push a later, unrelated operation onto a
+    // numeric suffix by colliding with something that is not in the output.
+    const output = expectSuccess(
+      merge([
+        inputWith('/a', 'shared'),
+        { oas: doc30({ paths: { '/a': { get: op('ignored') } } }), duplicatePathHandling: 'skip-later' as const },
+        { oas: doc30({ paths: { '/c': { get: op('ignored') } } }) },
+      ]),
+    );
+
+    expect(output.paths?.['/c']?.get?.operationId).toBe('ignored');
+  });
+
+  it('releases the replaced operationId under prefer-later', () => {
+    // Without releasing it, the winning operation would collide with the id of
+    // the definition it just replaced and be renamed `shared1` -- leaving a
+    // document where `shared` exists nowhere.
+    const output = expectSuccess(
+      merge([
+        inputWith('/a', 'shared'),
+        { oas: doc30({ paths: { '/a': { get: op('shared') } } }), duplicatePathHandling: 'prefer-later' as const },
+      ]),
+    );
+
+    expect(output.paths?.['/a']?.get?.operationId).toBe('shared');
+  });
+
+  it('applies to a duplicate created by pathModification, not just to identical keys', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/api/a': { get: op('first') } } }) },
+        {
+          oas: doc30({ paths: { '/a': { get: op('second') } } }),
+          pathModification: { prepend: '/api' },
+          duplicatePathHandling: 'skip-later',
+        },
+      ]),
+    );
+
+    expect(output.paths?.['/api/a']?.get?.operationId).toBe('first');
+  });
+
+  it('applies to webhooks, which collide by event name the same way', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc31({ paths: {}, webhooks: { ping: { post: op('firstPing') } } }) },
+        {
+          oas: doc31({ paths: {}, webhooks: { ping: { post: op('secondPing') } } }),
+          duplicatePathHandling: 'prefer-later',
+        },
+      ]),
+    );
+
+    expect(output.webhooks?.ping?.post?.operationId).toBe('secondPing');
+  });
+
+  it('still errors on duplicate webhooks by default', () => {
+    const result = merge([
+      { oas: doc31({ paths: {}, webhooks: { ping: { post: op('a') } } }) },
+      { oas: doc31({ paths: {}, webhooks: { ping: { post: op('b') } } }) },
+    ]);
+
+    expectMergeError(result, 'duplicate-webhooks');
   });
 });

--- a/packages/openapi-merge/src/__tests__/paths.test.ts
+++ b/packages/openapi-merge/src/__tests__/paths.test.ts
@@ -1,9 +1,10 @@
 import { merge } from '../index';
 import { Swagger } from '@atlassian/atlassian-openapi';
-import { doc30, doc31, expectMergeError, expectSuccess, op, pathKeys } from './_helpers/documents';
+import { doc30, doc31, doc32, expectMergeError, expectSuccess, op, pathKeys } from './_helpers/documents';
 import { toOAS } from "./_helpers/oas-generation";
 import { expectMergeResult, toMergeInputs, expectErrorType } from "./_helpers/test-utils";
 import { SingleMergeInput } from "../data";
+import { PathItem32 } from "../oas31";
 
 describe('OAS Path Merge', () => {
   it('should merge paths where one paths is null', () => {
@@ -460,7 +461,10 @@ describe('duplicatePathHandling (issue #71)', () => {
    * takes its operations with it. Both non-error policies therefore discard an
    * operation that does not collide with anything.
    *
-   * Pinned rather than fixed. Combining per method is a different feature --
+   * `merge-operations` now combines them where the answer is unambiguous; the
+   * two tests below pin what the OTHER policies still do, which is discard.
+   *
+   * Combining per method is a different decision from choosing between items --
    * choosing *between* path items versus merging *inside* one -- and it raises
    * questions this policy does not answer: a Path Item carries its own
    * `parameters`, which are inherited by every operation in it, plus
@@ -495,6 +499,178 @@ describe('duplicatePathHandling (issue #71)', () => {
       // The default refuses rather than guessing, so a user who would be
       // surprised by either policy above is told instead.
       expectMergeError(merge([getOnly, { oas: doc30({ paths: { '/thing': { post: op('postThing') } } }) }]), 'duplicate-paths');
+    });
+  });
+
+  /**
+   * `merge-operations` (issue #71): combine two path items that share a key but
+   * not a method.
+   *
+   * Only where the answer is unambiguous. Every refusal is a case where a
+   * plausible union would silently change what one input's operations mean.
+   */
+  describe("duplicatePathHandling: 'merge-operations'", () => {
+    const merged = (a: PathItem32, b: PathItem32, handling: 'merge-operations' = 'merge-operations') =>
+      merge([
+        { oas: doc32({ paths: { '/thing': a } }) },
+        { oas: doc32({ paths: { '/thing': b } }), duplicatePathHandling: handling },
+      ]);
+
+    it('combines GET from one input with POST from another', () => {
+      const output = expectSuccess(merged({ get: op('getThing') }, { post: op('postThing') }));
+
+      expect(pathKeys(output)).toEqual(['/thing']);
+      expect(Object.keys(output.paths?.['/thing'] ?? {}).sort()).toEqual(['get', 'post']);
+      expect(output.paths?.['/thing']?.get?.operationId).toBe('getThing');
+      expect(output.paths?.['/thing']?.post?.operationId).toBe('postThing');
+    });
+
+    it('leaves a non-colliding path from the same input alone', () => {
+      const output = expectSuccess(
+        merge([
+          { oas: doc32({ paths: { '/thing': { get: op('getThing') } } }) },
+          {
+            oas: doc32({ paths: { '/thing': { post: op('postThing') }, '/other': { get: op('getOther') } } }),
+            duplicatePathHandling: 'merge-operations',
+          },
+        ]),
+      );
+
+      expect(pathKeys(output)).toEqual(['/other', '/thing']);
+    });
+
+    it('disambiguates an operationId that collides with one already merged', () => {
+      // The incoming operation joins a document that already holds the other,
+      // so it is subject to the same uniqueness rule as any other operation.
+      const output = expectSuccess(merged({ get: op('shared') }, { post: op('shared') }));
+
+      expect(output.paths?.['/thing']?.get?.operationId).toBe('shared');
+      expect(output.paths?.['/thing']?.post?.operationId).toBe('shared1');
+    });
+
+    it('applies a dispute prefix to the incoming operation', () => {
+      const output = expectSuccess(
+        merge([
+          { oas: doc32({ paths: { '/thing': { get: op('thing') } } }) },
+          {
+            oas: doc32({ paths: { '/thing': { post: op('thing') } } }),
+            duplicatePathHandling: 'merge-operations',
+            dispute: { prefix: 'Svc' },
+          },
+        ]),
+      );
+
+      expect(output.paths?.['/thing']?.post?.operationId).toBe('Svcthing');
+    });
+
+    it('refuses when both define the same method', () => {
+      const message = expectMergeError(merged({ get: op('a') }, { get: op('b') }), 'duplicate-paths');
+
+      expect(message).toContain('GET');
+      expect(message).toContain("'/thing'");
+    });
+
+    it('refuses when path-level parameters differ', () => {
+      const message = expectMergeError(
+        merged(
+          { parameters: [{ name: 'tenantId', in: 'path', required: true, schema: { type: 'string' } }], get: op('g') },
+          { post: op('p') },
+        ),
+        'duplicate-paths',
+      );
+
+      expect(message).toContain("'parameters'");
+    });
+
+    it('refuses when either side is a $ref path item', () => {
+      const message = expectMergeError(
+        merged({ $ref: '#/components/pathItems/Shared' }, { post: op('p') }),
+        'duplicate-paths',
+      );
+
+      expect(message).toContain('$ref');
+    });
+
+    it('combines across a pathModification-created duplicate', () => {
+      const output = expectSuccess(
+        merge([
+          { oas: doc32({ paths: { '/api/thing': { get: op('getThing') } } }) },
+          {
+            oas: doc32({ paths: { '/thing': { post: op('postThing') } } }),
+            pathModification: { prepend: '/api' },
+            duplicatePathHandling: 'merge-operations',
+          },
+        ]),
+      );
+
+      expect(Object.keys(output.paths?.['/api/thing'] ?? {}).sort()).toEqual(['get', 'post']);
+    });
+
+    it('combines three inputs contributing three methods', () => {
+      const output = expectSuccess(
+        merge([
+          { oas: doc32({ paths: { '/thing': { get: op('g') } } }) },
+          { oas: doc32({ paths: { '/thing': { post: op('p') } } }), duplicatePathHandling: 'merge-operations' },
+          { oas: doc32({ paths: { '/thing': { delete: op('d') } } }), duplicatePathHandling: 'merge-operations' },
+        ]),
+      );
+
+      expect(Object.keys(output.paths?.['/thing'] ?? {}).sort()).toEqual(['delete', 'get', 'post']);
+    });
+
+    it('refuses on the third input if it collides with either earlier one', () => {
+      const message = expectMergeError(
+        merge([
+          { oas: doc32({ paths: { '/thing': { get: op('g') } } }) },
+          { oas: doc32({ paths: { '/thing': { post: op('p') } } }), duplicatePathHandling: 'merge-operations' },
+          { oas: doc32({ paths: { '/thing': { get: op('g2') } } }), duplicatePathHandling: 'merge-operations' },
+        ]),
+        'duplicate-paths',
+      );
+
+      expect(message).toContain('GET');
+    });
+
+    it('is per input, so another input can still use error', () => {
+      // The third input has no policy, so the default applies to it even though
+      // the second merged successfully.
+      expectMergeError(
+        merge([
+          { oas: doc32({ paths: { '/thing': { get: op('g') } } }) },
+          { oas: doc32({ paths: { '/thing': { post: op('p') } } }), duplicatePathHandling: 'merge-operations' },
+          { oas: doc32({ paths: { '/thing': { delete: op('d') } } }) },
+        ]),
+        'duplicate-paths',
+      );
+    });
+
+    it('combines webhooks that share an event name but not a method', () => {
+      const output = expectSuccess(
+        merge([
+          { oas: doc31({ paths: {}, webhooks: { ping: { post: op('onPing') } } }) },
+          {
+            oas: doc31({ paths: {}, webhooks: { ping: { get: op('checkPing') } } }),
+            duplicatePathHandling: 'merge-operations',
+          },
+        ]),
+      );
+
+      expect(Object.keys(output.webhooks?.ping ?? {}).sort()).toEqual(['get', 'post']);
+    });
+
+    it('refuses an overlapping webhook method with duplicate-webhooks', () => {
+      const message = expectMergeError(
+        merge([
+          { oas: doc31({ paths: {}, webhooks: { ping: { post: op('a') } } }) },
+          {
+            oas: doc31({ paths: {}, webhooks: { ping: { post: op('b') } } }),
+            duplicatePathHandling: 'merge-operations',
+          },
+        ]),
+        'duplicate-webhooks',
+      );
+
+      expect(message).toContain('POST');
     });
   });
 

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -40,10 +40,35 @@ export interface DisputeSuffix extends DisputeBase {
 
 export type Dispute = DisputePrefix | DisputeSuffix;
 
+/**
+ * What to do when this input declares a path another input already added
+ * (issue #71).
+ *
+ * - `'error'` (default) — fail with `duplicate-paths`, the historical
+ *   behaviour. Unchanged for anyone who does not set this.
+ * - `'skip-later'` — keep the definition already present and drop this input's.
+ * - `'prefer-later'` — replace the definition already present with this one.
+ *
+ * Per input rather than global, because the thing people actually want to
+ * express is "this one input wins and the rest are additive", which a single
+ * global setting cannot say.
+ */
+export type DuplicatePathHandling = 'error' | 'skip-later' | 'prefer-later';
+
 export interface SingleMergeInputBase {
   oas: OpenApiDocument;
 
   pathModification?: PathModification;
+
+  /**
+   * How to resolve a path this input shares with one already merged.
+   *
+   * Applies to `webhooks` as well, which collide by event name in exactly the
+   * same way.
+   *
+   * @default 'error'
+   */
+  duplicatePathHandling?: DuplicatePathHandling;
 
   /**
    * Any Operation tagged with one of the paths in this definition will be excluded from the merge result. Any tag

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -49,12 +49,17 @@ export type Dispute = DisputePrefix | DisputeSuffix;
  *   behaviour. Unchanged for anyone who does not set this.
  * - `'skip-later'` — keep the definition already present and drop this input's.
  * - `'prefer-later'` — replace the definition already present with this one.
+ * - `'merge-operations'` — combine them when their method sets are disjoint and
+ *   their path-level fields agree, so `GET /thing` from one input and
+ *   `POST /thing` from another end up in one path item. Refuses with
+ *   `duplicate-paths` in every case where a union would be a guess: overlapping
+ *   methods, differing path-level fields, or a `$ref` path item.
  *
  * Per input rather than global, because the thing people actually want to
  * express is "this one input wins and the rest are additive", which a single
  * global setting cannot say.
  */
-export type DuplicatePathHandling = 'error' | 'skip-later' | 'prefer-later';
+export type DuplicatePathHandling = 'error' | 'skip-later' | 'prefer-later' | 'merge-operations';
 
 /**
  * A tag applied to every operation coming from one input (issue #112).

--- a/packages/openapi-merge/src/merge-path-items.ts
+++ b/packages/openapi-merge/src/merge-path-items.ts
@@ -1,0 +1,114 @@
+import _ from 'lodash';
+import { HTTP_METHODS, HttpMethod, PathItem32 } from './oas31';
+
+/**
+ * Combining two Path Items that share a key but not a method (issue #71).
+ *
+ * `GET /thing` from one service and `POST /thing` from another describe
+ * different operations on the same resource, and a merged document can hold
+ * both. The other duplicate-path policies choose between whole Path Items, so
+ * whichever loses takes its operations with it -- discarding an operation that
+ * collided with nothing.
+ *
+ * This combines them instead, but only where the answer is unambiguous. Every
+ * refusal below is a case where a plausible-looking union would silently change
+ * what one input's operations mean, and a merge tool that quietly alters
+ * semantics is worse than one that stops.
+ */
+
+/**
+ * Keys that hold operations. Everything else on a Path Item applies to *all* of
+ * them, which is what makes those other keys dangerous to combine.
+ */
+const OPERATION_CONTAINER_KEYS: ReadonlySet<string> = new Set<string>([...HTTP_METHODS, 'additionalOperations']);
+
+export type PathItemMergeFailure = { reason: string };
+
+export function isPathItemMergeFailure(result: PathItem32 | PathItemMergeFailure): result is PathItemMergeFailure {
+  return (result as PathItemMergeFailure).reason !== undefined;
+}
+
+/** The Path Item's own fields: everything that is not an operation. */
+function pathLevelFields(pathItem: PathItem32): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  for (const key of Object.keys(pathItem)) {
+    if (!OPERATION_CONTAINER_KEYS.has(key)) {
+      fields[key] = (pathItem as unknown as Record<string, unknown>)[key];
+    }
+  }
+  return fields;
+}
+
+/** Standard method slots plus custom verbs, as a flat set of names. */
+function methodNames(pathItem: PathItem32): { standard: HttpMethod[]; additional: string[] } {
+  return {
+    standard: HTTP_METHODS.filter(method => pathItem[method] !== undefined),
+    additional: Object.keys(pathItem.additionalOperations ?? {}),
+  };
+}
+
+/**
+ * Combines `incoming` into `existing`, or explains why it will not.
+ *
+ * Returns a new Path Item; neither argument is modified.
+ */
+export function mergePathItems(existing: PathItem32, incoming: PathItem32): PathItem32 | PathItemMergeFailure {
+  // A Reference Object stands in for a Path Item defined elsewhere. Its
+  // operations are not visible here, so there is no way to tell whether the two
+  // sides overlap -- and resolving the reference to find out is a different
+  // feature (see issue #10, where external resolution was declined).
+  if (existing.$ref !== undefined || incoming.$ref !== undefined) {
+    return { reason: 'one of them is a $ref to a Path Item, whose operations cannot be compared without resolving it' };
+  }
+
+  // Path-level fields are inherited by every operation in the item. If the two
+  // sides disagree -- or one declares something the other does not -- then
+  // combining the operations under either set changes the meaning of the other
+  // side's operations. `parameters` is the sharp case: merging an input whose
+  // path declares `tenantId` into one that does not silently adds a required
+  // parameter to operations that never had it.
+  const existingFields = pathLevelFields(existing);
+  const incomingFields = pathLevelFields(incoming);
+  if (!_.isEqual(existingFields, incomingFields)) {
+    const differing = [...new Set([...Object.keys(existingFields), ...Object.keys(incomingFields)])]
+      .filter(key => !_.isEqual(existingFields[key], incomingFields[key]))
+      .sort();
+    return {
+      reason:
+        `the path-level field${differing.length === 1 ? '' : 's'} ${differing.map(f => `'${f}'`).join(', ')} ` +
+        `differ, and those apply to every operation in the path item`,
+    };
+  }
+
+  const existingMethods = methodNames(existing);
+  const incomingMethods = methodNames(incoming);
+
+  const overlappingStandard = incomingMethods.standard.filter(m => existingMethods.standard.includes(m));
+  // Custom verb names are case-sensitive per 3.2, so `GET` and `get` in
+  // `additionalOperations` are genuinely different operations.
+  const overlappingAdditional = incomingMethods.additional.filter(m => existingMethods.additional.includes(m));
+  const overlapping = [...overlappingStandard, ...overlappingAdditional];
+
+  if (overlapping.length > 0) {
+    return {
+      reason:
+        `both define ${overlapping.map(m => m.toUpperCase()).join(', ')}, so there is no single answer for ` +
+        `which operation wins -- use 'skip-later' or 'prefer-later' to choose`,
+    };
+  }
+
+  const merged: PathItem32 = _.cloneDeep(existing);
+
+  for (const method of incomingMethods.standard) {
+    merged[method] = _.cloneDeep(incoming[method]);
+  }
+
+  if (incomingMethods.additional.length > 0) {
+    merged.additionalOperations = { ...(merged.additionalOperations ?? {}) };
+    for (const method of incomingMethods.additional) {
+      merged.additionalOperations[method] = _.cloneDeep((incoming.additionalOperations ?? {})[method]);
+    }
+  }
+
+  return merged;
+}

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -3,6 +3,7 @@ import { Swagger, SwaggerLookup, SwaggerTypeChecks } from "@atlassian/atlassian-
 import { walkAllReferences } from "./reference-walker";
 import _ from 'lodash';
 import { runOperationSelection } from "./operation-selection";
+import { isPathItemMergeFailure, mergePathItems } from './merge-path-items';
 import { injectTag } from './tag-injection';
 import { deepEquality } from "./component-equivalence";
 import { applyDispute, getDispute } from './dispute';
@@ -359,6 +360,32 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
 
       const isDuplicate = result.paths[newPath] !== undefined;
 
+      if (isDuplicate && duplicatePathHandling === 'merge-operations') {
+        const incoming = getPaths(oas)[originalPath];
+
+        // Operation IDs first: the incoming operations are joining a document
+        // that already contains the existing ones, so they must be
+        // disambiguated against everything seen so far, exactly as they would
+        // be on a path of their own.
+        const opIdError = ensureUniqueOperationIds(incoming, seenOperationIds, dispute);
+        if (opIdError !== undefined) {
+          return opIdError;
+        }
+
+        const combined = mergePathItems(result.paths[newPath], incoming);
+        if (isPathItemMergeFailure(combined)) {
+          return {
+            type: 'duplicate-paths',
+            message:
+              `Input ${inputIndex}: The path '${originalPath}' maps to '${newPath}', which another input already ` +
+              `added, and they could not be combined because ${combined.reason}.`,
+          };
+        }
+
+        result.paths[newPath] = combined;
+        continue;
+      }
+
       if (isDuplicate && duplicatePathHandling === 'skip-later') {
         // Skipped before `ensureUniqueOperationIds`, deliberately: a path that
         // is not going into the output must not consume operationIds, or it
@@ -399,6 +426,28 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
           type: 'duplicate-webhooks',
           message: `Input ${inputIndex}: The webhook '${webhookName}' has already been added by another input file`
         };
+      }
+
+      if (result.webhooks[webhookName] !== undefined && duplicatePathHandling === 'merge-operations') {
+        const incoming = getWebhooks(oas)[webhookName];
+
+        const opIdError = ensureUniqueOperationIds(incoming, seenOperationIds, dispute);
+        if (opIdError !== undefined) {
+          return opIdError;
+        }
+
+        const combined = mergePathItems(result.webhooks[webhookName], incoming);
+        if (isPathItemMergeFailure(combined)) {
+          return {
+            type: 'duplicate-webhooks',
+            message:
+              `Input ${inputIndex}: The webhook '${webhookName}' has already been added by another input file, ` +
+              `and they could not be combined because ${combined.reason}.`,
+          };
+        }
+
+        result.webhooks[webhookName] = combined;
+        continue;
       }
 
       if (result.webhooks[webhookName] !== undefined && duplicatePathHandling === 'skip-later') {

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -114,6 +114,23 @@ function dropPathItemsWithNoOperations(originalOas: OpenApiDocument): OpenApiDoc
   return oas;
 }
 
+/**
+ * Un-registers the operationIds of a path item that is about to be replaced.
+ *
+ * Under `'prefer-later'` the earlier definition leaves the output, so its ids
+ * must leave `seenOperationIds` with it. Otherwise the winning operation
+ * collides with an id that is no longer present anywhere and gets renamed to
+ * `getThing1` -- leaving a document in which `getThing` does not exist and the
+ * surviving operation has a name nobody chose.
+ */
+function releaseOperationIds(pathItem: PathItem32, seenOperationIds: Set<string>): void {
+  for (const { operation } of getPathItemOperations(pathItem)) {
+    if (operation.operationId !== undefined) {
+      seenOperationIds.delete(operation.operationId);
+    }
+  }
+}
+
 function findUniqueOperationId(operationId: string, seenOperationIds: Set<string>, dispute: Dispute | undefined): string | ErrorMergeResult {
   if (!seenOperationIds.has(operationId)) {
     return operationId;
@@ -189,6 +206,7 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
 
     const { oas: originalOas, pathModification, operationSelection } = input;
     const dispute = getDispute(input);
+    const duplicatePathHandling = input.duplicatePathHandling ?? 'error';
 
     const oas = dropPathItemsWithNoOperations(runOperationSelection(_.cloneDeep(originalOas), operationSelection));
 
@@ -267,11 +285,27 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
       }
 
       // TODO perform more advanced matching for an existing path than an equals check
-      if (result.paths[newPath] !== undefined) {
+      if (result.paths[newPath] !== undefined && duplicatePathHandling === 'error') {
         return {
           type: 'duplicate-paths',
           message: `Input ${inputIndex}: The path '${originalPath}' maps to '${newPath}' and this has already been added by another input file`
         };
+      }
+
+      const isDuplicate = result.paths[newPath] !== undefined;
+
+      if (isDuplicate && duplicatePathHandling === 'skip-later') {
+        // Skipped before `ensureUniqueOperationIds`, deliberately: a path that
+        // is not going into the output must not consume operationIds, or it
+        // would push an unrelated later operation onto a numeric suffix for a
+        // collision with something that was discarded.
+        continue;
+      }
+
+      if (isDuplicate) {
+        // 'prefer-later' by elimination: 'error' returned and 'skip-later'
+        // continued above.
+        releaseOperationIds(result.paths[newPath], seenOperationIds);
       }
 
       const copyPathItem = getPaths(oas)[originalPath];
@@ -295,11 +329,19 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
     for (let webhookIndex = 0; webhookIndex < webhookNames.length; webhookIndex++) {
       const webhookName = webhookNames[webhookIndex];
 
-      if (result.webhooks[webhookName] !== undefined) {
+      if (result.webhooks[webhookName] !== undefined && duplicatePathHandling === 'error') {
         return {
           type: 'duplicate-webhooks',
           message: `Input ${inputIndex}: The webhook '${webhookName}' has already been added by another input file`
         };
+      }
+
+      if (result.webhooks[webhookName] !== undefined && duplicatePathHandling === 'skip-later') {
+        continue;
+      }
+
+      if (result.webhooks[webhookName] !== undefined) {
+        releaseOperationIds(result.webhooks[webhookName], seenOperationIds);
       }
 
       const copyWebhook = getWebhooks(oas)[webhookName];


### PR DESCRIPTION
Closes #71. Unblocks #8 and #109.

A duplicate path was an unconditional hard error, which blocks the API-gateway case this tool targets: two teams legitimately exposing the same route where one should simply win.

Per-input `duplicatePathHandling`:
- `error` (default, unchanged)
- `skip-later` — keep what's already there
- `prefer-later` — replace it

Per input rather than global, because what people want to say is *"this one input wins and the rest are additive"*, which a global setting can't express.

### Two operationId bugs the proposal didn't anticipate

Both produce a valid-*looking* document with wrong names:

- **A skipped path must not consume operationIds.** `skip-later` now returns before `ensureUniqueOperationIds` — otherwise a path that never reaches the output pushes an unrelated later operation onto a numeric suffix.
- **A replaced path must release them.** Under `prefer-later` the earlier definition leaves the output, so its ids must leave `seenOperationIds` too. Without it, two inputs both defining `getThing` on the same path give you an output where the survivor is called `getThing1` and `getThing` exists nowhere.

### Also applies to webhooks

Not in the proposal, but they collide by event name through the same code and had the same unconditional error. It'd be arbitrary for one config to resolve a path collision and hard-fail an event-name one.

### Not implemented: §4.3 per-method granularity

Letting a later input add `POST /x` beside an earlier `GET /x` raises questions the proposal doesn't answer — what becomes of the path item's own `summary`, `parameters` and `$ref` when two inputs disagree? Merging *inside* a path item is a different feature from choosing *between* path items, and #8/#109 need that discussion anyway.

### Verification

- 11 tests in `paths.test.ts`; **7 fail against `origin/main`**. The other four assert the unchanged default, including that duplicate webhooks still error.
- 4 CLI tests for the wiring, including ajv rejecting an unknown policy value
- Gate green: lint, 398 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)