### PR TITLE
feat(merge): accept openapi-types documents as input (#75)

### DIFF
--- a/ai-planning/issues/31-proposal-75-openapi-types-compat.md
+++ b/ai-planning/issues/31-proposal-75-openapi-types-compat.md
@@ -1,0 +1,102 @@
+# Implementation Proposal: Issue #75 — Accept `openapi-types` Documents
+
+**Issue:** [#75 — Typescript `atlassian-openapi` is not compatible with `openapi-types` OpenAPI3 type](https://github.com/robertmassaioli/openapi-merge/issues/75)
+
+**Status:** ✅ Implemented — written alongside the change rather than before it,
+because the design could not be chosen without first measuring how the two type
+systems actually diverge (§3).
+
+**Value:** 3 | **Effort:** 2
+
+---
+
+## 1. Issue summary
+
+A user parses specifications with `@apidevtools/swagger-parser`, which returns
+`OpenAPIV3.Document` from `openapi-types`, then passes the result to `merge()`
+and gets a compile error. They ask two things:
+
+1. How does one solve this?
+2. Why is Atlassian's OpenAPI type used here rather than the common one?
+
+The second question deserves a direct answer: `@atlassian/atlassian-openapi`
+provides `SwaggerLookup`, the `$ref` resolution this merge is built on, not just
+the type declarations. Swapping it out is a much larger change than accepting a
+second document type at the boundary, and the two describe the same JSON.
+
+## 2. Symptom
+
+```
+Type 'Document<{}>' is not assignable to type 'OpenApiDocument'.
+  Types of property 'paths' are incompatible.
+    'string' index signatures are incompatible.
+      Type '... | undefined' is not assignable to type 'PathItem32'.
+```
+
+`openapi-types` declares `PathsObject` values as possibly `undefined`; this
+library's `PathItemMap` does not.
+
+## 3. Why field-by-field widening was rejected
+
+The obvious fix is to loosen `PathItemMap` to allow `undefined`. Measured, that
+only moves the error:
+
+```
+components.responses  -> '{ [k: string]: ReferenceObject | ResponseObject }'
+                         not assignable to '{ [k: string]: Reference | Response }'
+  -> ResponseObject not assignable to Response
+    -> property 'headers' incompatible
+      -> ... and further down
+```
+
+The mismatches cascade. Loosening every one of them would weaken the types the
+merge relies on internally — `getPaths(oas)[path]` would become
+`PathItem32 | undefined` at every call site — to gain nothing, since the values
+are structurally fine at runtime. Both libraries model the same JSON; they
+simply disagree about how strictly to describe it.
+
+## 4. Design: widen the input, narrow once
+
+```ts
+export type MergeInputDocument = OpenApiDocument | OpenAPIV3.Document | OpenAPIV3_1.Document;
+```
+
+`SingleMergeInputBase.oas` takes that union. `merge()` narrows it exactly once:
+
+```ts
+const narrowedInputs = inputs as NarrowedMergeInput;
+```
+
+Everything below the entry point continues to see the single concrete type, so
+no internal code becomes union-aware and no internal type is weakened. One cast,
+in one place, with the reasoning attached — rather than a union that every
+internal function has to re-narrow, or a dozen loosened field types.
+
+`openapi-types` moves from `devDependencies` to `dependencies`. It is a
+types-only package: no runtime code, so it adds nothing to the bundle, but a
+published `.d.ts` that names it must be able to resolve it.
+
+## 5. What this does not do
+
+It does not validate that the document is well formed. The cast asserts that an
+`openapi-types` document is readable by this library, which is true because both
+describe the same JSON — it does not assert the document is *valid*. That was
+already the case for the library's own type and is unchanged.
+
+## 6. Verification
+
+`src/__tests__/openapi-types-compat.test.ts`:
+
+- The exact call from the issue, `merge([{ oas: parsed }])` with
+  `parsed: OpenAPIV3.Document`, plus the 3.1 equivalent.
+- An `openapi-types` document merged together with a plain one.
+- Components carried through from an `openapi-types` document.
+- A pure type assertion that all three document types are assignable.
+
+**The meaningful check is `bun run typecheck`, not `bun test`.** The reported
+symptom is a compile error, and `bun test` transpiles without typechecking — so
+these tests pass even against a broken build. Measured against `origin/main`,
+the file produces **5 typecheck errors**, including the `Document<{}> is not
+assignable` from the issue. That is the regression guard.
+
+Gate green: lint, 389 tests, 48 artifact checks.

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "eslint": "^10.0.0",
         "eslint-formatter-visualstudio": "^9.0.1",
         "globals": "^17.7.0",
+        "openapi-types": "^12.1.3",
         "typescript-eslint": "^8.65.0",
       },
     },
@@ -473,6 +474,8 @@
     "openapi-merge": ["openapi-merge@workspace:packages/openapi-merge"],
 
     "openapi-merge-cli": ["openapi-merge-cli@workspace:packages/openapi-merge-cli"],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 

--- a/packages/openapi-merge/package.json
+++ b/packages/openapi-merge/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@atlassian/atlassian-openapi": "^1.0.6",
     "lodash": "^4.17.15",
+    "openapi-types": "^12.1.3",
     "ts-is-present": "^1.1.1"
   },
   "publishConfig": {

--- a/packages/openapi-merge/src/__tests__/openapi-types-compat.test.ts
+++ b/packages/openapi-merge/src/__tests__/openapi-types-compat.test.ts
@@ -1,0 +1,122 @@
+import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import { merge } from '../index';
+import { MergeInputDocument } from '../oas31';
+import { expectSuccess } from './_helpers/documents';
+
+/**
+ * Issue #75: documents from `openapi-types` are accepted without a cast.
+ *
+ * The reported symptom was a compile error, so most of what matters here is
+ * checked by `bun run typecheck` rather than at runtime -- the assignments
+ * below fail the build if the input type ever narrows again, which is the
+ * regression worth guarding. `bun test` transpiles without typechecking, so
+ * these would pass even while broken; the typecheck step in `bun run lint` is
+ * what actually enforces them.
+ *
+ * The runtime cases exist to prove the accompanying claim: that the two
+ * libraries describe the same JSON, so a document typed by one really can be
+ * merged by the other.
+ */
+describe('openapi-types compatibility (issue #75)', () => {
+  it('accepts an OpenAPIV3.Document without a cast', () => {
+    const parsed: OpenAPIV3.Document = {
+      openapi: '3.0.3',
+      info: { title: 'Parsed by swagger-parser', version: '1.0.0' },
+      paths: {
+        '/thing': {
+          get: { operationId: 'getThing', responses: { '200': { description: 'ok' } } },
+        },
+      },
+    };
+
+    // The exact call from the issue. It did not compile before.
+    const output = expectSuccess(merge([{ oas: parsed }]));
+
+    expect(Object.keys(output.paths ?? {})).toEqual(['/thing']);
+  });
+
+  it('accepts an OpenAPIV3_1.Document without a cast', () => {
+    const parsed: OpenAPIV3_1.Document = {
+      openapi: '3.1.1',
+      info: { title: '3.1 document', version: '1.0.0' },
+      paths: {
+        '/thing': {
+          get: { operationId: 'getThing', responses: { '200': { description: 'ok' } } },
+        },
+      },
+    };
+
+    const output = expectSuccess(merge([{ oas: parsed }]));
+
+    expect(Object.keys(output.paths ?? {})).toEqual(['/thing']);
+  });
+
+  it('merges an openapi-types document together with a plain one', () => {
+    const fromParser: OpenAPIV3.Document = {
+      openapi: '3.0.3',
+      info: { title: 'A', version: '1.0.0' },
+      paths: { '/a': { get: { operationId: 'getA', responses: { '200': { description: 'ok' } } } } },
+    };
+
+    const output = expectSuccess(
+      merge([
+        { oas: fromParser },
+        {
+          oas: {
+            openapi: '3.0.3',
+            info: { title: 'B', version: '1.0.0' },
+            paths: { '/b': { get: { operationId: 'getB', responses: { '200': { description: 'ok' } } } } },
+          },
+        },
+      ]),
+    );
+
+    expect(Object.keys(output.paths ?? {}).sort()).toEqual(['/a', '/b']);
+  });
+
+  it('carries components through from an openapi-types document', () => {
+    const parsed: OpenAPIV3.Document = {
+      openapi: '3.0.3',
+      info: { title: 'With components', version: '1.0.0' },
+      paths: {
+        '/a': {
+          get: {
+            operationId: 'getA',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: { 'application/json': { schema: { $ref: '#/components/schemas/Thing' } } },
+              },
+            },
+          },
+        },
+      },
+      components: { schemas: { Thing: { type: 'object', properties: { id: { type: 'string' } } } } },
+    };
+
+    const output = expectSuccess(merge([{ oas: parsed }]));
+
+    expect(Object.keys(output.components?.schemas ?? {})).toEqual(['Thing']);
+  });
+
+  it('assigns all three document types to MergeInputDocument', () => {
+    // A pure type assertion. Its value is in `bun run typecheck`: if the union
+    // is ever narrowed back, the build fails here with a clear pointer to #75.
+    const v3: MergeInputDocument = {
+      openapi: '3.0.3',
+      info: { title: 'v3', version: '1' },
+      paths: {},
+    } satisfies OpenAPIV3.Document;
+
+    // 3.1 requires at least one of paths / webhooks / components.
+    const v31: MergeInputDocument = {
+      openapi: '3.1.1',
+      info: { title: 'v31', version: '1' },
+      webhooks: {},
+    } satisfies OpenAPIV3_1.Document;
+
+    const own: MergeInputDocument = { openapi: '3.2.0', info: { title: 'own', version: '1' }, paths: {} };
+
+    expect([v3, v31, own].map(d => d.openapi)).toEqual(['3.0.3', '3.1.1', '3.2.0']);
+  });
+});

--- a/packages/openapi-merge/src/__tests__/versions.test.ts
+++ b/packages/openapi-merge/src/__tests__/versions.test.ts
@@ -3,7 +3,7 @@ import { Swagger } from '@atlassian/atlassian-openapi';
 import {
   parseOpenApiVersion, SUPPORTED_MINOR_VERSIONS, toMinorVersion, validateInputVersions,
 } from '../openapi-version';
-import { SingleMergeInput, isErrorResult } from '../data';
+import { NarrowedMergeInput, SingleMergeInput, isErrorResult } from '../data';
 import { doc31, doc32, expectSuccess, expectMergeError, ok, op } from './_helpers/documents';
 
 /**
@@ -27,7 +27,7 @@ function oasAtVersion(version: unknown): Swagger.SwaggerV3 {
   return d as unknown as Swagger.SwaggerV3;
 }
 
-function inputsAt(...versions: unknown[]): SingleMergeInput[] {
+function inputsAt(...versions: unknown[]): NarrowedMergeInput {
   return versions.map(v => ({ oas: oasAtVersion(v) }));
 }
 

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -1,4 +1,4 @@
-import { OpenApiDocument } from './oas31';
+import { MergeInputDocument, OpenApiDocument } from './oas31';
 
 import { ServersStrategy } from './servers';
 
@@ -41,7 +41,15 @@ export interface DisputeSuffix extends DisputeBase {
 export type Dispute = DisputePrefix | DisputeSuffix;
 
 export interface SingleMergeInputBase {
-  oas: OpenApiDocument;
+  /**
+   * The specification to merge.
+   *
+   * Accepts this library's own `OpenApiDocument` as well as
+   * `OpenAPIV3.Document` / `OpenAPIV3_1.Document` from `openapi-types`, so a
+   * document straight out of `@apidevtools/swagger-parser` needs no cast
+   * (issue #75). See {@link MergeInputDocument}.
+   */
+  oas: MergeInputDocument;
 
   pathModification?: PathModification;
 
@@ -121,6 +129,17 @@ export type DescriptionTitle = {
 };
 
 export type MergeInput = Array<SingleMergeInput>;
+
+/**
+ * A `MergeInput` after `merge()` has narrowed each `oas` at the boundary.
+ *
+ * The public input type accepts `openapi-types` documents as well as this
+ * library's own (issue #75). Every function below the entry point wants the
+ * single concrete type, so `merge()` narrows once and passes this onward --
+ * one cast, in one place, with the reasoning attached, instead of a union
+ * every internal function has to re-narrow.
+ */
+export type NarrowedMergeInput = Array<SingleMergeInput & { oas: OpenApiDocument }>;
 
 /**
  * Document-level options for a merge.

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -1,5 +1,5 @@
 import { isPresent } from 'ts-is-present';
-import { MergeInput, MergeResult, isErrorResult, PathModification, OperationSelection, MergeOptions } from './data';
+import { MergeInput, NarrowedMergeInput, MergeResult, isErrorResult, PathModification, OperationSelection, MergeOptions } from './data';
 import { mergeTags } from './tags';
 import { mergePathsAndComponents } from './paths-and-components';
 import { mergeExtensions } from './extensions';
@@ -32,7 +32,7 @@ function getFirstMatching<A, B>(inputs: Array<A>, extract: (input: A) => B | und
  * value can change how relative `$ref`s resolve. It is therefore kept only in
  * the degenerate single-input case, where the output really is that document.
  */
-function mergeSelf(inputs: MergeInput): string | undefined {
+function mergeSelf(inputs: NarrowedMergeInput): string | undefined {
   return inputs.length === 1 ? inputs[0].oas.$self : undefined;
 }
 
@@ -44,15 +44,23 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     return { type: 'no-inputs', message: 'You must provide at least one OAS file as an input.' };
   }
 
+  // The one place the input union is narrowed (issue #75). `openapi-types`
+  // documents describe the same JSON as ours and differ only in how strictly
+  // they model it -- `PathsObject` values are declared possibly-undefined,
+  // several component maps are looser -- so the cast is safe in the direction
+  // that matters: every value present at runtime is one this library can read.
+  // Nothing below this line sees the union.
+  const narrowedInputs = inputs as NarrowedMergeInput;
+
   // Runs before any merging so that a version problem never leaves a partially
   // merged result, and so that the constructs a newer version would introduce
   // are never silently walked past by 3.0-shaped logic.
-  const versionError = validateInputVersions(inputs);
+  const versionError = validateInputVersions(narrowedInputs);
   if (versionError !== undefined) {
     return versionError;
   }
 
-  const pathAndComponentResult = mergePathsAndComponents(inputs);
+  const pathAndComponentResult = mergePathsAndComponents(narrowedInputs);
 
   if (isErrorResult(pathAndComponentResult)) {
     return pathAndComponentResult;
@@ -64,22 +72,22 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
 
   const output: OpenApiDocument = mergeExtensions(
     {
-      // The version the inputs actually declared, rather than a hard-coded
+      // The version the narrowedInputs actually declared, rather than a hard-coded
       // 3.0.3. Well defined because every input shares a major.minor by now.
-      openapi: negotiateOutputVersion(inputs) ?? '3.0.3',
-      info: mergeInfos(inputs),
-      servers: mergeServers(inputs, options?.serversStrategy),
-      externalDocs: getFirstMatching(inputs, input => input.oas.externalDocs),
-      security: getFirstMatching(inputs, input => input.oas.security),
-      tags: mergeTags(inputs),
+      openapi: negotiateOutputVersion(narrowedInputs) ?? '3.0.3',
+      info: mergeInfos(narrowedInputs),
+      servers: mergeServers(narrowedInputs, options?.serversStrategy),
+      externalDocs: getFirstMatching(narrowedInputs, input => input.oas.externalDocs),
+      security: getFirstMatching(narrowedInputs, input => input.oas.security),
+      tags: mergeTags(narrowedInputs),
       paths,
       // Omitted entirely for 3.0 documents, which cannot declare webhooks.
       webhooks: Object.keys(webhooks).length === 0 ? undefined : webhooks,
-      jsonSchemaDialect: getFirstMatching(inputs, input => input.oas.jsonSchemaDialect),
-      $self: mergeSelf(inputs),
+      jsonSchemaDialect: getFirstMatching(narrowedInputs, input => input.oas.jsonSchemaDialect),
+      $self: mergeSelf(narrowedInputs),
       components,
     },
-    inputs.map(input => input.oas)
+    narrowedInputs.map(input => input.oas)
   );
 
   return { output };

--- a/packages/openapi-merge/src/info.ts
+++ b/packages/openapi-merge/src/info.ts
@@ -1,5 +1,5 @@
 import { Swagger } from '@atlassian/atlassian-openapi';
-import { MergeInput, SingleMergeInput } from './data';
+import { NarrowedMergeInput, SingleMergeInput } from './data';
 import { isPresent } from 'ts-is-present';
 import _ from 'lodash';
 
@@ -23,7 +23,7 @@ function getInfoDescriptionWithHeading(mergeInput: SingleMergeInput): string | u
   return `${'#'.repeat(headingLevel)} ${title.value}\n\n${trimmedDescription}`;
 }
 
-export function mergeInfos(mergeInput: MergeInput): Swagger.Info {
+export function mergeInfos(mergeInput: NarrowedMergeInput): Swagger.Info {
   const finalInfo = _.cloneDeep(mergeInput[0].oas.info);
 
   const appendedDescriptions = mergeInput

--- a/packages/openapi-merge/src/oas31.ts
+++ b/packages/openapi-merge/src/oas31.ts
@@ -1,4 +1,5 @@
 import { Swagger } from '@atlassian/atlassian-openapi';
+import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 
 /**
  * OpenAPI 3.1 modelled as a delta over the 3.0 types.
@@ -137,3 +138,26 @@ export function getPaths(oas: OpenApiDocument): Swagger.Paths {
 export function getWebhooks(oas: OpenApiDocument): PathItemMap {
   return oas.webhooks ?? {};
 }
+
+/**
+ * A document this library will accept as merge input (issue #75).
+ *
+ * `OpenApiDocument` is how this library models a specification. Consumers
+ * frequently arrive with `OpenAPIV3.Document` or `OpenAPIV3_1.Document`
+ * instead, because that is what `@apidevtools/swagger-parser` and most other
+ * tooling returns. The two describe the *same JSON* -- they differ only in how
+ * strictly each models it. `openapi-types` marks `PathsObject` values as
+ * possibly `undefined` and types several component maps more loosely, so
+ * assignment fails in a dozen nested places even though every value is
+ * structurally fine at runtime.
+ *
+ * Widening each field individually was tried and abandoned: the mismatches
+ * cascade through `paths`, `components.responses`, `headers` and further down,
+ * and loosening all of them would weaken the types this library relies on
+ * internally for no benefit.
+ *
+ * Accepting the union instead keeps full checking inside the library while
+ * letting a caller pass what their parser gave them. `merge()` narrows once, at
+ * the boundary, where the reasoning lives.
+ */
+export type MergeInputDocument = OpenApiDocument | OpenAPIV3.Document | OpenAPIV3_1.Document;

--- a/packages/openapi-merge/src/openapi-version.ts
+++ b/packages/openapi-merge/src/openapi-version.ts
@@ -1,4 +1,4 @@
-import { ErrorMergeResult, MergeInput } from './data';
+import { ErrorMergeResult, NarrowedMergeInput } from './data';
 
 /**
  * All OpenAPI version handling lives here so that widening support is a
@@ -74,7 +74,7 @@ function describeSupported(supported: ReadonlyArray<string>): string {
  * the caller can actually do.
  */
 export function validateInputVersions(
-  inputs: MergeInput,
+  inputs: NarrowedMergeInput,
   /**
    * Which minor versions to accept. Defaults to what this library actually
    * supports; parameterised so the mixed-version rule can be tested
@@ -147,7 +147,7 @@ export function validateInputVersions(
  *
  * Returns undefined only when there are no inputs, which `merge` rejects first.
  */
-export function negotiateOutputVersion(inputs: MergeInput): string | undefined {
+export function negotiateOutputVersion(inputs: NarrowedMergeInput): string | undefined {
   let best: OpenApiVersion | undefined;
 
   for (const input of inputs) {

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -1,4 +1,4 @@
-import { MergeInput, ErrorMergeResult, Dispute } from "./data";
+import { NarrowedMergeInput, ErrorMergeResult, Dispute } from "./data";
 import { Swagger, SwaggerLookup } from "@atlassian/atlassian-openapi";
 import { walkAllReferences } from "./reference-walker";
 import _ from 'lodash';
@@ -175,7 +175,7 @@ function ensureUniqueOperationIds(pathItem: PathItem32, seenOperationIds: Set<st
  *
  * @param inputs
  */
-export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents | ErrorMergeResult {
+export function mergePathsAndComponents(inputs: NarrowedMergeInput): PathAndComponents | ErrorMergeResult {
   const seenOperationIds = new Set<string>();
 
   const result: PathAndComponents = {

--- a/packages/openapi-merge/src/servers.ts
+++ b/packages/openapi-merge/src/servers.ts
@@ -1,4 +1,4 @@
-import { MergeInput } from './data';
+import { NarrowedMergeInput } from './data';
 import { Server32 } from './oas31';
 
 /**
@@ -27,7 +27,7 @@ export const DEFAULT_SERVERS_STRATEGY: ServersStrategy = 'first';
  * first-wins everywhere else, so it does so here too rather than inventing a
  * new error for it.
  */
-export function mergeServers(inputs: MergeInput, strategy: ServersStrategy = DEFAULT_SERVERS_STRATEGY): Server32[] | undefined {
+export function mergeServers(inputs: NarrowedMergeInput, strategy: ServersStrategy = DEFAULT_SERVERS_STRATEGY): Server32[] | undefined {
   if (strategy === 'first') {
     const firstWithServers = inputs.find(input => input.oas.servers !== undefined);
     return firstWithServers?.oas.servers;

--- a/packages/openapi-merge/src/tags.ts
+++ b/packages/openapi-merge/src/tags.ts
@@ -1,4 +1,4 @@
-import { MergeInput } from './data';
+import { NarrowedMergeInput } from './data';
 import { Tag32 } from './oas31';
 
 function getNonExcludedTags(originalTags: Tag32[], excludedTagNames: string[]): Tag32[] {
@@ -9,7 +9,7 @@ function getNonExcludedTags(originalTags: Tag32[], excludedTagNames: string[]): 
   return originalTags.filter(tag => !excludedTagNames.includes(tag.name));
 }
 
-export function mergeTags(inputs: MergeInput): Tag32[] | undefined {
+export function mergeTags(inputs: NarrowedMergeInput): Tag32[] | undefined {
   const result = new Array<Tag32>();
 
   const seenTags = new Set<string>();


### PR DESCRIPTION
Closes #75.

A document from `@apidevtools/swagger-parser` is typed `OpenAPIV3.Document`, and passing it to `merge()` didn't compile: `openapi-types` declares `PathsObject` values as possibly `undefined` and our `PathItemMap` doesn't.

### Why not just widen the field

Tried it. The mismatch cascades:

```
paths -> components.responses -> ResponseObject vs Response -> headers -> ...
```

Loosening all of them would weaken the types the merge relies on internally — `getPaths(oas)[path]` becomes possibly-undefined at every call site — to gain nothing, since the values are structurally fine at runtime. Both libraries describe the same JSON and disagree only about how strictly.

### What it does instead

`SingleMergeInputBase.oas` accepts `OpenApiDocument | OpenAPIV3.Document | OpenAPIV3_1.Document`, and `merge()` narrows **once** at the boundary. Nothing below the entry point sees the union; no internal type is weakened.

`openapi-types` moves to `dependencies` — types-only, so no runtime code and nothing added to the bundle, but a published `.d.ts` naming it must be able to resolve it.

### The issue's second question

*"Why is Atlassian's OpenAPI used and not the official one?"* — because `@atlassian/atlassian-openapi` provides `SwaggerLookup`, the `$ref` resolution this merge is built on, not just type declarations. Swapping it out is far larger than accepting a second document type at the boundary. Answered in the new proposal.

### Verification

⚠️ **The regression guard here is `bun run typecheck`, not `bun test`.** The symptom is a compile error, and `bun test` transpiles without typechecking — these tests pass even against a broken build.

Measured against `origin/main`, the new test file produces **5 typecheck errors**, including the exact `Document<{}> is not assignable` from the issue.

Gate green: lint, 389 tests, 48 artifact checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)