### PR TITLE
feat(merge): allow the emitted OpenAPI version to be pinned (#76)

### DIFF
--- a/ai-planning/issues/04-proposal-76-openapi-version.md
+++ b/ai-planning/issues/04-proposal-76-openapi-version.md
@@ -544,3 +544,65 @@ matches the discriminated-union approach used in #114.
 - [ ] At no point does the tool re-label a document across `major.minor`
       lines automatically (§1 rule 2). Test cases above prove this for
       `highest-input`; `fixed` is explicit so the user owns the choice.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/76-openapi-version`. This proposal predates the phased 3.1/3.2
+work, and half of it has already shipped: phase 1 replaced the hardcoded
+`'3.0.3'` with `negotiateOutputVersion`, which is §3's `'highest-input'`
+strategy. What remained was the ability to *choose*.
+
+### 10.1 A version string, not a three-way strategy union
+
+§3 proposes `{ strategy: 'fixed' | 'first-input' | 'highest-input' }`. Shipped
+as a plain `openapiVersion?: string` instead.
+
+Phase 1 changed what those strategies mean. Every input must now share a
+major.minor before merging begins, so `'first-input'` and `'highest-input'` can
+differ only in the patch digit — a distinction with no feature content and no
+plausible reason to configure. That leaves one real choice, "use the negotiated
+version or this exact one", which a string expresses without asking the caller
+to learn a tagged union.
+
+### 10.2 The minor is validated, not just the format
+
+§4 proposes a `^3\.0\.[0-9]+$` pattern check. That is now too narrow — 3.1 and
+3.2 are supported — and it misses the more important rule.
+
+`resolveOutputVersion` rejects a pin whose **minor** differs from the inputs',
+with `mixed-openapi-versions`. 3.1 is not a compatible superset of 3.0:
+`nullable` became a type union, `exclusiveMinimum` changed from boolean to
+numeric. Relabelling a 3.0 merge as 3.1 produces a document declaring
+conformance to rules its own contents break — silently, and only detected much
+later by someone else's validator. Differing *patch* is allowed, which is
+exactly the latitude someone pinning `3.0.3` for a downstream generator needs.
+
+An unsupported or unparseable value gets `unsupported-openapi-version`, reusing
+the existing error type rather than adding one for a case with the same remedy.
+
+### 10.3 Three silent no-op edits, caught by tests
+
+Worth recording as a process note. Three separate patches to the CLI applied
+cleanly against text that no longer existed on this branch, because `main` had
+moved on:
+
+- the `Configuration` type now ends with `serversStrategy` (#4), not `formatting`;
+- the merge call is `merge(inputs, { serversStrategy })`, not `merge(inputs)`;
+- and the `@pattern` JSDoc got double-escaped, producing `^3\\.` in the
+  generated schema — a regex matching a literal backslash.
+
+Each one failed silently: the file was written, nothing errored, and the
+feature simply did not work. All three were found by the CLI tests, not by
+reading the diff. The lesson for the rest of the sweep is to assert the anchor
+exists before replacing it, which the last of these patches does.
+
+### 10.4 Verification
+
+- 7 tests in `versions.test.ts`. **5 fail against `origin/main`**, confirmed in
+  a detached worktree.
+- 4 CLI tests in `cli-merging.test.ts`, including exit 9 for a mismatched minor
+  and ajv rejecting a malformed version against the generated pattern.
+- Gate green: lint, 395 tests, 48 artifact checks.

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -130,3 +130,53 @@ describe('main - serversStrategy (issue #4)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #76: pinning the emitted OpenAPI version from a config file.
+ */
+describe('main - openapiVersion (issue #76)', () => {
+  it('negotiates from the inputs when unset', async () => {
+    cli.writeJson('a.json', { openapi: '3.0.1', info: { title: 'A', version: '1' }, paths: { '/a': getPath('getA') } });
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(JSON.parse(cli.read()).openapi).toBe('3.0.1');
+  });
+
+  it('emits the pinned version', async () => {
+    cli.writeJson('a.json', { openapi: '3.0.1', info: { title: 'A', version: '1' }, paths: { '/a': getPath('getA') } });
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+      openapiVersion: '3.0.3',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(JSON.parse(cli.read()).openapi).toBe('3.0.3');
+  });
+
+  it('exits 9 when the pinned minor does not match the inputs', async () => {
+    cli.writeJson('a.json', { openapi: '3.0.1', info: { title: 'A', version: '1' }, paths: { '/a': getPath('getA') } });
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+      openapiVersion: '3.1.0',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorOpenApiVersion);
+  });
+
+  it('rejects a malformed version against the generated schema', async () => {
+    cli.writeJson('a.json', { openapi: '3.0.1', info: { title: 'A', version: '1' }, paths: { '/a': getPath('getA') } });
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+      openapiVersion: 'latest',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -245,6 +245,21 @@ export type Configuration = {
    *   URL. For documenting several microservices in one file.
    */
   serversStrategy?: 'first' | 'concat';
+
+  /**
+   * The `openapi` version string to write into the merged output (issue #76).
+   *
+   * By default the output declares the highest version the inputs declared.
+   * Set this to pin an exact value, typically a patch level a downstream
+   * generator insists on.
+   *
+   * The minor must match the inputs'. Emitting a different minor is refused
+   * rather than obeyed: it would declare conformance to a specification the
+   * merged document does not follow.
+   *
+   * @pattern ^3\.[0-9]+\.[0-9]+$
+   */
+  openapiVersion?: string;
 };
 
 /**

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -249,7 +249,10 @@ export async function main(): Promise<void> {
 
   logger.log(`## Loaded the inputs into memory, merging the results.`);
 
-  const mergeResult = merge(inputs, { serversStrategy: config.serversStrategy });
+  const mergeResult = merge(inputs, {
+    serversStrategy: config.serversStrategy,
+    openapiVersion: config.openapiVersion,
+  });
 
   if (isErrorResult(mergeResult)) {
     console.error(`Error merging files: ${mergeResult.message} (${mergeResult.type})`);

--- a/packages/openapi-merge/src/__tests__/versions.test.ts
+++ b/packages/openapi-merge/src/__tests__/versions.test.ts
@@ -4,6 +4,7 @@ import {
   parseOpenApiVersion, SUPPORTED_MINOR_VERSIONS, toMinorVersion, validateInputVersions,
 } from '../openapi-version';
 import { SingleMergeInput, isErrorResult } from '../data';
+import { OpenApiDocument } from '../oas31';
 import { doc31, doc32, expectSuccess, expectMergeError, ok, op } from './_helpers/documents';
 
 /**
@@ -277,5 +278,75 @@ describe('3.2 - version rules', () => {
     const output = expectSuccess(merge([{ oas: doc32({ paths: { '/a': { get: op('getA') } } }) }]));
 
     expect(output.openapi).toBe('3.2.0');
+  });
+});
+
+/**
+ * Issue #76: pinning the emitted `openapi` version.
+ *
+ * Phase 1 made the output version negotiated from the inputs rather than
+ * hardcoded, which is the right default. What was still missing is the ability
+ * to *choose* it -- typically to pin an exact patch level a downstream
+ * generator insists on.
+ *
+ * The minor is not negotiable. 3.1 is not a compatible superset of 3.0
+ * (`nullable` became a type union, `exclusiveMinimum` changed from boolean to
+ * numeric), so relabelling would declare conformance to rules the document's
+ * own contents break.
+ */
+describe('openapiVersion override (issue #76)', () => {
+  const at = (version: string) => ({
+    oas: { openapi: version, info: { title: 'T', version: '1' }, paths: {} } as OpenApiDocument,
+  });
+
+  it('negotiates from the inputs when no override is given', () => {
+    const output = expectSuccess(merge([at('3.0.1'), at('3.0.3')]));
+
+    expect(output.openapi).toBe('3.0.3');
+  });
+
+  it('emits an explicit patch version when pinned', () => {
+    const output = expectSuccess(merge([at('3.0.3')], { openapiVersion: '3.0.0' }));
+
+    // Deliberately lower than the input: pinning is for satisfying a
+    // downstream tool, and within a minor the patch carries no features.
+    expect(output.openapi).toBe('3.0.0');
+  });
+
+  it('accepts a pin equal to the negotiated version', () => {
+    const output = expectSuccess(merge([at('3.1.1')], { openapiVersion: '3.1.1' }));
+
+    expect(output.openapi).toBe('3.1.1');
+  });
+
+  it('refuses a pin whose minor differs from the inputs', () => {
+    const message = expectMergeError(merge([at('3.0.3')], { openapiVersion: '3.1.0' }), 'mixed-openapi-versions');
+
+    expect(message).toContain('3.1.0');
+    expect(message).toContain('3.0');
+  });
+
+  it('refuses a pin this library cannot emit at all', () => {
+    const message = expectMergeError(merge([at('3.0.3')], { openapiVersion: '4.0.0' }), 'unsupported-openapi-version');
+
+    expect(message).toContain('4.0.0');
+  });
+
+  it('refuses a pin that is not a version string', () => {
+    expectMergeError(merge([at('3.0.3')], { openapiVersion: 'latest' }), 'unsupported-openapi-version');
+  });
+
+  it('leaves the merged content untouched when pinning', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          { oas: { openapi: '3.0.3', info: { title: 'A', version: '1' }, paths: { '/a': { get: { responses: { '200': { description: 'ok' } } } } } } as OpenApiDocument },
+        ],
+        { openapiVersion: '3.0.1' },
+      ),
+    );
+
+    expect(output.openapi).toBe('3.0.1');
+    expect(Object.keys(output.paths ?? {})).toEqual(['/a']);
   });
 });

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -135,6 +135,20 @@ export type MergeInput = Array<SingleMergeInput>;
  */
 export interface MergeOptions {
   /**
+   * The `openapi` version string to emit (issue #76).
+   *
+   * By default the output declares the highest version the inputs declared,
+   * which is already well defined because every input must share a
+   * major.minor. Set this to pin an exact value -- typically a specific patch
+   * level a downstream tool insists on.
+   *
+   * Must be a supported version whose minor matches the inputs'. Emitting a
+   * different minor is refused rather than obeyed: it would declare
+   * conformance to a specification the merged document does not follow.
+   */
+  openapiVersion?: string;
+
+  /**
    * How to combine the top-level `servers` array. Defaults to `'first'`.
    * See {@link ServersStrategy} for why that is the default (issue #4).
    */

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -4,7 +4,7 @@ import { mergeTags } from './tags';
 import { mergePathsAndComponents } from './paths-and-components';
 import { mergeExtensions } from './extensions';
 import { mergeInfos } from './info';
-import { negotiateOutputVersion, validateInputVersions } from './openapi-version';
+import { resolveOutputVersion, validateInputVersions } from './openapi-version';
 import { OpenApiDocument } from './oas31';
 import { mergeServers, ServersStrategy } from './servers';
 
@@ -52,6 +52,11 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     return versionError;
   }
 
+  const outputVersion = resolveOutputVersion(inputs, options?.openapiVersion);
+  if (outputVersion !== undefined && typeof outputVersion !== 'string') {
+    return outputVersion;
+  }
+
   const pathAndComponentResult = mergePathsAndComponents(inputs);
 
   if (isErrorResult(pathAndComponentResult)) {
@@ -66,7 +71,7 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     {
       // The version the inputs actually declared, rather than a hard-coded
       // 3.0.3. Well defined because every input shares a major.minor by now.
-      openapi: negotiateOutputVersion(inputs) ?? '3.0.3',
+      openapi: outputVersion ?? '3.0.3',
       info: mergeInfos(inputs),
       servers: mergeServers(inputs, options?.serversStrategy),
       externalDocs: getFirstMatching(inputs, input => input.oas.externalDocs),

--- a/packages/openapi-merge/src/openapi-version.ts
+++ b/packages/openapi-merge/src/openapi-version.ts
@@ -147,6 +147,52 @@ export function validateInputVersions(
  *
  * Returns undefined only when there are no inputs, which `merge` rejects first.
  */
+/**
+ * Resolves an explicit output-version override against the inputs (issue #76).
+ *
+ * Returns the version to emit, or an error if the override cannot honestly be
+ * emitted for these inputs.
+ *
+ * The minor must match. 3.1 is not a compatible superset of 3.0 -- `nullable`
+ * became a type union, `exclusiveMinimum` changed from boolean to numeric --
+ * so relabelling 3.0 documents as 3.1 produces a document that declares
+ * conformance to rules its own contents break. Patch is free to differ, because
+ * within a minor the patch level carries no feature difference; that is exactly
+ * the latitude someone pinning "3.0.3" for a downstream tool needs.
+ */
+export function resolveOutputVersion(inputs: MergeInput, override: string | undefined): string | undefined | ErrorMergeResult {
+  const negotiated = negotiateOutputVersion(inputs);
+
+  if (override === undefined) {
+    return negotiated;
+  }
+
+  const parsed = parseOpenApiVersion(override);
+  if (parsed === undefined || !SUPPORTED_MINOR_VERSIONS.includes(toMinorVersion(parsed))) {
+    return {
+      type: 'unsupported-openapi-version',
+      message:
+        `The requested output version '${String(override)}' is not one this library can emit. ` +
+        `Supported minor versions: ${SUPPORTED_MINOR_VERSIONS.join(', ')}.`,
+    };
+  }
+
+  // `negotiated` is undefined only when no input declared a parseable version,
+  // and validateInputVersions has already rejected that before we get here.
+  const inputsMinor = negotiated === undefined ? undefined : toMinorVersion(parseOpenApiVersion(negotiated) as OpenApiVersion);
+
+  if (inputsMinor !== undefined && toMinorVersion(parsed) !== inputsMinor) {
+    return {
+      type: 'mixed-openapi-versions',
+      message:
+        `The requested output version '${override}' does not match the inputs, which are ${inputsMinor}. ` +
+        `Emitting a different minor version would declare conformance to a specification the merged document does not follow.`,
+    };
+  }
+
+  return parsed.raw;
+}
+
 export function negotiateOutputVersion(inputs: MergeInput): string | undefined {
   let best: OpenApiVersion | undefined;
 


### PR DESCRIPTION
Closes #76.

Phase 1 already replaced the hardcoded `'3.0.3'` with a version negotiated from the inputs — that's the proposal's `highest-input` strategy, already shipped. What was missing was the ability to **choose**, typically to pin an exact patch level a downstream generator insists on.

### A string, not the proposal's three-way union

Phase 1 changed what those strategies mean. Every input must now share a major.minor before merging starts, so `first-input` and `highest-input` can only differ in the patch digit — no feature content, nothing anyone would configure. One real choice remains, and a string expresses it without a tagged union.

### The validation that matters

A pin whose **minor** differs from the inputs is refused with `mixed-openapi-versions`. 3.1 is not a compatible superset of 3.0 — `nullable` became a type union, `exclusiveMinimum` changed from boolean to numeric. Relabelling a 3.0 merge as 3.1 produces a document declaring conformance to rules its own contents break: silently, to be discovered later by someone else's validator.

Differing **patch** is allowed — that's the latitude the feature exists to provide.

### A process note worth reading

Three separate CLI patches in this change applied cleanly against text that no longer exists on this branch and **silently did nothing**:

- the `Configuration` type now ends with `serversStrategy` (#4), not `formatting`
- the merge call already had a second argument
- an over-escaped `@pattern` produced `^3\\.` in the schema — a regex matching a literal backslash

Each wrote the file, errored nothing, and left the feature inert. All three were caught by tests, not by reading the diff.

### Verification

- 7 tests in `versions.test.ts`; **5 fail against `origin/main`**
- 4 CLI tests including exit 9 for a mismatched minor and ajv rejecting a malformed version
- Gate green: lint, 395 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)