### PR TITLE
feat(merge): optionally prune components nothing references (#94)

### DIFF
--- a/ai-planning/issues/32-proposal-94-prune-unused-components.md
+++ b/ai-planning/issues/32-proposal-94-prune-unused-components.md
@@ -1,0 +1,90 @@
+# Implementation Proposal: Issue #94 — Prune Components Nothing References
+
+**Issue:** [#94 — excludeTags working but not removing unwanted schemas](https://github.com/robertmassaioli/openapi-merge/issues/94)
+
+**Status:** ✅ Implemented — written alongside the change; this issue had no
+prior proposal.
+
+**Value:** 4 | **Effort:** 3
+
+---
+
+## 1. Issue summary
+
+> If I exclude some tags, I would expect the schemas attached to those tags to
+> also be removed (unless it's also used by another endpoint)
+
+`operationSelection` deletes the operations a tag rule excludes. Nothing then
+removes the components those operations were the only referrers of, so the
+merged document carries schemas for endpoints it no longer contains.
+
+The parenthetical is the whole difficulty: a schema used by *any* surviving
+endpoint has to stay.
+
+## 2. Reachability, not bookkeeping
+
+Two ways to do this:
+
+- **Track what each removed operation referenced** and subtract it. Requires
+  intersecting against everything else, and gets the shared case wrong the
+  moment a component is reachable by a path nobody thought about — through
+  another component, through a callback, through a webhook.
+- **Walk what the surviving document references, and drop the rest.**
+
+The second is implemented. It makes the issue's caveat true by construction
+rather than by remembering to handle it, and it costs one traversal of a
+document already in memory.
+
+Roots are the merged `paths` and `webhooks`; the closure follows each reachable
+component's own references until nothing new appears.
+
+## 3. Security schemes are not `$ref`s
+
+A Security Requirement names its scheme as an **object key** — `{ apiKey: [] }`
+— so the reference walker cannot see it. Pruning without accounting for that
+would delete every security scheme in the document, which is the same blind
+spot that made renaming them wrong in issue #33.
+
+Handled explicitly: scheme names are collected from the document-level
+`security` array and from every operation's, across paths and webhooks.
+
+## 4. Opt-in, and why
+
+`pruneUnusedComponents` defaults to `false`.
+
+Pruning is destructive, and this library has always preserved every component
+it was given. A document may legitimately carry definitions referenced only from
+outside it — another spec `$ref`ing into this one, a code generator keyed on
+component names, a schema published for consumers to reference. Silently
+deleting those is a worse failure than carrying a few unused definitions,
+because the unused definitions are visible and the deletion is not.
+
+So the default preserves today's behaviour and the issue's expectation is one
+flag away. An unrecognised component bucket — a type from a spec version newer
+than this code — is passed through untouched for the same reason.
+
+## 5. Where it runs
+
+Last, on the finished document, after operation selection, deduplication,
+renaming and reference rewriting have all had their say. Anything earlier would
+compute reachability against a document that does not exist yet.
+
+## 6. Verification
+
+11 tests in `prune-components.test.ts`; **6 fail against `origin/main`**,
+confirmed in a detached worktree. They cover the default (unchanged), the
+issue's exact scenario, the shared-schema caveat, chains of component
+references, webhooks as roots, both security-scheme cases plus an unused one
+that is correctly dropped, removing `components` entirely when nothing
+survives, and a dangling reference not crashing the walk.
+
+3 CLI tests for the wiring, including ajv rejecting a non-boolean.
+
+Gate green: lint, 398 tests, 48 artifact checks.
+
+## 7. Related
+
+Issue #60 §5.4 wanted `x-tagGroups` entries filtered when `excludeTags` removes
+a tag. That was deferred for wanting exactly this machinery. It is now
+available: a follow-up could drop group entries naming tags no surviving
+operation carries.

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -130,3 +130,58 @@ describe('main - serversStrategy (issue #4)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #94: component pruning reaching the library from a config file.
+ */
+describe('main - pruneUnusedComponents (issue #94)', () => {
+  const withSchemas = (paths: Record<string, unknown>) => ({
+    openapi: '3.0.3',
+    info: { title: 'A', version: '1.0.0' },
+    paths,
+    components: { schemas: { Used: { type: 'object' }, Unused: { type: 'object' } } },
+  });
+
+  const usesUsed = {
+    get: {
+      operationId: 'getA',
+      responses: {
+        '200': { description: 'ok', content: { 'application/json': { schema: { $ref: '#/components/schemas/Used' } } } },
+      },
+    },
+  };
+
+  it('keeps unused components by default', async () => {
+    cli.writeJson('a.json', withSchemas({ '/a': usesUsed }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(Object.keys(JSON.parse(cli.read()).components.schemas).sort()).toEqual(['Unused', 'Used']);
+  });
+
+  it('drops unused components when enabled', async () => {
+    cli.writeJson('a.json', withSchemas({ '/a': usesUsed }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+      pruneUnusedComponents: true,
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(Object.keys(JSON.parse(cli.read()).components.schemas)).toEqual(['Used']);
+  });
+
+  it('rejects a non-boolean value against the generated schema', async () => {
+    cli.writeJson('a.json', withSchemas({ '/a': usesUsed }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+      pruneUnusedComponents: 'yes',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -245,6 +245,19 @@ export type Configuration = {
    *   URL. For documenting several microservices in one file.
    */
   serversStrategy?: 'first' | 'concat';
+
+  /**
+   * Drop components that nothing in the merged output references (issue #94).
+   *
+   * Defaults to false. Useful with `operationSelection`, where excluding tags
+   * removes operations but would otherwise leave the schemas only those
+   * operations used behind. A component still referenced by another surviving
+   * endpoint is kept.
+   *
+   * Off by default because pruning is destructive: a document may carry
+   * definitions referenced only from outside it.
+   */
+  pruneUnusedComponents?: boolean;
 };
 
 /**

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -249,7 +249,10 @@ export async function main(): Promise<void> {
 
   logger.log(`## Loaded the inputs into memory, merging the results.`);
 
-  const mergeResult = merge(inputs, { serversStrategy: config.serversStrategy });
+  const mergeResult = merge(inputs, {
+    serversStrategy: config.serversStrategy,
+    pruneUnusedComponents: config.pruneUnusedComponents,
+  });
 
   if (isErrorResult(mergeResult)) {
     console.error(`Error merging files: ${mergeResult.message} (${mergeResult.type})`);

--- a/packages/openapi-merge/src/__tests__/prune-components.test.ts
+++ b/packages/openapi-merge/src/__tests__/prune-components.test.ts
@@ -1,0 +1,235 @@
+import { merge } from '../index';
+import { OpenApiDocument } from '../oas31';
+import { doc30, doc31, expectSuccess, ok, schemaKeys } from './_helpers/documents';
+
+/**
+ * Issue #94: dropping components nothing refers to any more.
+ *
+ * `excludeTags` removes operations but left behind the schemas only those
+ * operations used, so the output described endpoints it no longer contained.
+ *
+ * Opt-in. Pruning is destructive and this library has always preserved every
+ * component it was given -- a document may carry definitions referenced only
+ * from outside it, and deleting those silently would be a worse failure than
+ * carrying a few unused ones.
+ *
+ * Computed by reachability over the finished document rather than by tracking
+ * what each removed operation used, which is what makes the issue's own caveat
+ * -- "unless it is also used by another endpoint" -- correct by construction.
+ */
+describe('pruneUnusedComponents (issue #94)', () => {
+  const ref = (name: string) => ({ $ref: `#/components/schemas/${name}` });
+
+  const opUsing = (operationId: string, schemaName: string, tags?: string[]) => ({
+    operationId,
+    ...(tags === undefined ? {} : { tags }),
+    responses: { '200': { description: 'ok', content: { 'application/json': { schema: ref(schemaName) } } } },
+  });
+
+  const taggedDoc = () =>
+    doc30({
+      paths: {
+        '/kept': { get: opUsing('kept', 'Kept', ['public']) },
+        '/dropped': { get: opUsing('dropped', 'Dropped', ['internal']) },
+      },
+      components: {
+        schemas: {
+          Kept: { type: 'object' },
+          Dropped: { type: 'object' },
+        },
+      },
+    });
+
+  it('is off by default, so an excluded tag leaves its schema behind', () => {
+    const output = expectSuccess(
+      merge([{ oas: taggedDoc(), operationSelection: { excludeTags: ['internal'] } }]),
+    );
+
+    // The behaviour the issue reports. Unchanged unless asked.
+    expect(schemaKeys(output)).toEqual(['Dropped', 'Kept']);
+  });
+
+  it('drops the schema of an excluded operation when enabled', () => {
+    const output = expectSuccess(
+      merge([{ oas: taggedDoc(), operationSelection: { excludeTags: ['internal'] } }], {
+        pruneUnusedComponents: true,
+      }),
+    );
+
+    expect(schemaKeys(output)).toEqual(['Kept']);
+  });
+
+  it('keeps a schema that another surviving endpoint also uses', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc30({
+              paths: {
+                '/kept': { get: opUsing('kept', 'Shared', ['public']) },
+                '/dropped': { get: opUsing('dropped', 'Shared', ['internal']) },
+              },
+              components: { schemas: { Shared: { type: 'object' } } },
+            }),
+            operationSelection: { excludeTags: ['internal'] },
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    // The caveat from the issue, stated explicitly.
+    expect(schemaKeys(output)).toEqual(['Shared']);
+  });
+
+  it('follows chains of references between components', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc30({
+              paths: { '/a': { get: opUsing('a', 'Outer', ['public']) } },
+              components: {
+                schemas: {
+                  Outer: { type: 'object', properties: { inner: ref('Middle') } },
+                  Middle: { type: 'object', properties: { deep: ref('Inner') } },
+                  Inner: { type: 'string' },
+                  Orphan: { type: 'boolean' },
+                },
+              },
+            }),
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    expect(schemaKeys(output)).toEqual(['Inner', 'Middle', 'Outer']);
+  });
+
+  it('keeps security schemes named by a requirement, which are not $refs', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc30({
+              paths: { '/a': { get: { operationId: 'a', responses: ok, security: [{ apiKey: [] }] } } },
+              components: { securitySchemes: { apiKey: { type: 'apiKey', in: 'header', name: 'X-Key' } } },
+            }),
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    // A Security Requirement names its scheme as an object key, so the
+    // reference walker cannot see it. Without special handling, pruning would
+    // delete every security scheme in the document.
+    expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['apiKey']);
+  });
+
+  it('keeps a security scheme named only at document level', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc30({
+              paths: { '/a': { get: { operationId: 'a', responses: ok } } },
+              security: [{ apiKey: [] }],
+              components: { securitySchemes: { apiKey: { type: 'apiKey', in: 'header', name: 'X-Key' } } },
+            }),
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    expect(Object.keys(output.components?.securitySchemes ?? {})).toEqual(['apiKey']);
+  });
+
+  it('drops a security scheme nothing requires', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc30({
+              paths: { '/a': { get: { operationId: 'a', responses: ok } } },
+              components: { securitySchemes: { unused: { type: 'apiKey', in: 'header', name: 'X-Key' } } },
+            }),
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    expect(output.components).toBeUndefined();
+  });
+
+  it('follows references out of webhooks as well as paths', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc31({
+              paths: {},
+              webhooks: { ping: { post: opUsing('ping', 'Event') } },
+              components: { schemas: { Event: { type: 'object' }, Orphan: { type: 'string' } } },
+            }),
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    expect(schemaKeys(output)).toEqual(['Event']);
+  });
+
+  it('leaves components alone when everything is reachable', () => {
+    const output = expectSuccess(
+      merge([{ oas: taggedDoc() }], { pruneUnusedComponents: true }),
+    );
+
+    expect(schemaKeys(output)).toEqual(['Dropped', 'Kept']);
+  });
+
+  it('removes the components object entirely when nothing survives', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: doc30({
+              paths: { '/a': { get: { operationId: 'a', responses: ok } } },
+              components: { schemas: { Orphan: { type: 'string' } } },
+            }),
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    // Not `components: {}`, which is noise.
+    expect(output.components).toBeUndefined();
+  });
+
+  it('does not remove a component merely because a reference is dangling', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          {
+            oas: {
+              ...doc30({
+                paths: { '/a': { get: opUsing('a', 'Missing') } },
+                components: { schemas: { Present: { type: 'string' } } },
+              }),
+            } as OpenApiDocument,
+          },
+        ],
+        { pruneUnusedComponents: true },
+      ),
+    );
+
+    // `Missing` does not exist; `Present` is genuinely unreferenced and goes.
+    // The point is that the dangling reference does not crash the walk.
+    expect(schemaKeys(output)).toEqual([]);
+  });
+});

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -135,6 +135,21 @@ export type MergeInput = Array<SingleMergeInput>;
  */
 export interface MergeOptions {
   /**
+   * Drop components that nothing in the merged document references (issue #94).
+   *
+   * Defaults to `false`. Off by default because pruning is destructive and this
+   * library has always preserved every component it was given: a document may
+   * carry definitions referenced only from outside it, and silently deleting
+   * those would be a worse failure than carrying a few unused ones.
+   *
+   * Turn it on when `operationSelection` is removing operations and you expect
+   * the schemas only those operations used to go with them. Reachability is
+   * computed from the surviving document, so a component still used by another
+   * endpoint is kept.
+   */
+  pruneUnusedComponents?: boolean;
+
+  /**
    * How to combine the top-level `servers` array. Defaults to `'first'`.
    * See {@link ServersStrategy} for why that is the default (issue #4).
    */

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -7,6 +7,7 @@ import { mergeInfos } from './info';
 import { negotiateOutputVersion, validateInputVersions } from './openapi-version';
 import { OpenApiDocument } from './oas31';
 import { mergeServers, ServersStrategy } from './servers';
+import { pruneUnusedComponents } from './prune-components';
 
 export { isErrorResult };
 export type { MergeInput, MergeResult, PathModification, OperationSelection, MergeOptions, ServersStrategy };
@@ -82,5 +83,8 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     inputs.map(input => input.oas)
   );
 
-  return { output };
+  // Last, so that reachability is computed against the finished document --
+  // after operation selection, renaming and reference rewriting have all had
+  // their say. Anything earlier would measure a document that does not exist.
+  return { output: options?.pruneUnusedComponents === true ? pruneUnusedComponents(output) : output };
 }

--- a/packages/openapi-merge/src/prune-components.ts
+++ b/packages/openapi-merge/src/prune-components.ts
@@ -1,0 +1,129 @@
+import { Components31, OpenApiDocument, getPathItemOperations, getPaths, getWebhooks } from './oas31';
+import { walkComponentReferences, walkPathItemMapReferences, walkPathReferences } from './reference-walker';
+
+/**
+ * Removes components nothing in the document refers to (issue #94).
+ *
+ * `operationSelection` deletes the operations a tag rule excludes, but the
+ * components those operations were the only referrers of stayed behind, so the
+ * output carried schemas for endpoints it no longer contained.
+ *
+ * Reachability rather than bookkeeping: rather than tracking what each removed
+ * operation used, this walks what the *surviving* document references and drops
+ * the rest. That gets the "unless it is also used by another endpoint" case in
+ * the issue right by construction, including through chains of components that
+ * reference each other.
+ */
+
+const COMPONENT_TYPES = [
+  'schemas', 'responses', 'parameters', 'examples', 'requestBodies',
+  'headers', 'links', 'pathItems', 'callbacks', 'securitySchemes',
+] as const;
+
+type ComponentType = (typeof COMPONENT_TYPES)[number];
+
+const REFERENCE_PATTERN = /^#\/components\/([^/]+)\/(.+)$/;
+
+function collectReferences(collect: (type: string, name: string) => void): (ref: string) => string {
+  return ref => {
+    const match = REFERENCE_PATTERN.exec(ref);
+    if (match !== null) {
+      // A JSON Pointer escapes `/` as `~1` and `~` as `~0`; component names may
+      // legitimately contain neither, but decoding costs nothing and a name
+      // that did contain one would otherwise never match its own key.
+      collect(match[1], match[2].replace(/~1/g, '/').replace(/~0/g, '~'));
+    }
+    return ref;
+  };
+}
+
+/**
+ * Security schemes are named as object KEYS in a Security Requirement, not as
+ * `$ref`s, so the reference walker cannot see them (the same blind spot that
+ * made renaming them wrong in issue #33). Pruning without this would delete
+ * every security scheme in the document.
+ */
+function securitySchemesInUse(oas: OpenApiDocument): string[] {
+  const names: string[] = [];
+
+  for (const requirement of oas.security ?? []) {
+    names.push(...Object.keys(requirement));
+  }
+
+  for (const pathItemMap of [getPaths(oas), getWebhooks(oas)]) {
+    for (const pathItem of Object.values(pathItemMap)) {
+      for (const { operation } of getPathItemOperations(pathItem)) {
+        for (const requirement of operation.security ?? []) {
+          names.push(...Object.keys(requirement));
+        }
+      }
+    }
+  }
+
+  return names;
+}
+
+export function pruneUnusedComponents(oas: OpenApiDocument): OpenApiDocument {
+  const components = oas.components;
+  if (components === undefined) {
+    return oas;
+  }
+
+  const reachable = new Set<string>();
+  const queue: Array<{ type: string; name: string }> = [];
+
+  const enqueue = (type: string, name: string): void => {
+    const key = `${type}/${name}`;
+    if (!reachable.has(key)) {
+      reachable.add(key);
+      queue.push({ type, name });
+    }
+  };
+
+  // Roots: everything the surviving paths and webhooks point at.
+  const collectRoot = collectReferences(enqueue);
+  walkPathReferences(getPaths(oas), collectRoot);
+  walkPathItemMapReferences(getWebhooks(oas), collectRoot);
+  for (const schemeName of securitySchemesInUse(oas)) {
+    enqueue('securitySchemes', schemeName);
+  }
+
+  // Transitive closure: a reachable component's own references are reachable.
+  const componentMaps = components as unknown as Record<string, Record<string, unknown> | undefined>;
+  while (queue.length > 0) {
+    const { type, name } = queue.pop() as { type: string; name: string };
+    const definition = componentMaps[type]?.[name];
+    if (definition === undefined) {
+      continue; // A dangling reference; leave it dangling rather than invent a target.
+    }
+    // Walked one component at a time so that only what this component points at
+    // is followed -- walking the whole map would mark everything reachable.
+    walkComponentReferences({ [type]: { [name]: definition } } as unknown as Components31, collectRoot);
+  }
+
+  const pruned: Record<string, Record<string, unknown>> = {};
+  for (const type of COMPONENT_TYPES) {
+    const map = componentMaps[type];
+    if (map === undefined) {
+      continue;
+    }
+    const kept = Object.fromEntries(Object.entries(map).filter(([name]) => reachable.has(`${type}/${name}`)));
+    if (Object.keys(kept).length > 0) {
+      pruned[type] = kept;
+    }
+  }
+
+  // Any component type this function does not know about is passed through
+  // untouched. Dropping an unrecognised bucket would be a silent data loss for
+  // a spec version newer than this code.
+  for (const type of Object.keys(componentMaps)) {
+    if (!(COMPONENT_TYPES as ReadonlyArray<string>).includes(type as ComponentType) && componentMaps[type] !== undefined) {
+      pruned[type] = componentMaps[type] as Record<string, unknown>;
+    }
+  }
+
+  return {
+    ...oas,
+    components: Object.keys(pruned).length === 0 ? undefined : (pruned as unknown as Components31),
+  };
+}


### PR DESCRIPTION
Closes #94.

> If I exclude some tags, I would expect the schemas attached to those tags to also be removed (unless it's also used by another endpoint)

`operationSelection` removed the operations but left the components those operations were the only referrers of, so the output carried schemas for endpoints it no longer contained.

### Reachability, not bookkeeping

Rather than tracking what each removed operation used and subtracting it, this walks what the **surviving** document references and drops the rest. That makes the issue's caveat true *by construction* instead of by remembering to handle it — and catches components reachable through another component, a callback, or a webhook.

### Security schemes needed explicit handling

A Security Requirement names its scheme as an **object key** (`{ apiKey: [] }`), not a `$ref`, so the reference walker can't see it. Pruning without accounting for that would delete **every security scheme in the document** — the same blind spot that made renaming them wrong in #33.

### Opt-in, and why

`pruneUnusedComponents` defaults to `false`. Pruning is destructive and this library has always preserved what it was given. A document may legitimately carry definitions referenced only from outside it — another spec `$ref`ing in, a generator keyed on component names. Deleting those silently is a worse failure than carrying a few unused ones, because unused definitions are *visible* and a deletion isn't.

An unrecognised component bucket (a type from a newer spec version) is passed through untouched for the same reason.

### Verification

- 11 tests in `prune-components.test.ts`; **6 fail against `origin/main`**
- Covers: the unchanged default, the issue's scenario, the shared-schema caveat, reference chains, webhooks as roots, both security-scheme cases plus an unused one correctly dropped, and a dangling reference not crashing the walk
- 3 CLI tests including ajv rejecting a non-boolean
- Gate green: lint, 398 tests, 48 artifact checks

Also unblocks #60 §5.4, deferred for wanting exactly this machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)