### PR TITLE
fix(merge): rewrite discriminator mappings on rename (#99)

### DIFF
--- a/ai-planning/issues/10-proposal-99-discriminator-mapping-prefix.md
+++ b/ai-planning/issues/10-proposal-99-discriminator-mapping-prefix.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#99 — Issue on discriminator mapping](https://github.com/robertmassaioli/openapi-merge/issues/99)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 / **Effort:** 2 / **Incremental Effort (bundled with #106):** 0
 
@@ -387,3 +387,54 @@ This issue is part of the **dispute completeness** cluster alongside:
 2. **Compatibility with OpenAPI tools:** Some third-party tools may not handle bare names in discriminator mappings correctly. By preserving the original form (bare vs. full ref), we avoid introducing regressions.
 3. **Future work:** After #106 and #99 are merged, consider extending discriminator handling to callback discriminators (if those exist in the spec) as a follow-up.
 
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/99-discriminator-mapping`. One new function in
+`reference-walker.ts`, called from `walkSchemaReferences`, so every place a
+schema is already walked now also rewrites its discriminator mapping — paths,
+webhooks, components, callbacks, all of it, without a second traversal.
+
+### 10.1 Both spellings, and the author's is preserved
+
+The specification allows a mapping value to be a full reference
+(`#/components/schemas/Dog`) or a bare schema name (`Dog`), defined as shorthand
+for the same thing. Both occur.
+
+A bare name is rewritten by asking `modify` about the reference it abbreviates,
+then writing back the abbreviated form of the answer — so `Dog` becomes `Dog1`,
+not `#/components/schemas/Dog1`. Expanding shorthand would be a correct document
+and a bad diff: this tool passes most content through untouched, and turning
+every mapping into a full reference would bury the real changes.
+
+### 10.2 What is deliberately not rewritten
+
+A value containing `/` or `#` that is not an internal pointer — a URL, a
+relative file path — is left exactly as found, because it does not point into
+this document's components. Same reasoning as external `$ref` preservation.
+
+### 10.3 The pinned test flipped
+
+`spec-edge-case-findings.md` §2.4 pinned this as a `KNOWN GAP` with a test
+asserting the *broken* behaviour. That test failed the moment the fix landed,
+which is precisely what it was for, and now asserts the correct behaviour. The
+findings document is updated.
+
+### 10.4 Verification
+
+- 6 new tests plus the flipped pinned one. **5 fail against `origin/main`**,
+  confirmed in a detached worktree.
+- Cover: full reference, bare name, a target that was not renamed, an external
+  URL, a relative file path, several entries in one discriminator, and a
+  dispute prefix.
+- Gate green: lint, 391 tests, 48 artifact checks.
+
+### 10.5 What #106 still owes
+
+3.2's `defaultMapping` and the Link `operationRef` gap in
+`spec-edge-case-findings.md` §2.5. Both are the same shape as this — a pointer
+that is not spelled `$ref` — and now have a place to live: the function this
+change adds.

--- a/ai-planning/spec-edge-case-findings.md
+++ b/ai-planning/spec-edge-case-findings.md
@@ -108,17 +108,24 @@ for.
 
 ### 2.4 Discriminator pointers are not rewritten on rename
 
-Already tracked as **issues #99 and #106**, with proposals in
-`issues/10-proposal-99-discriminator-mapping-prefix.md` and
-`issues/09-proposal-106-discriminator-mappings.md`. Confirmed still present for
-both `mapping` (3.0) and the new 3.2 `defaultMapping`:
+**`mapping` fixed** (issue #99). `defaultMapping` (3.2) and Link `operationRef`
+(§2.5) remain, tracked as issue #106.
+
+The reference walker now treats a Discriminator Object's `mapping` values as
+pointers. They are plain strings in a plain object rather than `$ref` members,
+which is why nothing saw them:
 
 ```
-oneOf $ref            -> #/components/schemas/Dog1   (correctly rewritten)
-discriminator.mapping -> #/components/schemas/Dog    (stale)
+oneOf $ref            -> #/components/schemas/Dog1   (was always correct)
+discriminator.mapping -> #/components/schemas/Dog1   (now follows the rename)
 ```
 
-The new tests add `defaultMapping` coverage those proposals predate.
+Both spellings the specification permits are handled — a full reference, and a
+bare schema name, which is shorthand for one. A bare name stays bare after
+rewriting; expanding every shorthand would produce a large, noisy diff in
+documents this tool is only passing through.
+
+The `KNOWN GAP` test that pinned this now asserts the fix instead.
 
 ### 2.5 A Link `operationRef` is not rewritten when its path moves
 

--- a/packages/openapi-merge/src/__tests__/references.test.ts
+++ b/packages/openapi-merge/src/__tests__/references.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../reference-walker';
 import { at, doc30, doc31, doc32, expectSuccess, ok, op, pathKeys, schema, schemaKeys } from './_helpers/documents';
 import { Modify } from '../reference-walker';
+import { OpenApiDocument } from '../oas31';
 
 /**
  * Run a walker and collect every reference it reaches, without changing them.
@@ -435,11 +436,12 @@ describe('3.0 edge: references', () => {
     expect((output.components?.schemas?.Alias as { $ref: string }).$ref).toBe('#/components/schemas/Thing1');
   });
 
-  it('KNOWN GAP (issues #99/#106): a discriminator mapping is not rewritten on rename', () => {
-    // The oneOf $ref follows the rename but the discriminator mapping value,
-    // which points at the same schema, does not. Already tracked by
-    // issues/10-proposal-99-discriminator-mapping-prefix.md and
-    // issues/09-proposal-106-discriminator-mappings.md.
+  it('rewrites a discriminator mapping on rename (issue #99)', () => {
+    // Was pinned here as a KNOWN GAP: the oneOf $ref followed the rename while
+    // the mapping value pointing at the same schema did not, producing a
+    // document that looked valid and resolved to nothing. Fixed by teaching the
+    // reference walker that a Discriminator Object's mapping values are
+    // pointers, even though they are plain strings rather than $ref members.
     const output = expectSuccess(merge([
       { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: { type: 'string' } } } }) },
       { oas: doc30({
@@ -456,8 +458,7 @@ describe('3.0 edge: references', () => {
 
     const pet = output.components?.schemas?.Pet as Record<string, Record<string, unknown>>;
     expect((pet.oneOf as unknown as Array<{ $ref: string }>)[0].$ref).toBe('#/components/schemas/Dog1');
-    // Still pointing at the pre-rename name -- this is the bug.
-    expect((pet.discriminator.mapping as Record<string, string>).dog).toBe('#/components/schemas/Dog');
+    expect((pet.discriminator.mapping as Record<string, string>).dog).toBe('#/components/schemas/Dog1');
   });
 
   it('deduplicates identical components rather than renaming them', () => {
@@ -593,5 +594,126 @@ describe('3.2 - references inside the new slots', () => {
       .content['application/json'].schema.$ref;
 
     expect(ref).toBe('#/components/schemas/Thing1');
+  });
+});
+
+/**
+ * Issue #99: discriminator mappings are pointers the walker has to know about.
+ *
+ * The values of a Discriminator Object's `mapping` point at schemas, but they
+ * are plain strings in a plain object rather than `$ref` members, so nothing
+ * rewrote them when deduplication renamed their target. The result resolved to
+ * nothing while looking entirely valid.
+ *
+ * The specification permits two spellings and both occur in the wild: a full
+ * reference, and a bare schema name that is defined as shorthand for exactly
+ * that reference.
+ */
+describe('discriminator mapping rewriting (issue #99)', () => {
+  const petWith = (mapping: Record<string, string>) => ({
+    Dog: { type: 'object' as const },
+    Pet: {
+      oneOf: [{ $ref: '#/components/schemas/Dog' }],
+      discriminator: { propertyName: 'kind', mapping },
+    },
+  });
+
+  const twoInputs = (mapping: Record<string, string>) => [
+    { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: { type: 'string' } } } }) },
+    { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { schemas: petWith(mapping) } }) },
+  ];
+
+  const mappingOf = (output: OpenApiDocument): Record<string, string> =>
+    ((output.components?.schemas?.Pet as Record<string, Record<string, unknown>>).discriminator
+      .mapping) as Record<string, string>;
+
+  it('rewrites a full reference', () => {
+    const output = expectSuccess(merge(twoInputs({ dog: '#/components/schemas/Dog' })));
+
+    expect(mappingOf(output).dog).toBe('#/components/schemas/Dog1');
+  });
+
+  it('rewrites a bare schema name, keeping it bare', () => {
+    const output = expectSuccess(merge(twoInputs({ dog: 'Dog' })));
+
+    // The spec defines a bare name as shorthand for the full reference.
+    // Expanding it here would produce a large, noisy diff in documents this
+    // tool is only passing through.
+    expect(mappingOf(output).dog).toBe('Dog1');
+  });
+
+  it('leaves a mapping alone when its target was not renamed', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('a') } } }) },
+        { oas: doc30({ paths: { '/b': { get: op('b') } }, components: { schemas: petWith({ dog: 'Dog' }) } }) },
+      ]),
+    );
+
+    expect(mappingOf(output).dog).toBe('Dog');
+  });
+
+  it('leaves an external URL mapping untouched', () => {
+    const output = expectSuccess(merge(twoInputs({ dog: 'https://example.com/schemas.json#/Dog' })));
+
+    // It does not point into this document's components.
+    expect(mappingOf(output).dog).toBe('https://example.com/schemas.json#/Dog');
+  });
+
+  it('leaves a relative file mapping untouched', () => {
+    const output = expectSuccess(merge(twoInputs({ dog: '../other.yaml#/components/schemas/Dog' })));
+
+    expect(mappingOf(output).dog).toBe('../other.yaml#/components/schemas/Dog');
+  });
+
+  it('rewrites several mapping entries in one discriminator', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/a': { get: op('a') } },
+            components: { schemas: { Dog: { type: 'string' }, Cat: { type: 'string' } } },
+          }),
+        },
+        {
+          oas: doc30({
+            paths: { '/b': { get: op('b') } },
+            components: {
+              schemas: {
+                Dog: { type: 'object' },
+                Cat: { type: 'object' },
+                Pet: {
+                  oneOf: [{ $ref: '#/components/schemas/Dog' }, { $ref: '#/components/schemas/Cat' }],
+                  discriminator: { propertyName: 'kind', mapping: { dog: 'Dog', cat: '#/components/schemas/Cat' } },
+                },
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    expect(mappingOf(output)).toEqual({ dog: 'Dog1', cat: '#/components/schemas/Cat1' });
+  });
+
+  it('rewrites a mapping under a dispute prefix', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/b': { get: op('b') } }, components: { schemas: petWith({ dog: 'Dog' }) } }),
+          dispute: { prefix: 'Svc', alwaysApply: true },
+        },
+      ]),
+    );
+
+    const pet = (expectSuccess(merge([
+      {
+        oas: doc30({ paths: { '/b': { get: op('b') } }, components: { schemas: petWith({ dog: 'Dog' }) } }),
+        dispute: { prefix: 'Svc', alwaysApply: true },
+      },
+    ])).components?.schemas?.SvcPet) as Record<string, Record<string, unknown>>;
+
+    expect((pet.discriminator.mapping as Record<string, string>).dog).toBe('SvcDog');
+    expect(output.components?.schemas?.SvcDog).toBeDefined();
   });
 });

--- a/packages/openapi-merge/src/reference-walker.ts
+++ b/packages/openapi-merge/src/reference-walker.ts
@@ -42,6 +42,59 @@ export function walkSchemaReferences(schema: Swagger.Schema | Swagger.Reference,
     if (schema.additionalProperties !== undefined && typeof schema.additionalProperties !== 'boolean') {
       walkSchemaReferences(schema.additionalProperties, modify);
     }
+
+    walkDiscriminatorMapping(schema, modify);
+  }
+}
+
+/**
+ * Rewrites the pointers hiding in `discriminator.mapping` (issue #99).
+ *
+ * A Discriminator Object maps a property value to a schema, and the map's
+ * *values* are pointers -- but they are plain strings in a plain object, not
+ * `$ref` members, so the reference walker never saw them. When deduplication
+ * renamed `Dog` to `Dog1`, the `oneOf` `$ref` was rewritten and the mapping was
+ * not, leaving a document that resolves to nothing while looking entirely
+ * valid.
+ *
+ * The specification allows a value to be written two ways, and both occur:
+ *
+ * - a full reference, `#/components/schemas/Dog`;
+ * - a bare schema name, `Dog`, which the spec defines as shorthand for exactly
+ *   that reference.
+ *
+ * A bare name is therefore rewritten by asking `modify` about the reference it
+ * abbreviates and, if that changed, writing back the abbreviated form of the
+ * result. Preserving the author's chosen spelling matters: expanding every
+ * shorthand into a full reference would produce a large, noisy diff in
+ * documents this tool merely passes through.
+ *
+ * Anything else -- a URL, a relative file path -- is left untouched, because it
+ * does not point into this document's components.
+ */
+function walkDiscriminatorMapping(schema: Swagger.Schema, modify: Modify): void {
+  const mapping = (schema as { discriminator?: { mapping?: Record<string, string> } }).discriminator?.mapping;
+  if (mapping === undefined) {
+    return;
+  }
+
+  const SCHEMA_PREFIX = '#/components/schemas/';
+
+  for (const key of Object.keys(mapping)) {
+    const value = mapping[key];
+
+    if (value.startsWith('#/')) {
+      mapping[key] = modify(value);
+      continue;
+    }
+
+    // A bare name is shorthand only when it is a name, not a path or a URL.
+    if (!value.includes('/') && !value.includes('#')) {
+      const rewritten = modify(`${SCHEMA_PREFIX}${value}`);
+      if (rewritten !== `${SCHEMA_PREFIX}${value}` && rewritten.startsWith(SCHEMA_PREFIX)) {
+        mapping[key] = rewritten.slice(SCHEMA_PREFIX.length);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Closes #99.

A Discriminator Object's `mapping` values point at schemas — but they're plain strings in a plain object, not `$ref` members, so the reference walker never saw them. When deduplication renamed `Dog` to `Dog1`, the `oneOf` `$ref` followed and the mapping didn't:

```
oneOf $ref            -> #/components/schemas/Dog1   (correct)
discriminator.mapping -> #/components/schemas/Dog    (stale)
```

A document that resolves to nothing while looking entirely valid.

Handled inside `walkSchemaReferences`, so every existing traversal covers it — paths, webhooks, components, callbacks — with no second walk.

### Both spellings, and the author's is preserved

The spec allows a full reference **or** a bare schema name (shorthand for the same thing). Both occur in the wild. A bare `Dog` becomes `Dog1`, not `#/components/schemas/Dog1`.

Expanding shorthand would be *correct* and a *bad diff*: this tool passes most content through untouched, and turning every mapping into a full reference would bury the real changes.

A value that's a URL or relative file path is left alone — it doesn't point into this document's components, same as external `$ref` preservation.

### The pinned test flipped

`spec-edge-case-findings.md` §2.4 pinned this as a `KNOWN GAP` with a test asserting the *broken* behaviour. It failed the moment the fix landed — exactly what it was for — and now asserts the correct result. Findings doc updated.

### Verification

- 6 new tests plus the flipped pin; **5 fail against `origin/main`**
- Cover: full reference, bare name, unrenamed target, external URL, relative file path, multiple entries, dispute prefix
- Gate green: lint, 391 tests, 48 artifact checks

**#106 still owes** 3.2's `defaultMapping` and the Link `operationRef` gap (§2.5) — same shape, and this change gives them a place to live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)