### PR TITLE
fix(merge): rewrite defaultMapping and Link operationRef (#106)

### DIFF
--- a/ai-planning/issues/09-proposal-106-discriminator-mappings.md
+++ b/ai-planning/issues/09-proposal-106-discriminator-mappings.md
@@ -2,7 +2,7 @@
 
 **Issue**: [#106 Discriminator mappings not prefixed under disputes](https://github.com/robertmassaioli/openapi-merge/issues/106)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 / **Effort:** 2
 
@@ -460,3 +460,63 @@ All should be bundled into a single minor release once #99 is confirmed to have 
 3. **Future discriminator features**: OpenAPI 3.1 may introduce new discriminator fields. Keep the normalise/denormalise logic generic; adding support for new fields will only require adding new walk calls (no changes to the helper functions).
 
 4. **Compatibility with #99**: Confirm that #99's proposed fix (if any) does not duplicate this logic. Both issues should reference each other in their implementation PRs to ensure coordinated review.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/106-discriminator-defaultmapping`. Closes both halves of
+`spec-edge-case-findings.md` §2.4 and §2.5, which that document already argued
+should be fixed together as "rewrite every kind of internal pointer, not just
+`$ref`".
+
+### 10.1 `walkDiscriminatorPointers` covers `mapping` and `defaultMapping`
+
+3.2 added `defaultMapping`: the schema to use when the discriminating value
+matches no entry. Same kind of pointer, same two permitted spellings — a full
+reference, or a bare schema name that is shorthand for one — so it goes through
+the same rewrite, and a bare name stays bare.
+
+This branch carries the `mapping` fix as well as `defaultMapping`, because it
+was cut from `main` and #99 is not merged there yet. The two will conflict on
+this function; keeping either copy is correct, they are the same code.
+
+### 10.2 `operationRef` needed JSON Pointer escaping
+
+The one thing the discriminator work did not need. A path key appears in an
+`operationRef` as `#/paths/~1thing/get`, while `referenceModification` is keyed
+on the raw path `#/paths//thing`. So the segment is decoded before lookup and
+re-encoded after: `prepend: '/api'` turns `#/paths/~1thing/get` into
+`#/paths/~1api~1thing/get`.
+
+### 10.3 What is deliberately left alone
+
+- **An `operationRef` into another document.** Moving our paths says nothing
+  about someone else's.
+- **A link that uses `operationId`.** An id travels with its operation —
+  `ensureUniqueOperationIds` renames both together — so a link by id is correct
+  after a path move without any rewriting. There is a test asserting this
+  *doesn't* change, because "fix every pointer" is exactly the instinct that
+  would break it.
+
+### 10.4 Two pinned tests flipped, and one that must not
+
+The `KNOWN GAP` tests for `mapping` and `defaultMapping` both failed the moment
+the fix landed and now assert the fix.
+
+A third test — "carries discriminator defaultMapping", a single-input
+pass-through — has an assertion identical in text to the pinned one, and a
+careless bulk edit changed it too. It must keep expecting the *unrenamed*
+value: nothing is renamed in a single-input merge, and asserting `Dog1` there
+would have pinned a bug. Caught by the suite immediately; noted because the
+next bulk edit will hit the same shape.
+
+### 10.5 Verification
+
+- 7 new tests plus two flipped pins. **7 failures against `origin/main`** across
+  the two touched files, confirmed in a detached worktree.
+- Cover: `defaultMapping` as a reference and as a bare name, both together with
+  `mapping`, `operationRef` under `prepend` and under `stripStart`, an
+  unmoved path, an external `operationRef`, and an `operationId` link.
+- Gate green: lint, 391 tests, 48 artifact checks.

--- a/ai-planning/spec-edge-case-findings.md
+++ b/ai-planning/spec-edge-case-findings.md
@@ -106,7 +106,7 @@ Left as-is deliberately; changing it would resurrect empty path items that
 `operationSelection` has just emptied, which is the behaviour the dropping exists
 for.
 
-### 2.4 Discriminator pointers are not rewritten on rename
+### 2.4 Discriminator pointers are not rewritten on rename — FIXED (#99, #106)
 
 Already tracked as **issues #99 and #106**, with proposals in
 `issues/10-proposal-99-discriminator-mapping-prefix.md` and
@@ -120,15 +120,21 @@ discriminator.mapping -> #/components/schemas/Dog    (stale)
 
 The new tests add `defaultMapping` coverage those proposals predate.
 
-### 2.5 A Link `operationRef` is not rewritten when its path moves
+### 2.5 A Link `operationRef` is not rewritten when its path moves — FIXED (#106)
 
 A Link's `operationRef` is a URI pointing at an Operation. Under
-`pathModification.prepend: '/api'`, the path becomes `/api/thing` but a link
-pointing at `#/paths/~1thing/get` is left dangling.
+`pathModification.prepend: '/api'`, the path became `/api/thing` while a link
+pointing at `#/paths/~1thing/get` was left dangling.
 
-Related to §2.4 — both are "pointers the reference walker does not know about".
-Worth fixing together as "rewrite every kind of internal pointer, not just
-`$ref`".
+Fixed together with §2.4, as this section suggested: they are the same problem,
+"pointers the reference walker does not know about". `operationRef` needed one
+thing the others did not — JSON Pointer escaping. A path key appears in a
+pointer as `~1thing` while the rename table is keyed on the raw `/thing`, so
+the segment is decoded before lookup and re-encoded after.
+
+Left alone deliberately: an `operationRef` into another document, and a link
+that uses `operationId` instead — an id travels with its operation, so a link
+by id needs no rewriting when the path moves.
 
 ### 2.6 Semantic schema equivalences are not deduplicated
 

--- a/packages/openapi-merge/src/__tests__/document-metadata.test.ts
+++ b/packages/openapi-merge/src/__tests__/document-metadata.test.ts
@@ -632,13 +632,14 @@ describe('3.2 edge: additive fields pass through', () => {
       } },
     }) }]));
 
+    // Single input, nothing renamed: the pointer must be untouched.
     expect(at(output.components?.schemas?.Pet, 'discriminator', 'defaultMapping'))
       .toBe('#/components/schemas/Dog');
   });
 
-  it('KNOWN GAP: discriminator defaultMapping is not rewritten on rename', () => {
-    // Same class of gap as the `mapping` field (issues #99/#106): the oneOf
-    // reference follows the rename, the discriminator pointer does not.
+  it('rewrites discriminator defaultMapping on rename (issue #106)', () => {
+    // Was pinned as a KNOWN GAP alongside `mapping` (#99). Both are pointers
+    // the walker could not see because they are not spelled `$ref`.
     const output = expectSuccess(merge([
       { oas: doc32({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: schema({ type: 'string' }) } } }) },
       { oas: doc32({
@@ -655,7 +656,7 @@ describe('3.2 edge: additive fields pass through', () => {
 
     expect(at(output.components?.schemas?.Pet, 'oneOf', '0', '$ref')).toBe('#/components/schemas/Dog1');
     expect(at(output.components?.schemas?.Pet, 'discriminator', 'defaultMapping'))
-      .toBe('#/components/schemas/Dog');
+      .toBe('#/components/schemas/Dog1');
   });
 
   it('carries itemSchema for sequential media types', () => {

--- a/packages/openapi-merge/src/__tests__/references.test.ts
+++ b/packages/openapi-merge/src/__tests__/references.test.ts
@@ -435,11 +435,9 @@ describe('3.0 edge: references', () => {
     expect((output.components?.schemas?.Alias as { $ref: string }).$ref).toBe('#/components/schemas/Thing1');
   });
 
-  it('KNOWN GAP (issues #99/#106): a discriminator mapping is not rewritten on rename', () => {
-    // The oneOf $ref follows the rename but the discriminator mapping value,
-    // which points at the same schema, does not. Already tracked by
-    // issues/10-proposal-99-discriminator-mapping-prefix.md and
-    // issues/09-proposal-106-discriminator-mappings.md.
+  it('rewrites a discriminator mapping on rename (issues #99/#106)', () => {
+    // Was pinned as a KNOWN GAP. The mapping value points at the same schema
+    // the oneOf $ref does, and now follows the same rename.
     const output = expectSuccess(merge([
       { oas: doc30({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: { type: 'string' } } } }) },
       { oas: doc30({
@@ -456,8 +454,7 @@ describe('3.0 edge: references', () => {
 
     const pet = output.components?.schemas?.Pet as Record<string, Record<string, unknown>>;
     expect((pet.oneOf as unknown as Array<{ $ref: string }>)[0].$ref).toBe('#/components/schemas/Dog1');
-    // Still pointing at the pre-rename name -- this is the bug.
-    expect((pet.discriminator.mapping as Record<string, string>).dog).toBe('#/components/schemas/Dog');
+    expect((pet.discriminator.mapping as Record<string, string>).dog).toBe('#/components/schemas/Dog1');
   });
 
   it('deduplicates identical components rather than renaming them', () => {
@@ -495,9 +492,10 @@ describe('3.0 edge: callbacks and links', () => {
     expect(ref).toBe('#/components/schemas/Thing1');
   });
 
-  it('KNOWN GAP: a link operationRef is not rewritten when the path it targets changes', () => {
-    // A Link's operationRef is a URI pointing at an Operation. When
-    // pathModification renames the path, the reference is left dangling.
+  it('rewrites a link operationRef when the path it targets moves (issue #106)', () => {
+    // A Link's operationRef is a URI pointing at an Operation. pathModification
+    // used to move the path out from under it and leave the reference dangling
+    // in a document that still looked valid. Was pinned here as a KNOWN GAP.
     const output = expectSuccess(merge([
       {
         oas: doc30({ paths: { '/thing': { get: op('getThing') }, '/other': { get: {
@@ -510,9 +508,9 @@ describe('3.0 edge: callbacks and links', () => {
       },
     ]));
 
-    // Still points at the pre-prepend location.
+    // Follows the path, with the `/` re-escaped as `~1` per JSON Pointer.
     expect(at(output.paths?.['/api/other'], 'get', 'responses', '200', 'links', 'next', 'operationRef'))
-      .toBe('#/paths/~1thing/get');
+      .toBe('#/paths/~1api~1thing/get');
     expect(pathKeys(output)).toEqual(['/api/other', '/api/thing']);
   });
 });
@@ -593,5 +591,191 @@ describe('3.2 - references inside the new slots', () => {
       .content['application/json'].schema.$ref;
 
     expect(ref).toBe('#/components/schemas/Thing1');
+  });
+});
+
+/**
+ * Issue #106: the remaining pointers that are not spelled `$ref`.
+ *
+ * #99 taught the walker about `discriminator.mapping`. Two of the same shape
+ * were left: 3.2's `discriminator.defaultMapping`, and a Link's
+ * `operationRef`. Both point into the document, neither is a `$ref`, and both
+ * were silently left stale.
+ */
+describe('defaultMapping and operationRef (issue #106)', () => {
+  it('rewrites discriminator.defaultMapping on rename', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc32({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: { type: 'string' } } } }) },
+        {
+          oas: doc32({
+            paths: { '/b': { get: op('b') } },
+            components: {
+              schemas: {
+                Dog: { type: 'object' },
+                Pet: {
+                  oneOf: [{ $ref: '#/components/schemas/Dog' }],
+                  discriminator: { propertyName: 'kind', defaultMapping: '#/components/schemas/Dog' },
+                },
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    const pet = output.components?.schemas?.Pet as Record<string, Record<string, unknown>>;
+    expect(pet.discriminator.defaultMapping).toBe('#/components/schemas/Dog1');
+  });
+
+  it('rewrites a bare-name defaultMapping, keeping it bare', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc32({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: { type: 'string' } } } }) },
+        {
+          oas: doc32({
+            paths: { '/b': { get: op('b') } },
+            components: {
+              schemas: {
+                Dog: { type: 'object' },
+                Pet: { discriminator: { propertyName: 'kind', defaultMapping: 'Dog' } },
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    const pet = output.components?.schemas?.Pet as Record<string, Record<string, unknown>>;
+    expect(pet.discriminator.defaultMapping).toBe('Dog1');
+  });
+
+  it('rewrites mapping and defaultMapping together', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc32({ paths: { '/a': { get: op('a') } }, components: { schemas: { Dog: { type: 'string' } } } }) },
+        {
+          oas: doc32({
+            paths: { '/b': { get: op('b') } },
+            components: {
+              schemas: {
+                Dog: { type: 'object' },
+                Pet: {
+                  discriminator: {
+                    propertyName: 'kind',
+                    mapping: { dog: 'Dog' },
+                    defaultMapping: '#/components/schemas/Dog',
+                  },
+                },
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    const discriminator = (output.components?.schemas?.Pet as Record<string, Record<string, unknown>>).discriminator;
+    expect(discriminator.mapping).toEqual({ dog: 'Dog1' });
+    expect(discriminator.defaultMapping).toBe('#/components/schemas/Dog1');
+  });
+
+  it('leaves an operationRef alone when the path did not move', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: {
+              '/thing': { get: op('getThing') },
+              '/other': {
+                get: {
+                  operationId: 'other',
+                  responses: { '200': { description: 'ok', links: { next: { operationRef: '#/paths/~1thing/get' } } } },
+                },
+              },
+            },
+          }),
+        },
+      ]),
+    );
+
+    expect(at(output.paths?.['/other'], 'get', 'responses', '200', 'links', 'next', 'operationRef'))
+      .toBe('#/paths/~1thing/get');
+  });
+
+  it('leaves an external operationRef untouched', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: {
+              '/other': {
+                get: {
+                  operationId: 'other',
+                  responses: {
+                    '200': {
+                      description: 'ok',
+                      links: { next: { operationRef: 'https://example.com/api.json#/paths/~1thing/get' } },
+                    },
+                  },
+                },
+              },
+            },
+          }),
+          pathModification: { prepend: '/api' },
+        },
+      ]),
+    );
+
+    // Points into another document; moving our paths says nothing about it.
+    expect(at(output.paths?.['/api/other'], 'get', 'responses', '200', 'links', 'next', 'operationRef'))
+      .toBe('https://example.com/api.json#/paths/~1thing/get');
+  });
+
+  it('leaves an operationId link alone, since ids move with their operation', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: {
+              '/thing': { get: op('getThing') },
+              '/other': {
+                get: {
+                  operationId: 'other',
+                  responses: { '200': { description: 'ok', links: { next: { operationId: 'getThing' } } } },
+                },
+              },
+            },
+          }),
+          pathModification: { prepend: '/api' },
+        },
+      ]),
+    );
+
+    expect(at(output.paths?.['/api/other'], 'get', 'responses', '200', 'links', 'next', 'operationId'))
+      .toBe('getThing');
+  });
+
+  it('rewrites an operationRef under stripStart as well as prepend', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: {
+              '/v1/thing': { get: op('getThing') },
+              '/v1/other': {
+                get: {
+                  operationId: 'other',
+                  responses: { '200': { description: 'ok', links: { next: { operationRef: '#/paths/~1v1~1thing/get' } } } },
+                },
+              },
+            },
+          }),
+          pathModification: { stripStart: '/v1' },
+        },
+      ]),
+    );
+
+    expect(at(output.paths?.['/other'], 'get', 'responses', '200', 'links', 'next', 'operationRef'))
+      .toBe('#/paths/~1thing/get');
   });
 });

--- a/packages/openapi-merge/src/reference-walker.ts
+++ b/packages/openapi-merge/src/reference-walker.ts
@@ -42,6 +42,70 @@ export function walkSchemaReferences(schema: Swagger.Schema | Swagger.Reference,
     if (schema.additionalProperties !== undefined && typeof schema.additionalProperties !== 'boolean') {
       walkSchemaReferences(schema.additionalProperties, modify);
     }
+
+    walkDiscriminatorPointers(schema, modify);
+  }
+}
+
+/**
+ * Rewrites the pointers inside a Discriminator Object (issues #99 and #106).
+ *
+ * A Discriminator maps a property value to a schema, and the targets are
+ * pointers -- but they are plain strings in a plain object rather than `$ref`
+ * members, so the reference walker never saw them. When deduplication renamed
+ * `Dog` to `Dog1` the `oneOf` `$ref` was rewritten and these were not, leaving
+ * a document that resolves to nothing while looking entirely valid.
+ *
+ * Covers `mapping` (#99) and 3.2's `defaultMapping` (#106), which is the schema
+ * to use when the discriminating value matches no entry.
+ *
+ * The specification allows a target to be written two ways, and both occur:
+ *
+ * - a full reference, `#/components/schemas/Dog`;
+ * - a bare schema name, `Dog`, defined as shorthand for exactly that reference.
+ *
+ * A bare name is rewritten by asking `modify` about the reference it
+ * abbreviates and writing back the abbreviated form of the answer. Preserving
+ * the author's spelling matters: expanding every shorthand would produce a
+ * large, noisy diff in documents this tool merely passes through.
+ *
+ * A URL or relative file path is left untouched -- it does not point into this
+ * document's components.
+ */
+function walkDiscriminatorPointers(schema: Swagger.Schema, modify: Modify): void {
+  const discriminator = (schema as {
+    discriminator?: { mapping?: Record<string, string>; defaultMapping?: string };
+  }).discriminator;
+  if (discriminator === undefined) {
+    return;
+  }
+
+  const SCHEMA_PREFIX = '#/components/schemas/';
+
+  const rewriteTarget = (value: string): string => {
+    if (value.startsWith('#/')) {
+      return modify(value);
+    }
+
+    if (!value.includes('/') && !value.includes('#')) {
+      const rewritten = modify(`${SCHEMA_PREFIX}${value}`);
+      if (rewritten !== `${SCHEMA_PREFIX}${value}` && rewritten.startsWith(SCHEMA_PREFIX)) {
+        return rewritten.slice(SCHEMA_PREFIX.length);
+      }
+    }
+
+    return value;
+  };
+
+  const mapping = discriminator.mapping;
+  if (mapping !== undefined) {
+    for (const key of Object.keys(mapping)) {
+      mapping[key] = rewriteTarget(mapping[key]);
+    }
+  }
+
+  if (discriminator.defaultMapping !== undefined) {
+    discriminator.defaultMapping = rewriteTarget(discriminator.defaultMapping);
   }
 }
 
@@ -125,11 +189,54 @@ export function walkHeaderReferences(header: Swagger.Header | Swagger.Reference,
   }
 }
 
+/**
+ * `#/paths/~1thing/get` -> the path `/thing`, or undefined if not that shape.
+ *
+ * A JSON Pointer escapes `/` as `~1` and `~` as `~0`, so a path key appears in
+ * an `operationRef` in escaped form while `referenceModification` is keyed on
+ * the raw path. Decoding is what connects the two.
+ */
+function parseOperationRef(operationRef: string): { path: string; method: string } | undefined {
+  const match = /^#\/paths\/([^/]+)\/([^/]+)$/.exec(operationRef);
+  if (match === null) {
+    return undefined;
+  }
+  return { path: match[1].replace(/~1/g, '/').replace(/~0/g, '~'), method: match[2] };
+}
+
+function escapePointerSegment(segment: string): string {
+  return segment.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
 export function walkLinkReferences(link: Swagger.Link | Swagger.Reference, modify: Modify): void {
   if (TC.isReference(link)) {
     link.$ref = modify(link.$ref);
   } else {
-    // TODO work out if there are any references in here that should be updated
+    // A Link's `operationRef` is a URI pointing at an Operation (issue #106).
+    // `pathModification` can move the path out from under it, and nothing
+    // rewrote it: prepending "/api" left every operationRef dangling, in a
+    // document that still looked valid.
+    //
+    // `operationId` links need no rewriting here -- ensureUniqueOperationIds
+    // renames the operation and its id together, and a link by id follows the
+    // id, not a location.
+    const operationRef = (link as { operationRef?: string }).operationRef;
+    if (operationRef === undefined) {
+      return;
+    }
+
+    const parsed = parseOperationRef(operationRef);
+    if (parsed === undefined) {
+      // An external or otherwise unrecognised URI. Left alone: it does not
+      // point into this document.
+      return;
+    }
+
+    const rewrittenPath = modify(`#/paths/${parsed.path}`);
+    if (rewrittenPath !== `#/paths/${parsed.path}` && rewrittenPath.startsWith('#/paths/')) {
+      const newPath = rewrittenPath.slice('#/paths/'.length);
+      (link as { operationRef?: string }).operationRef = `#/paths/${escapePointerSegment(newPath)}/${parsed.method}`;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #106. Closes both halves of `spec-edge-case-findings.md` §2.4 and §2.5 — which that document already argued should be fixed together, since they're the same problem: **pointers the reference walker can't see because they aren't spelled `$ref`.**

- **3.2's `discriminator.defaultMapping`** — same treatment as `mapping`: both permitted spellings, and a bare name stays bare.
- **A Link's `operationRef`** now follows its path.

### `operationRef` needed something the others didn't

JSON Pointer escaping. A path appears in a pointer as `~1thing` while the rename table is keyed on the raw `/thing`, so the segment is decoded before lookup and re-encoded after:

```
prepend: '/api'   #/paths/~1thing/get  ->  #/paths/~1api~1thing/get
```

### Deliberately left alone

- **An `operationRef` into another document** — moving our paths says nothing about someone else's.
- **A link using `operationId`** — an id travels with its operation, so the link is already correct after a path move. There's a test asserting it *doesn't* change, because "fix every pointer" is exactly the instinct that would break it.

### Note on overlap with #99

This branch was cut from `main`, where #99 isn't merged, so it carries the `mapping` fix too. The two conflict on one function; either copy is correct — they're the same code.

### A near-miss worth flagging

Two `KNOWN GAP` tests flipped to assert the fix. A **third** test has assertion text identical to one of them — a single-input pass-through where nothing is renamed — and my bulk edit changed it too. Asserting the renamed value there would have pinned a bug. The suite caught it immediately.

### Verification

- 7 new tests plus two flipped pins; **7 failures against `origin/main`**
- Gate green: lint, 391 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)