### PR TITLE
feat(merge): allow the merged info object to be overridden (#102)

### DIFF
--- a/ai-planning/issues/14-proposal-102-global-info-override.md
+++ b/ai-planning/issues/14-proposal-102-global-info-override.md
@@ -1,7 +1,7 @@
 # Proposal: Issue #102 — Global title/description override in config
 
 **Issue Link:** https://github.com/robertmassaioli/openapi-merge/issues/102  
-**Status:** Proposal  
+**Status:** ✅ Implemented — see §10  
 **Value:** 3 / **Effort:** 2
 
 ---
@@ -478,3 +478,47 @@ cat test-output.json | grep -A2 '"info"'
 
 4. **Shared `MergeOptions` future:** This `MergeOptions` interface mirrors the pattern in proposal-76 (for `openapi` version override). A future proposal may unify them into one options object, e.g., `{ info?: ..., openapi?: ... }`.
 
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/102-global-info-override`. Option B, the library-level option, as
+recommended — `merge(inputs, { info })`, with the CLI passing `config.info`
+through.
+
+### 10.1 Merged field by field, not replaced wholesale
+
+`Partial<Swagger.Info>` is applied key by key over the merged `info`. Replacing
+the object outright would force anyone overriding just the title to restate
+`version`, which the specification requires — turning a one-line convenience
+into a chore that silently invites a wrong version number.
+
+### 10.2 An explicit `undefined` does not blank a value
+
+Only keys whose value is actually present override. A configuration file cannot
+express the difference between "absent" and "explicitly undefined", and between
+the two readings the destructive one is the surprising one. Tested.
+
+### 10.3 Applied after description appending
+
+So `info.description` in the override beats an appended description, while an
+override that says nothing about `description` leaves the appending intact.
+Both directions are tested, because this is the one interaction where the
+feature could quietly undo an existing one.
+
+### 10.4 The CLI exposes a narrow subset
+
+`title`, `version` and `description` rather than the whole Info object.
+`contact`, `licence` and `termsOfService` are available to library callers but
+are not worth the generated-schema surface for a configuration file; keeping the
+schema small is also what lets `--noExtraProps` turn a typo like `titel` into an
+error instead of a silent no-op. There is a test for exactly that.
+
+### 10.5 Verification
+
+- 8 library tests in `document-metadata.test.ts`, which owns document-level
+  metadata. **5 fail against `origin/main`**, confirmed in a detached worktree.
+- 3 CLI tests for the wiring, including the typo case.
+- Gate green: lint, 395 tests, 48 artifact checks.

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -130,3 +130,53 @@ describe('main - serversStrategy (issue #4)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #102: the info override reaching the library from a config file.
+ */
+describe('main - info override (issue #102)', () => {
+  const named = (title: string, path: string, opId: string) => ({
+    openapi: '3.0.3',
+    info: { title, version: '1.0.0' },
+    paths: { [path]: getPath(opId) },
+  });
+
+  it('titles the output after the first input by default', async () => {
+    cli.writeJson('a.json', named('Service A', '/a', 'getA'));
+    cli.writeJson('b.json', named('Service B', '/b', 'getB'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(JSON.parse(cli.read()).info.title).toBe('Service A');
+  });
+
+  it('applies a title override, keeping the version', async () => {
+    cli.writeJson('a.json', named('Service A', '/a', 'getA'));
+    cli.writeJson('b.json', named('Service B', '/b', 'getB'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }, { inputFile: './b.json' }],
+      output: './output.json',
+      info: { title: 'Combined API' },
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    const info = JSON.parse(cli.read()).info;
+    expect(info.title).toBe('Combined API');
+    expect(info.version).toBe('1.0.0');
+  });
+
+  it('rejects an unknown info field against the generated schema', async () => {
+    cli.writeJson('a.json', named('Service A', '/a', 'getA'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './output.json',
+      info: { titel: 'typo' },
+    });
+
+    // --noExtraProps is what makes a typo an error rather than a silent no-op.
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -245,6 +245,30 @@ export type Configuration = {
    *   URL. For documenting several microservices in one file.
    */
   serversStrategy?: 'first' | 'concat';
+
+  /**
+   * Override fields of the merged `info` object (issue #102).
+   *
+   * Without this, `info` comes from the first input, so a merged document is
+   * titled after whichever service happens to be listed first. Merged field by
+   * field, so setting only `title` does not require restating `version`.
+   */
+  info?: ConfigurationInfoOverride;
+};
+
+/**
+ * The subset of `info` worth overriding from a configuration file.
+ *
+ * Deliberately not the full Info object: `version` and `title` are the ones
+ * people ask for, and description rounds it out. Kept narrow so the generated
+ * schema stays readable and `--noExtraProps` still catches typos.
+ */
+export type ConfigurationInfoOverride = {
+  /** @minLength 1 */
+  title?: string;
+  /** @minLength 1 */
+  version?: string;
+  description?: string;
 };
 
 /**

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -249,7 +249,10 @@ export async function main(): Promise<void> {
 
   logger.log(`## Loaded the inputs into memory, merging the results.`);
 
-  const mergeResult = merge(inputs, { serversStrategy: config.serversStrategy });
+  const mergeResult = merge(inputs, {
+    serversStrategy: config.serversStrategy,
+    info: config.info,
+  });
 
   if (isErrorResult(mergeResult)) {
     console.error(`Error merging files: ${mergeResult.message} (${mergeResult.type})`);

--- a/packages/openapi-merge/src/__tests__/document-metadata.test.ts
+++ b/packages/openapi-merge/src/__tests__/document-metadata.test.ts
@@ -792,3 +792,92 @@ describe('servers strategy (issue #4)', () => {
     expect(inputs[1].oas.servers).toEqual([{ url: 'https://second.example.com' }]);
   });
 });
+
+/**
+ * Issue #102: overriding the merged `info`.
+ *
+ * `info` is otherwise taken from the first input, so an aggregate document ends
+ * up titled after whichever service happened to be listed first -- describing
+ * itself as something it is not.
+ */
+describe('info override (issue #102)', () => {
+  const two = () => [
+    { oas: doc30({ paths: { '/a': { get: op('a') } }, info: { title: 'Service A', version: '1.0.0' } }) },
+    { oas: doc30({ paths: { '/b': { get: op('b') } }, info: { title: 'Service B', version: '2.0.0' } }) },
+  ];
+
+  it('takes info from the first input when no override is given', () => {
+    const output = expectSuccess(merge(two()));
+
+    expect(output.info).toEqual({ title: 'Service A', version: '1.0.0' });
+  });
+
+  it('overrides the title while keeping the rest', () => {
+    const output = expectSuccess(merge(two(), { info: { title: 'Combined API' } }));
+
+    // version is required, and overriding only the title must not demand it.
+    expect(output.info).toEqual({ title: 'Combined API', version: '1.0.0' });
+  });
+
+  it('overrides several fields at once', () => {
+    const output = expectSuccess(
+      merge(two(), { info: { title: 'Combined API', version: '9.9.9', description: 'Everything.' } }),
+    );
+
+    expect(output.info).toEqual({ title: 'Combined API', version: '9.9.9', description: 'Everything.' });
+  });
+
+  it('overrides a description that would otherwise be appended', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          { oas: doc30({ paths: { '/a': { get: op('a') } }, info: { title: 'A', version: '1', description: 'From A' } }), description: { append: true } },
+          { oas: doc30({ paths: { '/b': { get: op('b') } }, info: { title: 'B', version: '1', description: 'From B' } }), description: { append: true } },
+        ],
+        { info: { description: 'Written by hand.' } },
+      ),
+    );
+
+    // Applied after appending, so an explicit description wins.
+    expect(output.info.description).toBe('Written by hand.');
+  });
+
+  it('leaves appended descriptions alone when the override does not mention them', () => {
+    const output = expectSuccess(
+      merge(
+        [
+          { oas: doc30({ paths: { '/a': { get: op('a') } }, info: { title: 'A', version: '1', description: 'From A' } }), description: { append: true } },
+          { oas: doc30({ paths: { '/b': { get: op('b') } }, info: { title: 'B', version: '1', description: 'From B' } }), description: { append: true } },
+        ],
+        { info: { title: 'Combined' } },
+      ),
+    );
+
+    expect(output.info.title).toBe('Combined');
+    expect(output.info.description).toBe('From A\n\nFrom B');
+  });
+
+  it('ignores an explicitly undefined field rather than blanking the value', () => {
+    const output = expectSuccess(merge(two(), { info: { title: undefined } }));
+
+    // A config file cannot express the difference between absent and
+    // explicitly undefined, and the destructive reading is the surprising one.
+    expect(output.info.title).toBe('Service A');
+  });
+
+  it('does not mutate the input it copied info from', () => {
+    const inputs = two();
+    merge(inputs, { info: { title: 'Combined API' } });
+
+    expect(inputs[0].oas.info.title).toBe('Service A');
+  });
+
+  it('carries a contact or licence supplied only by the override', () => {
+    const output = expectSuccess(
+      merge(two(), { info: { contact: { name: 'Platform', email: 'platform@example.com' } } }),
+    );
+
+    expect(output.info.contact).toEqual({ name: 'Platform', email: 'platform@example.com' });
+    expect(output.info.title).toBe('Service A');
+  });
+});

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -1,3 +1,4 @@
+import { Swagger } from '@atlassian/atlassian-openapi';
 import { OpenApiDocument } from './oas31';
 
 import { ServersStrategy } from './servers';
@@ -134,6 +135,19 @@ export type MergeInput = Array<SingleMergeInput>;
  * existed before the option did, so `merge(inputs)` is unchanged.
  */
 export interface MergeOptions {
+  /**
+   * Override fields of the merged `info` object (issue #102).
+   *
+   * `info` is otherwise taken from the first input, so a merged document is
+   * titled after whichever service happens to be listed first -- misleading for
+   * an aggregate API that is none of its inputs.
+   *
+   * Merged field by field, so overriding only `title` does not require
+   * restating the required `version`. Applied after description appending, so
+   * an explicit `description` wins over the appended one.
+   */
+  info?: Partial<Swagger.Info>;
+
   /**
    * How to combine the top-level `servers` array. Defaults to `'first'`.
    * See {@link ServersStrategy} for why that is the default (issue #4).

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -67,7 +67,7 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
       // The version the inputs actually declared, rather than a hard-coded
       // 3.0.3. Well defined because every input shares a major.minor by now.
       openapi: negotiateOutputVersion(inputs) ?? '3.0.3',
-      info: mergeInfos(inputs),
+      info: mergeInfos(inputs, options?.info),
       servers: mergeServers(inputs, options?.serversStrategy),
       externalDocs: getFirstMatching(inputs, input => input.oas.externalDocs),
       security: getFirstMatching(inputs, input => input.oas.security),

--- a/packages/openapi-merge/src/info.ts
+++ b/packages/openapi-merge/src/info.ts
@@ -23,7 +23,7 @@ function getInfoDescriptionWithHeading(mergeInput: SingleMergeInput): string | u
   return `${'#'.repeat(headingLevel)} ${title.value}\n\n${trimmedDescription}`;
 }
 
-export function mergeInfos(mergeInput: MergeInput): Swagger.Info {
+export function mergeInfos(mergeInput: MergeInput, override?: Partial<Swagger.Info>): Swagger.Info {
   const finalInfo = _.cloneDeep(mergeInput[0].oas.info);
 
   const appendedDescriptions = mergeInput
@@ -33,6 +33,26 @@ export function mergeInfos(mergeInput: MergeInput): Swagger.Info {
 
   if (appendedDescriptions.length > 0) {
     finalInfo.description = appendedDescriptions.join('\n\n');
+  }
+
+  // Applied last, so it wins over both first-input-wins and the appended
+  // descriptions (issue #102). An aggregate of several services is not any one
+  // of them, and its title should say so rather than name whichever input
+  // happened to be listed first.
+  //
+  // Merged field by field rather than replacing `info` wholesale: someone
+  // overriding only the title should not have to restate `version`, which is
+  // required. Only keys actually present override -- an explicit `undefined`
+  // does not blank out an input's value, because a config file cannot express
+  // the difference between "absent" and "explicitly undefined" and the
+  // surprising reading is the destructive one.
+  if (override !== undefined) {
+    for (const key of Object.keys(override) as Array<keyof Swagger.Info>) {
+      const value = override[key];
+      if (value !== undefined) {
+        (finalInfo as unknown as Record<string, unknown>)[key] = value;
+      }
+    }
   }
 
   return finalInfo;


### PR DESCRIPTION
Closes #102.

`info` was taken from the first input, so a merged document ended up titled after whichever service happened to be listed first — describing itself as something it isn't. Adds `info` to the merge options, with the CLI passing it through from the config file.

### Three decisions worth stating

- **Merged field by field, not replaced wholesale.** Overriding just the title shouldn't require restating `version`, which the spec requires — making people restate it silently invites a wrong number.
- **An explicitly `undefined` field doesn't blank the value.** A config file can't express the difference between *absent* and *explicitly undefined*, and between the two readings the destructive one is the surprising one.
- **Applied after description appending**, so an explicit `description` beats an appended one, while an override that says nothing about `description` leaves appending intact. Both directions tested — this is the one interaction where the new feature could quietly undo an existing one.

### CLI surface is deliberately narrow

`title`, `version`, `description` — not the whole Info object. `contact` and `licence` are available to library callers but aren't worth the generated-schema surface. Keeping it small is also what lets `--noExtraProps` turn a typo like `titel` into an error instead of a silent no-op. There's a test for that.

### Verification

- 8 library tests in `document-metadata.test.ts`; **5 fail against `origin/main`**
- 3 CLI tests including the typo case
- Gate green: lint, 395 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)