### PR TITLE
fix(merge): deduplicate operationIds inside callbacks (#105)

### DIFF
--- a/ai-planning/issues/07-proposal-105-callback-operationid.md
+++ b/ai-planning/issues/07-proposal-105-callback-operationid.md
@@ -2,7 +2,7 @@
 
 **Issue Link:** https://github.com/robertmassaioli/openapi-merge/issues/105
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 / **Effort:** 2
 
@@ -400,3 +400,41 @@ Recommend bundling #40, #99, #105, #106, and #111 into a single minor release ("
 3. **Import scope:** Ensure `TC` is in scope; it's already imported in most modules.
 4. **Deployment:** This is a bug fix, not a breaking change. Consider a patch or minor version bump depending on release strategy.
 5. **Documentation:** Update the CHANGELOG to note that callback operationIds are now included in dispute resolution.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/105-callback-operationid`. `ensureUniqueOperationIds` now descends
+into each operation's `callbacks`.
+
+### 10.1 One namespace, not a separate one
+
+The specification says an operationId must be "unique among all operations
+described in the API". A callback operation is one of them, so callback ids
+share the single `seenOperationIds` set with everything else rather than getting
+their own. A callback id colliding with an ordinary operation id is
+disambiguated, and there is a test for that specific case — it is the one a
+separate namespace would get wrong.
+
+### 10.2 A `$ref` callback is not descended into
+
+Its operations live in the component it points at, and that component is
+already walked in its own right. Descending here would count them twice and
+rename the second copy for colliding with the first. Tested.
+
+### 10.3 Also covers collisions inside a single input
+
+Two callbacks on the same operation declaring the same id are a duplicate in the
+same document, so the second is disambiguated even with one input. Not something
+the proposal mentions; it falls out of using the same set, and is tested so it
+stays deliberate.
+
+### 10.4 Verification
+
+- 6 tests in `operation-ids.test.ts`, the suite that owns id uniqueness.
+  **4 fail against `origin/main`**, confirmed in a detached worktree; the other
+  two assert what must *not* change — a non-colliding id, and a `$ref` callback
+  left alone.
+- Gate green: lint, 390 tests, 48 artifact checks.

--- a/packages/openapi-merge/src/__tests__/operation-ids.test.ts
+++ b/packages/openapi-merge/src/__tests__/operation-ids.test.ts
@@ -3,7 +3,7 @@ import { Swagger } from '@atlassian/atlassian-openapi';
 import { SingleMergeInput } from '../data';
 import { toOAS } from './_helpers/oas-generation';
 import { toMergeInputs } from './_helpers/test-utils';
-import { doc30, doc32, expectSuccess, ok, op, pathKeys } from './_helpers/documents';
+import { at, doc30, doc32, expectSuccess, ok, op, pathKeys } from './_helpers/documents';
 
 /**
  * operationId uniqueness.
@@ -100,5 +100,124 @@ describe('3.0 edge: operationId uniqueness', () => {
     ]));
 
     expect(pathKeys(output)).toEqual(['/a', '/b']);
+  });
+});
+
+/**
+ * Issue #105: operationIds inside callbacks.
+ *
+ * The spec requires an operationId to be "unique among all operations described
+ * in the API", and an operation inside a Callback Object is one of them -- a
+ * Callback is a map of runtime expressions to Path Items, and those hold real
+ * operations. They were skipped, so two inputs declaring the same callback
+ * operationId produced a document with a duplicate: invalid, and silently so.
+ *
+ * References inside callbacks were already rewritten correctly, which made this
+ * the one remaining callback-shaped gap.
+ */
+describe('callback operationIds (issue #105)', () => {
+  const withCallback = (outerId: string, callbackId: string) => ({
+    paths: {
+      [`/${outerId}`]: {
+        post: {
+          operationId: outerId,
+          responses: ok,
+          callbacks: {
+            onEvent: {
+              '{$request.body#/callbackUrl}': {
+                post: { operationId: callbackId, responses: ok },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const callbackOpId = (output: ReturnType<typeof expectSuccess>, path: string): unknown =>
+    at(output.paths?.[path], 'post', 'callbacks', 'onEvent', '{$request.body#/callbackUrl}', 'post', 'operationId');
+
+  it('disambiguates a callback operationId that collides across inputs', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30(withCallback('first', 'onData')) },
+        { oas: doc30(withCallback('second', 'onData')) },
+      ]),
+    );
+
+    expect(callbackOpId(output, '/first')).toBe('onData');
+    expect(callbackOpId(output, '/second')).toBe('onData1');
+  });
+
+  it('disambiguates a callback id colliding with a top-level operation id', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('onData') } } }) },
+        { oas: doc30(withCallback('second', 'onData')) },
+      ]),
+    );
+
+    // Same namespace: the spec does not have a separate one for callbacks.
+    expect(callbackOpId(output, '/second')).toBe('onData1');
+  });
+
+  it('applies a dispute prefix to a callback operationId', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30(withCallback('first', 'onData')) },
+        { oas: doc30(withCallback('second', 'onData')), dispute: { prefix: 'Svc' } },
+      ]),
+    );
+
+    expect(callbackOpId(output, '/second')).toBe('SvconData');
+  });
+
+  it('leaves a non-colliding callback operationId alone', () => {
+    const output = expectSuccess(merge([{ oas: doc30(withCallback('first', 'onData')) }]));
+
+    expect(callbackOpId(output, '/first')).toBe('onData');
+  });
+
+  it('handles several callbacks on one operation', () => {
+    const twoCallbacks = {
+      paths: {
+        '/a': {
+          post: {
+            operationId: 'a',
+            responses: ok,
+            callbacks: {
+              onOne: { '{$request.body#/u}': { post: { operationId: 'shared', responses: ok } } },
+              onTwo: { '{$request.body#/v}': { post: { operationId: 'shared', responses: ok } } },
+            },
+          },
+        },
+      },
+    };
+
+    const output = expectSuccess(merge([{ oas: doc30(twoCallbacks) }]));
+
+    // Both are in the same document, so the second must be disambiguated even
+    // within a single input.
+    expect(at(output.paths?.['/a'], 'post', 'callbacks', 'onOne', '{$request.body#/u}', 'post', 'operationId')).toBe('shared');
+    expect(at(output.paths?.['/a'], 'post', 'callbacks', 'onTwo', '{$request.body#/v}', 'post', 'operationId')).toBe('shared1');
+  });
+
+  it('does not descend into a $ref callback', () => {
+    // The operations live in the component it points at, and that component is
+    // walked in its own right -- descending here would count them twice.
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/a': { post: { operationId: 'a', responses: ok, callbacks: { onEvent: { $ref: '#/components/callbacks/Shared' } } } } },
+            components: {
+              callbacks: { Shared: { '{$request.body#/u}': { post: { operationId: 'onShared', responses: ok } } } },
+            },
+          }),
+        },
+      ]),
+    );
+
+    expect(at(output.paths?.['/a'], 'post', 'callbacks', 'onEvent', '$ref')).toBe('#/components/callbacks/Shared');
   });
 });

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -1,5 +1,5 @@
 import { MergeInput, ErrorMergeResult, Dispute } from "./data";
-import { Swagger, SwaggerLookup } from "@atlassian/atlassian-openapi";
+import { Swagger, SwaggerLookup, SwaggerTypeChecks } from "@atlassian/atlassian-openapi";
 import { walkAllReferences } from "./reference-walker";
 import _ from 'lodash';
 import { runOperationSelection } from "./operation-selection";
@@ -158,11 +158,61 @@ function ensureUniqueOperationIds(pathItem: PathItem32, seenOperationIds: Set<st
   const operations = getPathItemOperations(pathItem);
 
   for (let opIndex = 0; opIndex < operations.length; opIndex++) {
-    const result = ensureUniqueOperationId(operations[opIndex].operation, seenOperationIds, dispute);
+    const { operation } = operations[opIndex];
+
+    const result = ensureUniqueOperationId(operation, seenOperationIds, dispute);
     if (result !== undefined) {
       return result;
     }
+
+    const callbackError = ensureUniqueCallbackOperationIds(operation, seenOperationIds, dispute);
+    if (callbackError !== undefined) {
+      return callbackError;
+    }
   }
+}
+
+/**
+ * Operation IDs nested inside an operation's `callbacks` (issue #105).
+ *
+ * The specification requires an operationId to be "unique among all operations
+ * described in the API", and an operation inside a Callback Object is one of
+ * them -- a Callback is a map of runtime expressions to Path Items, and those
+ * Path Items hold real operations.
+ *
+ * They were skipped, so two inputs declaring the same callback operationId
+ * produced a document with a duplicate: invalid, and silently so. References
+ * inside callbacks were already rewritten correctly, which made this the one
+ * remaining callback-shaped gap.
+ *
+ * A `$ref` callback is left alone: the operations live in the component it
+ * points at, and that component is walked in its own right.
+ */
+function ensureUniqueCallbackOperationIds(
+  operation: Swagger.Operation,
+  seenOperationIds: Set<string>,
+  dispute: Dispute | undefined,
+): ErrorMergeResult | undefined {
+  const callbacks = operation.callbacks;
+  if (callbacks === undefined) {
+    return undefined;
+  }
+
+  for (const callbackName of Object.keys(callbacks)) {
+    const callback = callbacks[callbackName];
+    if (SwaggerTypeChecks.isReference(callback)) {
+      continue;
+    }
+
+    for (const expression of Object.keys(callback)) {
+      const result = ensureUniqueOperationIds(callback[expression] as PathItem32, seenOperationIds, dispute);
+      if (result !== undefined) {
+        return result;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #105.

The spec requires an operationId to be *"unique among all operations described in the API"*, and an operation inside a Callback Object is one of them — a Callback is a map of runtime expressions to Path Items, and those hold real operations.

They were skipped, so two inputs declaring the same callback operationId produced a document containing a duplicate: **invalid, and silently so.**

References inside callbacks were already rewritten correctly, which made this the last callback-shaped gap.

### One namespace, not a separate one

Callback ids share the single `seenOperationIds` set, because the spec has one namespace. So a callback id colliding with an *ordinary* operation id is disambiguated too — there's a test for that case specifically, since it's the one a separate namespace would get wrong.

### A `$ref` callback isn't descended into

Its operations live in the component it points at, which is already walked in its own right. Descending would count them twice and rename the second copy for colliding with the first. Tested.

### Also covers collisions within a single input

Two callbacks on one operation declaring the same id. That falls out of sharing the set rather than being designed, so it's tested to keep it deliberate.

### Verification

- 6 tests in `operation-ids.test.ts`; **4 fail against `origin/main`**
- The other two assert what must *not* change: a non-colliding id, and the `$ref` callback
- Gate green: lint, 390 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)