### PR TITLE
feat(merge): support wildcards in includeTags and excludeTags (#111)

### DIFF
--- a/ai-planning/issues/08-proposal-111-wildcard-tags.md
+++ b/ai-planning/issues/08-proposal-111-wildcard-tags.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#111 — Support wildcards in include/excludeTags](https://github.com/robertmassaioli/openapi-merge/issues/111)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 / **Effort:** 2 / **ROI:** 6 / **Quadrant:** Quick Win
 
@@ -414,3 +414,57 @@ This includes operations tagged with `public-users`, `public-posts`, `admin`, et
 5. Follows user expectations (glob syntax is intuitive).
 
 **Recommendation:** Implement Option A (glob-style wildcards) immediately. Defer Option B (regex) and Option C (both) to a future v2 minor release pending user feedback.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/111-wildcard-tags`. A `TagMatcher` in a new `tag-matching.ts`,
+used by both the operation filter and the top-level tag list.
+
+### 10.1 Only `*`, deliberately
+
+Not `?`, not character classes, not regular expressions. Tag names are short
+identifiers and `service-*` is the whole of what was asked for. Accepting
+regular expressions would silently reinterpret every existing configuration's
+tags as patterns, giving new meaning to characters people did not know were
+significant — `v1.0` would start matching `v1x0`.
+
+For the same reason the pattern is escaped before `*` is reintroduced, so a tag
+containing `.`, `+` or `(` matches literally. Tested both ways.
+
+### 10.2 Anchored at both ends
+
+`service-*` does not match `my-service-a`. An unanchored match would mean
+excluding one team's tags quietly took another team's with them, which is
+exactly the silent-wrong-output failure the tag mechanism exists to prevent.
+
+### 10.3 The top-level `tags` list uses the same matcher
+
+Not mentioned in the proposal, and it would have been a visible bug: a wildcard
+would have removed the operations while leaving their tag declarations in the
+output, describing tags the document no longer uses. Exact tags were already
+filtered there; wildcards had to be too.
+
+### 10.4 A pre-existing gap this surfaced
+
+`dropPathItemsWithNoOperations` only looked at `paths`. An `excludeTags` rule
+that emptied a **webhook** left `{ ping: {} }` behind — an event the document
+announces and then says nothing about — while the equivalent path was dropped.
+Predates this issue; found by the wildcard webhook test and fixed here, because
+a test asserting the empty webhook was acceptable would have pinned a defect.
+
+Extending that loop then broke an existing test for an input with `paths: null`,
+which the old `for...in` tolerated and `Object.keys` does not. Guarded, and
+worth noting as the second time this sweep that an old test has caught a
+plausible-looking rewrite.
+
+### 10.5 Verification
+
+- 11 unit tests in `tag-matching.test.ts`, weighted towards what must *not*
+  match: anchoring, and regex syntax treated literally.
+- 6 in `operation-selection.test.ts` driving a real merge, including webhooks
+  and the top-level tag list. **5 fail against `origin/main`**; the sixth
+  asserts exact tags are unchanged.
+- Gate green: lint, 401 tests, 48 artifact checks.

--- a/packages/openapi-merge/src/__tests__/operation-selection.test.ts
+++ b/packages/openapi-merge/src/__tests__/operation-selection.test.ts
@@ -1,7 +1,7 @@
 import { merge } from '../index';
 import { toOAS } from './_helpers/oas-generation';
 import { expectMergeResult } from './_helpers/test-utils';
-import { doc32, expectSuccess, op } from './_helpers/documents';
+import { doc30, doc31, doc32, expectSuccess, op, pathKeys, tagged } from './_helpers/documents';
 
 /**
  * Operation selection: filtering operations by tag via `includeTags` and
@@ -389,5 +389,83 @@ describe('3.2 - tag selection covers the new slots', () => {
 
     expect(output.paths?.['/search'].query).toBeDefined();
     expect(output.paths?.['/search'].get).toBeUndefined();
+  });
+});
+
+/**
+ * Issue #111: wildcards driving a real merge.
+ *
+ * Tag selection was exact-match, so a team with `service-a`, `service-b`, …
+ * had to enumerate every tag and update the config whenever one appeared.
+ * Forgetting silently includes or excludes the wrong operations.
+ */
+describe('wildcard tag selection (issue #111)', () => {
+  const doc = () =>
+    doc30({
+      paths: {
+        '/a': { get: tagged('a', ['service-a']) },
+        '/b': { get: tagged('b', ['service-b']) },
+        '/other': { get: tagged('other', ['public']) },
+      },
+      tags: [{ name: 'service-a' }, { name: 'service-b' }, { name: 'public' }],
+    });
+
+  it('excludes every tag matching a wildcard', () => {
+    const output = expectSuccess(
+      merge([{ oas: doc(), operationSelection: { excludeTags: ['service-*'] } }]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/other']);
+  });
+
+  it('includes only the tags matching a wildcard', () => {
+    const output = expectSuccess(
+      merge([{ oas: doc(), operationSelection: { includeTags: ['service-*'] } }]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/a', '/b']);
+  });
+
+  it('removes wildcard-excluded tags from the top-level tags list', () => {
+    const output = expectSuccess(
+      merge([{ oas: doc(), operationSelection: { excludeTags: ['service-*'] } }]),
+    );
+
+    // Otherwise the operations go and their declarations stay, describing
+    // tags the document no longer uses.
+    expect(output.tags?.map(t => t.name)).toEqual(['public']);
+  });
+
+  it('still supports exact tags unchanged', () => {
+    const output = expectSuccess(
+      merge([{ oas: doc(), operationSelection: { excludeTags: ['service-a'] } }]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/b', '/other']);
+    expect(output.tags?.map(t => t.name)).toEqual(['service-b', 'public']);
+  });
+
+  it('mixes exact and wildcard patterns in one list', () => {
+    const output = expectSuccess(
+      merge([{ oas: doc(), operationSelection: { excludeTags: ['public', 'service-*'] } }]),
+    );
+
+    expect(pathKeys(output)).toEqual([]);
+  });
+
+  it('applies wildcards to webhook operations too', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc31({
+            paths: {},
+            webhooks: { ping: { post: tagged('ping', ['internal-ping']) }, keep: { post: tagged('keep', ['public']) } },
+          }),
+          operationSelection: { excludeTags: ['internal-*'] },
+        },
+      ]),
+    );
+
+    expect(Object.keys(output.webhooks ?? {})).toEqual(['keep']);
   });
 });

--- a/packages/openapi-merge/src/__tests__/tag-matching.test.ts
+++ b/packages/openapi-merge/src/__tests__/tag-matching.test.ts
@@ -1,0 +1,93 @@
+import { TagMatcher } from '../tag-matching';
+
+/**
+ * Wildcard tag matching (issue #111).
+ *
+ * Unit tests for the matcher itself; operation-selection.test.ts covers it
+ * driving a merge. The cases that matter most here are the ones about *not*
+ * matching: an anchored pattern, and a tag containing regex syntax.
+ */
+describe('TagMatcher (issue #111)', () => {
+  it('matches an exact tag', () => {
+    expect(new TagMatcher(['service-a']).matches('service-a')).toBe(true);
+    expect(new TagMatcher(['service-a']).matches('service-b')).toBe(false);
+  });
+
+  it('matches a trailing wildcard', () => {
+    const matcher = new TagMatcher(['service-*']);
+
+    expect(matcher.matches('service-a')).toBe(true);
+    expect(matcher.matches('service-')).toBe(true);
+    expect(matcher.matches('other')).toBe(false);
+  });
+
+  it('matches a leading wildcard', () => {
+    const matcher = new TagMatcher(['*-internal']);
+
+    expect(matcher.matches('billing-internal')).toBe(true);
+    expect(matcher.matches('internal-billing')).toBe(false);
+  });
+
+  it('matches a wildcard in the middle', () => {
+    const matcher = new TagMatcher(['svc-*-v2']);
+
+    expect(matcher.matches('svc-billing-v2')).toBe(true);
+    // The `*` may match nothing, but the literal hyphens on both sides of it
+    // still have to be there: `svc-*-v2` accepts `svc--v2`, not `svc-v2`.
+    expect(matcher.matches('svc--v2')).toBe(true);
+    expect(matcher.matches('svc-v2')).toBe(false);
+    expect(matcher.matches('svc-billing-v3')).toBe(false);
+  });
+
+  it('is anchored at both ends', () => {
+    // `service-*` must not match `my-service-a`, or excluding one team's tags
+    // would quietly take another team's with it.
+    expect(new TagMatcher(['service-*']).matches('my-service-a')).toBe(false);
+    expect(new TagMatcher(['*-internal']).matches('billing-internal-v2')).toBe(false);
+  });
+
+  it('treats a lone * as matching everything', () => {
+    const matcher = new TagMatcher(['*']);
+
+    expect(matcher.matches('anything')).toBe(true);
+    expect(matcher.matches('')).toBe(true);
+  });
+
+  it('matches a tag containing regex syntax literally', () => {
+    // Without escaping, `v1.0` would also match `v1x0`, and `(beta)` would
+    // match nothing at all.
+    expect(new TagMatcher(['v1.0']).matches('v1.0')).toBe(true);
+    expect(new TagMatcher(['v1.0']).matches('v1x0')).toBe(false);
+    expect(new TagMatcher(['(beta)']).matches('(beta)')).toBe(true);
+    expect(new TagMatcher(['a+b']).matches('a+b')).toBe(true);
+    expect(new TagMatcher(['a+b']).matches('aab')).toBe(false);
+  });
+
+  it('combines a wildcard pattern with regex syntax', () => {
+    const matcher = new TagMatcher(['v1.*']);
+
+    expect(matcher.matches('v1.0')).toBe(true);
+    expect(matcher.matches('v1.10')).toBe(true);
+    expect(matcher.matches('v1x0')).toBe(false);
+  });
+
+  it('matches when any pattern in the list matches', () => {
+    const matcher = new TagMatcher(['exact', 'wild-*']);
+
+    expect(matcher.matches('exact')).toBe(true);
+    expect(matcher.matches('wild-thing')).toBe(true);
+    expect(matcher.matches('neither')).toBe(false);
+  });
+
+  it('reports an empty pattern list as empty', () => {
+    expect(new TagMatcher([]).isEmpty).toBe(true);
+    expect(new TagMatcher(['a']).isEmpty).toBe(false);
+    expect(new TagMatcher(['*']).isEmpty).toBe(false);
+  });
+
+  it('matchesAny handles an operation with no tags', () => {
+    expect(new TagMatcher(['a']).matchesAny(undefined)).toBe(false);
+    expect(new TagMatcher(['a']).matchesAny([])).toBe(false);
+    expect(new TagMatcher(['a']).matchesAny(['b', 'a'])).toBe(true);
+  });
+});

--- a/packages/openapi-merge/src/operation-selection.ts
+++ b/packages/openapi-merge/src/operation-selection.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { Swagger } from "@atlassian/atlassian-openapi";
 import { OperationSelection } from './data';
 import { getPathItemOperations, HttpMethod, OpenApiDocument, PathItem32, PathItemMap } from './oas31';
+import { TagMatcher } from './tag-matching';
 
 /**
  * Remove an operation from a Path Item, whether it sits in a standard method
@@ -15,8 +16,8 @@ function deleteOperation(pathItem: PathItem32, method: string, isAdditional: boo
   }
 }
 
-function operationContainsAnyTag(operation: Swagger.Operation, tags: string[]): boolean {
-  return operation.tags !== undefined && operation.tags.some(tag => tags.includes(tag));
+function operationContainsAnyTag(operation: Swagger.Operation, matcher: TagMatcher): boolean {
+  return matcher.matchesAny(operation.tags);
 }
 
 /**
@@ -60,19 +61,21 @@ function removeOperations(
 }
 
 function dropOperationsThatHaveTags(originalOas: OpenApiDocument, excludedTags: string[]): OpenApiDocument {
-  if (excludedTags.length === 0) {
+  const matcher = new TagMatcher(excludedTags);
+  if (matcher.isEmpty) {
     return originalOas;
   }
 
-  return removeOperations(originalOas, operation => operationContainsAnyTag(operation, excludedTags));
+  return removeOperations(originalOas, operation => operationContainsAnyTag(operation, matcher));
 }
 
 function includeOperationsThatHaveTags(originalOas: OpenApiDocument, includeTags: string[]): OpenApiDocument {
-  if (includeTags.length === 0) {
+  const matcher = new TagMatcher(includeTags);
+  if (matcher.isEmpty) {
     return originalOas;
   }
 
-  return removeOperations(originalOas, operation => !operationContainsAnyTag(operation, includeTags));
+  return removeOperations(originalOas, operation => !operationContainsAnyTag(operation, matcher));
 }
 
 

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -100,13 +100,21 @@ function pathItemHasContent(pathItem: PathItem32): boolean {
 function dropPathItemsWithNoOperations(originalOas: OpenApiDocument): OpenApiDocument {
   const oas = _.cloneDeep(originalOas);
 
-  for (const path in oas.paths) {
-    /* eslint-disable-next-line no-prototype-builtins */
-    if (oas.paths.hasOwnProperty(path)) {
-      const pathItem = oas.paths[path];
+  // Webhooks as well as paths. An `excludeTags` rule that empties a webhook
+  // used to leave `{ ping: {} }` behind -- an event the document announces and
+  // then says nothing about -- while the equivalent path was dropped. Surfaced
+  // by a wildcard test for issue #111; the inconsistency predates it.
+  for (const map of [oas.paths, oas.webhooks]) {
+    // Not just `!== undefined`: a document in the wild can carry `paths: null`,
+    // which the previous `for...in` tolerated silently and `Object.keys` does
+    // not. There is a test for exactly that input, and it caught this.
+    if (map === undefined || map === null) {
+      continue;
+    }
 
-      if (!pathItemHasContent(pathItem)) {
-        delete oas.paths[path];
+    for (const key of Object.keys(map)) {
+      if (!pathItemHasContent(map[key])) {
+        delete map[key];
       }
     }
   }

--- a/packages/openapi-merge/src/tag-matching.ts
+++ b/packages/openapi-merge/src/tag-matching.ts
@@ -1,0 +1,58 @@
+/**
+ * Tag matching for `includeTags` and `excludeTags`, with `*` wildcards
+ * (issue #111).
+ *
+ * Selection was exact-match, so a team with `service-a`, `service-b`, … had to
+ * enumerate every tag and remember to update the configuration whenever one was
+ * added. Forgetting silently includes or excludes the wrong operations, which
+ * is the failure mode the tag mechanism exists to prevent.
+ */
+
+/**
+ * `*` matches any run of characters, including none. Nothing else is special.
+ *
+ * Only `*` is supported — not `?`, not character classes, not full regular
+ * expressions. Tag names are short identifiers and `service-*` is the whole of
+ * what was asked for; accepting regular expressions would make every existing
+ * configuration's tags into patterns whose meaning depends on characters people
+ * did not know were significant.
+ */
+const WILDCARD = '*';
+
+function patternToRegExp(pattern: string): RegExp {
+  // Escape first, so a tag containing regex metacharacters -- `v1.0`, `a+b`,
+  // `(beta)` -- is matched literally, then reintroduce `*` as the one
+  // metacharacter. Anchored: `service-*` must not match `my-service-a`.
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escaped.split('\\*').join('.*')}$`);
+}
+
+/**
+ * A compiled matcher for a list of tag patterns.
+ *
+ * Patterns without a `*` are kept in a Set and matched by equality, so the
+ * overwhelmingly common case costs no more than it did before this feature and
+ * behaves identically -- including for a tag that happens to contain regex
+ * syntax.
+ */
+export class TagMatcher {
+  private readonly exact: Set<string>;
+  private readonly patterns: RegExp[];
+
+  public constructor(tagPatterns: ReadonlyArray<string>) {
+    this.exact = new Set(tagPatterns.filter(pattern => !pattern.includes(WILDCARD)));
+    this.patterns = tagPatterns.filter(pattern => pattern.includes(WILDCARD)).map(patternToRegExp);
+  }
+
+  public get isEmpty(): boolean {
+    return this.exact.size === 0 && this.patterns.length === 0;
+  }
+
+  public matches(tag: string): boolean {
+    return this.exact.has(tag) || this.patterns.some(pattern => pattern.test(tag));
+  }
+
+  public matchesAny(tags: ReadonlyArray<string> | undefined): boolean {
+    return tags !== undefined && tags.some(tag => this.matches(tag));
+  }
+}

--- a/packages/openapi-merge/src/tags.ts
+++ b/packages/openapi-merge/src/tags.ts
@@ -1,12 +1,17 @@
 import { MergeInput } from './data';
 import { Tag32 } from './oas31';
+import { TagMatcher } from './tag-matching';
 
 function getNonExcludedTags(originalTags: Tag32[], excludedTagNames: string[]): Tag32[] {
-  if (excludedTagNames.length === 0) {
+  // The same matcher the operation filter uses, so a wildcard cannot remove the
+  // operations while leaving their tag declarations behind in the output
+  // (issue #111).
+  const matcher = new TagMatcher(excludedTagNames);
+  if (matcher.isEmpty) {
     return originalTags;
   }
 
-  return originalTags.filter(tag => !excludedTagNames.includes(tag.name));
+  return originalTags.filter(tag => !matcher.matches(tag.name));
 }
 
 export function mergeTags(inputs: MergeInput): Tag32[] | undefined {


### PR DESCRIPTION
Closes #111.

Tag selection was exact-match, so a team with `service-a`, `service-b`, … had to enumerate every tag and update the config whenever one appeared. Forgetting silently includes or excludes the wrong operations.

### Only `*`, deliberately

Not `?`, not character classes, not regular expressions. Tag names are short identifiers and `service-*` is what was asked for. Accepting regexes would silently reinterpret every existing config's tags as patterns — `v1.0` would start matching `v1x0`.

For the same reason patterns are **escaped before `*` is reintroduced**, so a tag containing `.`, `+` or `(` matches literally. And they're **anchored at both ends**: `service-*` must not match `my-service-a`, or excluding one team's tags would quietly take another team's with them.

### The top-level `tags` list uses the same matcher

Not in the proposal, and it would have been a visible bug: a wildcard would remove the operations while leaving their tag declarations behind, describing tags the document no longer uses.

### Two pre-existing things this surfaced

- **`dropPathItemsWithNoOperations` only looked at `paths`.** An `excludeTags` rule that emptied a *webhook* left `{ ping: {} }` behind — an event the document announces then says nothing about — while the equivalent path was dropped. Fixed here, because a test accepting the empty webhook would have pinned a defect.
- Extending that loop then **broke an existing test for `paths: null`**, which the old `for...in` tolerated and `Object.keys` doesn't. Guarded. Second time this sweep an old test has caught a plausible-looking rewrite.

### Verification

- 11 unit tests in `tag-matching.test.ts`, weighted towards what must *not* match
- 6 in `operation-selection.test.ts` driving a real merge; **5 fail against `origin/main`**
- Gate green: lint, 401 tests, 48 artifact checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)