### PR TITLE
feat(merge): per-input tag injection (#112)

### DIFF
--- a/ai-planning/issues/15-proposal-112-merge-into-tag.md
+++ b/ai-planning/issues/15-proposal-112-merge-into-tag.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#112 — Option to merge an input into a tag](https://github.com/robertmassaioli/openapi-merge/issues/112)
 
-**Status:** Proposal
+**Status:** ✅ Implemented — see §10
 
 **Value:** 4 / **Effort:** 3 / **ROI:** 5 / **Quadrant:** Big Bet (low)
 
@@ -481,3 +481,61 @@ Update the "Key types" section of "The `openapi-merge` Library" to document `Tag
 **Value:** 4 (users get a powerful per-input tag-injection feature; improves UI organization in API gateways)  
 **Effort:** 3 (well-defined scope; reuses existing markdown-heading logic; ~3 hours coding)  
 **ROI:** 5 (4 ÷ 3 ≈ 1.33, high impact relative to effort)
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/112-merge-into-tag`. §3.1's `TagInjection` with `name` and
+`description`, and §3.2's per-input `tag` field.
+
+### 10.1 `appendInfoDescription` not implemented
+
+§3.1 also proposes a flag appending the input's `info.description` to the tag's
+description, using `DescriptionMergeBehaviour`'s heading rules. Left out.
+
+It duplicates an existing mechanism against a different target, and the two
+would then disagree about what a heading level means depending on where the
+text landed. Nobody has asked for it; `description` covers the stated need, and
+a second description-assembly path is worth avoiding until someone does.
+
+### 10.2 Ordering: after selection, and after empty path items are dropped
+
+§3.2 says "after operationSelection filtering", which is right and worth
+spelling out. Injecting first would let `includeTags: ['billing']` match
+operations *because this input injects `billing`* — a filter that appears to do
+nothing and quietly keeps everything. Running after the empty-path-item drop
+also means nothing is tagged that is not in the output. Both are tested.
+
+### 10.3 Appended, never replacing
+
+An operation's own tags say what it does; the injected one says where it came
+from. Both are worth keeping, and a document that lost the former would be far
+less useful than one that never gained the latter. A tag the operation already
+carries is not added twice — that would be an invalid duplicate.
+
+### 10.4 The tag is declared, not just applied
+
+Not in the proposal. Operations carrying a tag the document never declares is
+legal but unhelpful: anything building navigation from `tags` shows a heading
+with no description, or omits the group. The injected tag is added to the
+top-level `tags` array, before the input's own declarations so it reads as the
+grouping it is, and first-wins if two inputs inject the same name.
+
+### 10.5 Verification
+
+- 11 tests in `tag-injection.test.ts`. **9 fail against `origin/main`**,
+  confirmed in a detached worktree.
+- Cover: appending to existing tags, no duplicate, the top-level declaration
+  with and without a description, first-wins across inputs, webhooks, input
+  immutability, and the ordering guarantee in §10.2.
+- 3 CLI tests including ajv rejecting a missing and an empty tag name.
+- Gate green: lint, 398 tests, 48 artifact checks.
+
+### 10.6 Completes the tag trio
+
+With #100 (tag-based path selection) and #111 (wildcards), this is the third of
+three features on the same tag machinery. Injection is the write side of what
+those two read: an input can now be tagged on the way in and filtered by that
+tag downstream.

--- a/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-merging.test.ts
@@ -130,3 +130,47 @@ describe('main - serversStrategy (issue #4)', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
   });
 });
+
+/**
+ * Issue #112: per-input tag injection reaching the library from a config file.
+ */
+describe('main - tag injection (issue #112)', () => {
+  it('tags every operation from the configured input', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    cli.writeJson('b.json', oas({ '/b': getPath('getB') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [
+        { inputFile: './a.json', tag: { name: 'service-a', description: 'Service A.' } },
+        { inputFile: './b.json' },
+      ],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read());
+    expect(output.paths['/a'].get.tags).toEqual(['service-a']);
+    expect(output.paths['/b'].get.tags).toBeUndefined();
+    expect(output.tags).toEqual([{ name: 'service-a', description: 'Service A.' }]);
+  });
+
+  it('rejects a tag injection with no name against the generated schema', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json', tag: { description: 'no name' } }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+
+  it('rejects an empty tag name', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json', tag: { name: '' } }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -143,7 +143,36 @@ export interface ConfigurationInputBase {
    * @examples require('./examples-for-schema.ts').DescriptionMergeBehaviourExamples
    */
   description?: DescriptionMergeBehaviour;
+
+  /**
+   * Add a tag to every operation from this input (issue #112).
+   *
+   * Lets the merged document say which service an operation came from without
+   * editing the upstream specification. Applied after `operationSelection`, so
+   * the injected tag cannot influence which operations survive.
+   *
+   * @examples require('./examples-for-schema.ts').TagInjectionExamples
+   */
+  tag?: TagInjectionConfig;
 }
+
+/**
+ * A tag applied to every operation from one input.
+ */
+export type TagInjectionConfig = {
+  /**
+   * The tag name to add.
+   *
+   * @minLength 1
+   */
+  name: string;
+
+  /**
+   * Description for the tag in the merged document's top-level `tags` array.
+   * First-wins if another input injects the same name.
+   */
+  description?: string;
+};
 
 /**
  * A single Configuration input from a File.

--- a/packages/openapi-merge-cli/src/examples-for-schema.ts
+++ b/packages/openapi-merge-cli/src/examples-for-schema.ts
@@ -117,3 +117,8 @@ export const ConfigurationInputExamples: Array<Array<ConfigurationInput>> = [
     }
   ]
 ];
+/** Per-input tag injection (issue #112). */
+export const TagInjectionExamples: Array<{ name: string; description?: string }> = [
+  { name: 'billing' },
+  { name: 'billing', description: 'Everything served by the billing service.' },
+];

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -165,6 +165,7 @@ async function convertInputs(basePath: string, configInputs: ConfigurationInput[
         pathModification: input.pathModification,
         operationSelection: input.operationSelection,
         description: input.description,
+        tag: input.tag,
       };
 
       if ('dispute' in input) {

--- a/packages/openapi-merge/src/__tests__/tag-injection.test.ts
+++ b/packages/openapi-merge/src/__tests__/tag-injection.test.ts
@@ -1,0 +1,158 @@
+import { merge } from '../index';
+import { doc30, doc31, expectSuccess, ok, op, tagged } from './_helpers/documents';
+
+/**
+ * Issue #112: tagging every operation from one input.
+ *
+ * Lets a merged document say which service an operation came from without
+ * anyone editing the upstream specifications, which are usually owned by
+ * another team. The complement to the tag *filtering* in #100 and #111.
+ */
+describe('tag injection (issue #112)', () => {
+  const opTags = (output: ReturnType<typeof expectSuccess>, path: string): string[] | undefined =>
+    output.paths?.[path]?.get?.tags;
+
+  it('adds the tag to every operation from that input', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: op('a') }, '/b': { get: op('b') } } }),
+          tag: { name: 'billing' },
+        },
+      ]),
+    );
+
+    expect(opTags(output, '/a')).toEqual(['billing']);
+    expect(opTags(output, '/b')).toEqual(['billing']);
+  });
+
+  it('leaves other inputs untagged', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('a') } } }), tag: { name: 'billing' } },
+        { oas: doc30({ paths: { '/b': { get: op('b') } } }) },
+      ]),
+    );
+
+    expect(opTags(output, '/a')).toEqual(['billing']);
+    expect(opTags(output, '/b')).toBeUndefined();
+  });
+
+  it("appends to an operation's existing tags rather than replacing them", () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: tagged('a', ['reports']) } } }),
+          tag: { name: 'billing' },
+        },
+      ]),
+    );
+
+    // The operation's own tags say what it does; the injected one says where it
+    // came from. Both are worth keeping.
+    expect(opTags(output, '/a')).toEqual(['reports', 'billing']);
+  });
+
+  it('does not duplicate a tag the operation already carries', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: tagged('a', ['billing']) } } }),
+          tag: { name: 'billing' },
+        },
+      ]),
+    );
+
+    expect(opTags(output, '/a')).toEqual(['billing']);
+  });
+
+  it('declares the injected tag in the top-level tags array', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: op('a') } } }),
+          tag: { name: 'billing', description: 'The billing service.' },
+        },
+      ]),
+    );
+
+    // Operations carrying a tag the document never declares is legal but
+    // unhelpful for anything building navigation from `tags`.
+    expect(output.tags).toEqual([{ name: 'billing', description: 'The billing service.' }]);
+  });
+
+  it('omits the description key entirely when none is given', () => {
+    const output = expectSuccess(
+      merge([{ oas: doc30({ paths: { '/a': { get: op('a') } } }), tag: { name: 'billing' } }]),
+    );
+
+    expect(output.tags).toEqual([{ name: 'billing' }]);
+  });
+
+  it('keeps the first description when two inputs inject the same tag', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: doc30({ paths: { '/a': { get: op('a') } } }), tag: { name: 'shared', description: 'First.' } },
+        { oas: doc30({ paths: { '/b': { get: op('b') } } }), tag: { name: 'shared', description: 'Second.' } },
+      ]),
+    );
+
+    expect(output.tags).toEqual([{ name: 'shared', description: 'First.' }]);
+    expect(opTags(output, '/a')).toEqual(['shared']);
+    expect(opTags(output, '/b')).toEqual(['shared']);
+  });
+
+  it('keeps an input\'s own tag declarations alongside the injected one', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/a': { get: tagged('a', ['reports']) } },
+            tags: [{ name: 'reports', description: 'Reporting.' }],
+          }),
+          tag: { name: 'billing' },
+        },
+      ]),
+    );
+
+    expect(output.tags).toEqual([{ name: 'billing' }, { name: 'reports', description: 'Reporting.' }]);
+  });
+
+  it('runs after operationSelection, so the injected tag cannot affect filtering', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/keep': { get: tagged('keep', ['public']) }, '/drop': { get: tagged('drop', ['internal']) } } }),
+          operationSelection: { includeTags: ['public'] },
+          tag: { name: 'internal' },
+        },
+      ]),
+    );
+
+    // `/drop` is excluded because includeTags saw only the author's tags.
+    // Injecting first would have made includeTags: ['internal'] match
+    // everything -- a filter that appears to do nothing.
+    expect(Object.keys(output.paths ?? {})).toEqual(['/keep']);
+    expect(opTags(output, '/keep')).toEqual(['public', 'internal']);
+  });
+
+  it('tags webhook operations too', () => {
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc31({ paths: {}, webhooks: { ping: { post: { operationId: 'ping', responses: ok } } } }),
+          tag: { name: 'billing' },
+        },
+      ]),
+    );
+
+    expect(output.webhooks?.ping?.post?.tags).toEqual(['billing']);
+  });
+
+  it('does not mutate the input document', () => {
+    const input = { oas: doc30({ paths: { '/a': { get: op('a') } } }), tag: { name: 'billing' } };
+    merge([input]);
+
+    expect(input.oas.paths?.['/a']?.get?.tags).toBeUndefined();
+  });
+});

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -40,6 +40,30 @@ export interface DisputeSuffix extends DisputeBase {
 
 export type Dispute = DisputePrefix | DisputeSuffix;
 
+/**
+ * A tag applied to every operation coming from one input (issue #112).
+ *
+ * Lets a merged document distinguish which service each operation came from
+ * without anybody editing the upstream specifications -- which is the point,
+ * since those are usually owned by another team.
+ */
+export type TagInjection = {
+  /**
+   * The tag to add to every operation from this input.
+   *
+   * @minLength 1
+   */
+  name: string;
+
+  /**
+   * Description for this tag in the output's top-level `tags` array.
+   *
+   * Ignored if another input already contributed a tag of the same name --
+   * first-wins, as everywhere else in this merge.
+   */
+  description?: string;
+};
+
 export interface SingleMergeInputBase {
   oas: OpenApiDocument;
 
@@ -56,6 +80,16 @@ export interface SingleMergeInputBase {
    * into the final resulting OpenAPI file
    */
   description?: DescriptionMergeBehaviour;
+
+  /**
+   * Add a tag to every operation from this input (issue #112).
+   *
+   * Applied *after* `operationSelection`, so an injected tag cannot influence
+   * the include/exclude rules that decided which operations survive. Injecting
+   * first would make `includeTags: ['billing']` match operations solely because
+   * this input injects `billing`, which reads as a filter doing nothing.
+   */
+  tag?: TagInjection;
 }
 
 /**

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -3,6 +3,7 @@ import { Swagger, SwaggerLookup } from "@atlassian/atlassian-openapi";
 import { walkAllReferences } from "./reference-walker";
 import _ from 'lodash';
 import { runOperationSelection } from "./operation-selection";
+import { injectTag } from './tag-injection';
 import { deepEquality } from "./component-equivalence";
 import { applyDispute, getDispute } from './dispute';
 import { Components31, getPathItemOperations, getPaths, getWebhooks, OpenApiDocument, PathItem32, PathItemMap } from './oas31';
@@ -190,7 +191,13 @@ export function mergePathsAndComponents(inputs: MergeInput): PathAndComponents |
     const { oas: originalOas, pathModification, operationSelection } = input;
     const dispute = getDispute(input);
 
-    const oas = dropPathItemsWithNoOperations(runOperationSelection(_.cloneDeep(originalOas), operationSelection));
+    // Tag injection comes last: after selection has decided what survives, and
+    // after empty path items are dropped, so nothing is tagged that is not in
+    // the output (issue #112).
+    const oas = injectTag(
+      dropPathItemsWithNoOperations(runOperationSelection(_.cloneDeep(originalOas), operationSelection)),
+      input.tag,
+    );
 
     // Original references will be transformed to new non-conflicting references
     const referenceModification: { [originalReference: string]: string } = {};

--- a/packages/openapi-merge/src/tag-injection.ts
+++ b/packages/openapi-merge/src/tag-injection.ts
@@ -1,0 +1,47 @@
+import _ from 'lodash';
+import { TagInjection } from './data';
+import { getPathItemOperations, OpenApiDocument } from './oas31';
+
+/**
+ * Adds an input's configured tag to every operation it contributes (issue #112).
+ *
+ * The merged document can then say which service an operation came from without
+ * anyone editing the upstream specifications, which are usually owned by
+ * somebody else.
+ *
+ * Runs after `operationSelection`, so the injected tag cannot influence the
+ * rules that decided which operations survive. Injecting first would let
+ * `includeTags: ['billing']` match operations only because this input injects
+ * `billing` -- a filter that appears to do nothing.
+ *
+ * Appended rather than replacing: an operation's own tags say what it does, and
+ * the injected one says where it came from. Both are worth keeping, and a
+ * document that lost the former would be much less useful than one that never
+ * had the latter.
+ */
+export function injectTag(originalOas: OpenApiDocument, tag: TagInjection | undefined): OpenApiDocument {
+  if (tag === undefined) {
+    return originalOas;
+  }
+
+  const oas = _.cloneDeep(originalOas);
+
+  for (const map of [oas.paths, oas.webhooks]) {
+    if (map === undefined || map === null) {
+      continue;
+    }
+
+    for (const key of Object.keys(map)) {
+      for (const { operation } of getPathItemOperations(map[key])) {
+        const existing = operation.tags ?? [];
+        // Already tagged by the author: adding it twice would be an invalid
+        // duplicate in the operation's tag list.
+        if (!existing.includes(tag.name)) {
+          operation.tags = [...existing, tag.name];
+        }
+      }
+    }
+  }
+
+  return oas;
+}

--- a/packages/openapi-merge/src/tags.ts
+++ b/packages/openapi-merge/src/tags.ts
@@ -16,6 +16,23 @@ export function mergeTags(inputs: MergeInput): Tag32[] | undefined {
   inputs.forEach(input => {
     const { operationSelection } = input;
     const { tags } = input.oas;
+
+    // An injected tag has to be declared as well as applied (issue #112).
+    // Operations carrying a tag the document never declares is legal but
+    // unhelpful: tooling that builds navigation from `tags` would show the
+    // operations under a heading with no description, or not at all.
+    //
+    // Declared before this input's own tags so it reads as the grouping it is,
+    // and first-wins if another input already contributed the same name.
+    if (input.tag !== undefined && !seenTags.has(input.tag.name)) {
+      seenTags.add(input.tag.name);
+      result.push(
+        input.tag.description === undefined
+          ? { name: input.tag.name }
+          : { name: input.tag.name, description: input.tag.description },
+      );
+    }
+
     if (tags !== undefined) {
       const excludeTags = operationSelection !== undefined && operationSelection.excludeTags !== undefined ? operationSelection.excludeTags : [];
       const nonExcludedTags = getNonExcludedTags(tags, excludeTags);


### PR DESCRIPTION
Closes #112.

Lets a merged document say which service an operation came from — without anyone editing the upstream specification, which is usually owned by another team.

```jsonc
{ "inputFile": "./billing.json", "tag": { "name": "billing", "description": "The billing service." } }
```

### Ordering is the substantive decision

Injection runs **after** `operationSelection`, and after empty path items are dropped.

Injecting first would let `includeTags: ['billing']` match operations *because this input injects `billing`* — a filter that appears to do nothing and quietly keeps everything. Running after the drop means nothing is tagged that isn't in the output. Both are tested.

### Appended, never replacing

An operation's own tags say what it does; the injected one says where it came from. Losing the former is much worse than never gaining the latter. A tag the operation already carries isn't added twice — that'd be an invalid duplicate.

### The tag is declared, not just applied

Not in the proposal. Operations carrying a tag the document never declares is legal but unhelpful: anything building navigation from `tags` shows a heading with no description, or omits the group. First-wins if two inputs inject the same name.

### Not implemented

The proposal's flag for appending the input's `info.description` to the tag description. It duplicates `DescriptionMergeBehaviour` against a different target, the two would then disagree about heading levels depending on where the text landed, and nobody has asked for it.

### Verification

- 11 library tests; **9 fail against `origin/main`**
- 3 CLI tests including ajv rejecting a missing and an empty tag name
- Gate green: lint, 398 tests, 48 artifact checks

Third of three features on the same tag machinery, with #100 and #111 — injection is the write side of what those two read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)