### PR TITLE
docs(cli): document tag-based operation selection (#100)

### DIFF
--- a/ai-planning/issues/18-proposal-100-tag-based-path-merge.md
+++ b/ai-planning/issues/18-proposal-100-tag-based-path-merge.md
@@ -1,6 +1,6 @@
 # Implementation Proposal: Issue #100 — Merge Paths Based on Specific Tags
 
-**Status:** Proposal
+**Status:** ✅ Implemented (documentation) — see §10
 
 **Value:** 3 / **Effort:** 2 / **ROI:** 4 / **Quadrant:** Quick Win
 
@@ -231,3 +231,63 @@ The existing `operationSelection` logic is sufficient. No new types, functions, 
 ## 11. Timeline
 
 **Can ship immediately** as part of the "CLI Ergonomics" minor release (as suggested in the triage document). No code review or testing needed beyond verification that the documentation is clear.
+
+
+---
+
+## 10. What was implemented
+
+Branch `issue/100-tag-based-path-merge`. **No production code changed**, and
+that is the finding rather than a shortfall.
+
+### 10.1 §4's conclusion was verified, not assumed
+
+§4 says there are no code-level gaps. Before writing documentation on that
+basis, the behaviour was probed against the current implementation:
+
+```
+includeTags: ['Service1'] over
+  /mixed    { get (Service1), post (Other) }
+  /untagged { get (no tags) }
+->
+  paths: ['/mixed'],  /mixed methods: ['get']
+```
+
+Exactly as §4 claims: filtering is per operation, a partially-filtered path
+survives with its remaining operations, and a path left empty is dropped.
+
+### 10.2 Delivered as documentation plus pinning tests
+
+§4.1's clarification and §4.2's worked example are now in the CLI README, which
+calls out the three behaviours someone reading "include these tags" would most
+plausibly get wrong:
+
+- untagged operations do **not** survive an allow-list;
+- a partially-filtered path keeps its remaining operations;
+- `includeTags` does not prune the top-level `tags` array — only `excludeTags`
+  does.
+
+Six tests pin those claims, one per documented sentence. For a feature whose
+entire problem was that its behaviour was not discoverable, documentation
+without tests would decay into the same state within a release or two.
+
+### 10.3 These tests do not fail against `origin/main`
+
+Every other issue in this sweep contributed tests that fail before the change
+and pass after. These do not, and cannot: there is no behaviour change. They
+pass identically on `origin/main`, confirmed in a detached worktree rather than
+assumed.
+
+That is the honest position for a documentation fix. A manufactured failing
+test here would misrepresent what changed.
+
+### 10.4 The sweep ledger entry was wrong
+
+`issue-recommendations.md` justified this as "a small extension of the existing
+filter". It is not an extension of anything. Corrected there, because a ledger
+whose reasoning is wrong is worse than one that is merely incomplete.
+
+### 10.5 Verification
+
+- 6 tests in `operation-selection.test.ts`, passing before and after.
+- Gate green: lint, 390 tests, 48 artifact checks.

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -58,11 +58,41 @@ In this configuration you specify your inputs and your output file. For each inp
 * `dispute`: if two inputs both define a component with the same name then, in order to prevent incorrect overlaps, we will attempt to use the dispute prefix or suffix to come up with a unique name for that component. Please [read the documentation for more details on the format](https://github.com/robertmassaioli/openapi-merge/wiki/configuration-definitions-dispute).
 * `pathModification.stripStart`: When copying over the `paths` from your OpenAPI specification for this input, it will strip this string from the start of the path if it is found.
 * `pathModification.prepend`: When copying over the `paths` from your OpenAPI specification for this input, it will prepend this string to the start of the path if it is found. `prepend` will always run after `stripStart` so that it is deterministic.
-* `operationSelection.includeTags`: Only operations that are tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. This instruction will not remove other tags from the top level tags definition for this input.
+* `operationSelection.includeTags`: Only operations that are tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. This instruction will not remove other tags from the top level tags definition for this input. **This filter works per operation, not per path**: if `GET /thing` carries the tag and `POST /thing` does not, the merged document contains `/thing` with only its `GET`. A path whose operations are all filtered out is dropped entirely.
 * `operationSelection.excludeTags`: Only operations that are NOT tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. Also, these tags will also be removed from the top level `tags` element for this file before being merged. If a single REST API operation has an `includeTags` reference and an `excludeTags` reference then the exclusion rule will take precidence.
 * `description.append`: All of the inputs with `append: true` will have their `info.description`s merged together, in order, and placed in the output OpenAPI file in the `info.description` section.
 * `description.title.value`: An optional string that lets you specify a custom section title for this input's description when it is merged together in the output OpenAPI file's `info.description` section
 * `description.title.headingLevel`: The integer heading level for the title, `1` to `6`. The default is `1`.
+
+### Selecting only the operations with a particular tag
+
+A common case (see [issue #100](https://github.com/robertmassaioli/openapi-merge/issues/100)) is merging several services but taking only the operations each one owns, identified by a tag:
+
+``` json
+{
+  "inputs": [
+    {
+      "inputFile": "service1/swagger.json",
+      "operationSelection": { "includeTags": ["Service1"] }
+    },
+    {
+      "inputFile": "service2/swagger.json",
+      "operationSelection": { "includeTags": ["Service2"] }
+    },
+    {
+      "inputFile": "service3/swagger.json",
+      "operationSelection": { "includeTags": ["Service3"] }
+    }
+  ],
+  "output": "./dist/service.output.swagger.json"
+}
+```
+
+Three things are worth knowing about how this behaves:
+
+* **Untagged operations are excluded.** `includeTags` is an allow-list, so an operation with no tags at all does not survive it. If a service has operations you want that are not tagged, either tag them upstream or use `excludeTags` to remove what you do not want instead.
+* **A partially-filtered path keeps its remaining operations.** Filtering is per operation; the path itself survives as long as one of its operations does.
+* **The top-level `tags` array is only pruned by `excludeTags`.** `includeTags` deliberately leaves it alone, so a tag you filtered *in* keeps its description.
 
 And then, once you have your Inputs in place and your configuration file you merely run the following in the directory that has your configuration file:
 

--- a/packages/openapi-merge/src/__tests__/operation-selection.test.ts
+++ b/packages/openapi-merge/src/__tests__/operation-selection.test.ts
@@ -1,7 +1,7 @@
 import { merge } from '../index';
 import { toOAS } from './_helpers/oas-generation';
 import { expectMergeResult } from './_helpers/test-utils';
-import { doc32, expectSuccess, op } from './_helpers/documents';
+import { doc30, doc32, expectSuccess, op, pathKeys, tagged } from './_helpers/documents';
 
 /**
  * Operation selection: filtering operations by tag via `includeTags` and
@@ -389,5 +389,123 @@ describe('3.2 - tag selection covers the new slots', () => {
 
     expect(output.paths?.['/search'].query).toBeDefined();
     expect(output.paths?.['/search'].get).toBeUndefined();
+  });
+});
+
+/**
+ * Issue #100: selecting only the operations carrying a given tag.
+ *
+ * The reported need was already met by `includeTags`; the proposal for this
+ * issue concluded there were no code-level gaps, only documentation ones, and
+ * a probe against the current code confirmed it.
+ *
+ * So these tests exist to pin the semantics the README now states. Every
+ * assertion here corresponds to a sentence in
+ * `packages/openapi-merge-cli/README.md`, so the documentation cannot quietly
+ * drift away from the behaviour -- which is the actual risk for a feature whose
+ * problem was that nobody could tell what it did.
+ */
+describe('tag-based path selection, as documented (issue #100)', () => {
+  const service = (name: string, tag: string) =>
+    doc30({
+      paths: {
+        [`/${name}/owned`]: { get: tagged(`${name}Owned`, [tag]) },
+        [`/${name}/other`]: { get: tagged(`${name}Other`, ['Shared']) },
+      },
+    });
+
+  it('takes only the operations carrying each service tag', () => {
+    const output = expectSuccess(
+      merge([
+        { oas: service('one', 'Service1'), operationSelection: { includeTags: ['Service1'] } },
+        { oas: service('two', 'Service2'), operationSelection: { includeTags: ['Service2'] } },
+      ]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/one/owned', '/two/owned']);
+  });
+
+  it('filters per operation, keeping a path whose other method survives', () => {
+    // README: "if GET /thing carries the tag and POST /thing does not, the
+    // merged document contains /thing with only its GET".
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: {
+              '/thing': { get: tagged('getThing', ['Wanted']), post: tagged('postThing', ['Unwanted']) },
+            },
+          }),
+          operationSelection: { includeTags: ['Wanted'] },
+        },
+      ]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/thing']);
+    expect(Object.keys(output.paths?.['/thing'] ?? {})).toEqual(['get']);
+  });
+
+  it('drops a path whose operations are all filtered out', () => {
+    // README: "A path whose operations are all filtered out is dropped
+    // entirely."
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/keep': { get: tagged('k', ['Wanted']) }, '/drop': { get: tagged('d', ['Unwanted']) } },
+          }),
+          operationSelection: { includeTags: ['Wanted'] },
+        },
+      ]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/keep']);
+  });
+
+  it('excludes an operation with no tags at all', () => {
+    // README: "includeTags is an allow-list, so an operation with no tags at
+    // all does not survive it." This is the behaviour most likely to surprise.
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/tagged': { get: tagged('t', ['Wanted']) }, '/untagged': { get: op('u') } } }),
+          operationSelection: { includeTags: ['Wanted'] },
+        },
+      ]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/tagged']);
+  });
+
+  it('leaves the top-level tags array alone under includeTags', () => {
+    // README: "The top-level tags array is only pruned by excludeTags."
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({
+            paths: { '/a': { get: tagged('a', ['Wanted']) } },
+            tags: [{ name: 'Wanted', description: 'Kept.' }, { name: 'Unwanted', description: 'Also kept.' }],
+          }),
+          operationSelection: { includeTags: ['Wanted'] },
+        },
+      ]),
+    );
+
+    expect(output.tags?.map(t => t.name)).toEqual(['Wanted', 'Unwanted']);
+  });
+
+  it('gives exclusion precedence when a tag is both included and excluded', () => {
+    // Documented in the excludeTags bullet: "the exclusion rule will take
+    // precedence".
+    const output = expectSuccess(
+      merge([
+        {
+          oas: doc30({ paths: { '/a': { get: tagged('a', ['Both']) }, '/b': { get: tagged('b', ['Wanted']) } } }),
+          operationSelection: { includeTags: ['Both', 'Wanted'], excludeTags: ['Both'] },
+        },
+      ]),
+    );
+
+    expect(pathKeys(output)).toEqual(['/b']);
   });
 });


### PR DESCRIPTION
Closes #100.

**No production code changed — that's the finding, not a shortfall.**

The issue asks how to merge several services taking only the paths carrying a given tag. `includeTags` already does exactly that. The proposal's §4 concluded there were no code-level gaps; rather than take that on trust I probed the current implementation first:

```
includeTags: ['Service1'] over
  /mixed    { get (Service1), post (Other) }
  /untagged { get (no tags) }
->
  paths: ['/mixed'],  /mixed methods: ['get']
```

Confirmed: filtering is per operation, a partially-filtered path keeps its remaining methods, an emptied path is dropped.

### What the issue actually reports

That none of this was discoverable. So: the README clarification and worked example, calling out the three behaviours someone reading *"include these tags"* would most plausibly get wrong —

- untagged operations do **not** survive an allow-list
- a partially-filtered path keeps its remaining operations
- `includeTags` does **not** prune the top-level `tags` array; only `excludeTags` does

Six tests pin those claims, one per documented sentence. For a feature whose whole problem was undiscoverable behaviour, documentation without tests decays back to the same state within a release or two.

### ⚠️ These tests don't fail on `origin/main`

And can't — there's no behaviour change. Confirmed in a detached worktree rather than assumed.

Every other PR in this sweep contributed tests that fail before and pass after. Presenting a manufactured failing test here would misrepresent what changed.

### Also

Corrects the sweep ledger, which justified this issue as *"a small extension of the existing filter"*. It isn't an extension of anything.

Gate green: lint, 390 tests, 48 artifact checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)