### PR TITLE
feat(cli): init writes YAML with every optional field commented in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,8 @@ both point at `dist/index`. Only `dist/!(__tests__)` (and subtree) are published
 
 A thin command-line wrapper around the `openapi-merge` library that:
 
-1. Loads a JSON or YAML configuration file (default: `openapi-merge.json`).
+1. Loads a JSON or YAML configuration file (default: `openapi-merge.yaml`,
+   falling back to `openapi-merge.json` if that is the only one present).
 2. Validates it against a generated JSON Schema (`configuration.schema.json`).
 3. Loads each input OpenAPI document either from disk (`inputFile`) or HTTP
    (`inputURL`) — JSON or YAML.

--- a/ai-planning/34-proposal-init-yaml-commented-options.md
+++ b/ai-planning/34-proposal-init-yaml-commented-options.md
@@ -1,0 +1,300 @@
+# Implementation Proposal: `init` Emits YAML With Every Optional Field Commented In
+
+**Status:** ✅ Implemented.
+**Type:** CLI / developer experience
+**Scope:** `packages/openapi-merge-cli`
+**Date:** 2026-08-01
+**Branch:** `feature/init-yaml-with-optional-fields`
+
+---
+
+## 1. The problem
+
+[33](33-proposal-cli-init-command.md) built `init` to write `openapi-merge.json` with only
+`inputs` and `output` filled in, and explicitly declined to generate anything
+else (§8): *"Generating anything beyond `inputs` and `output`... a generated
+file full of options the user did not ask for is harder to read than a short
+one."*
+
+That was the right call for a first version. Since then `Configuration` has
+grown a lot of optional behaviour — per-input `dispute`, `pathModification`,
+`operationSelection`, `description`, `duplicatePathHandling`, `tag`, and
+top-level `outputRoot`, `formatting`, `serversStrategy`,
+`securitySchemesStrategy`, `pruneUnusedComponents`, `info` — and none of it is
+discoverable from the generated file. Finding out any of this exists means
+reading the README or the JSON Schema.
+
+The ask: make `init` write YAML (comments require it — JSON has no comment
+syntax) with every optional field present in the file, commented out, so a
+user can see what exists and uncomment what they want.
+
+## 2. What "good" looks like
+
+- `init`'s output is still valid and mergeable with zero edits — the
+  invariant from 33 must not regress.
+- Every optional field on `Configuration` and `ConfigurationInputBase` —
+  **and every required sub-field of an optional object** (e.g.
+  `description.append`, `dispute.prefix`/`suffix`, `tag.name`,
+  `formatting.indent.style`+`width`) — appears somewhere in the file,
+  commented out, with enough of a description to be useful without opening
+  the README. Uncommenting one block must always produce something the
+  schema accepts; a block that shows only the optional leaves of a required
+  shape breaks the feature's whole promise on first use. The deprecated
+  `disputePrefix` (`DisputeV1`) is excluded — only the current (`V2`,
+  `dispute`) shape is shown.
+- The *active* (uncommented) part of the file is still just `inputs` and
+  `output` — nothing behavioural changes for someone who ignores the
+  comments and runs the tool as before.
+- Running `init` twice in the same directory still produces identical output
+  (existing invariant, §4 of 33).
+
+## 3. Decisions
+
+### 3.1 Filename: keep `openapi-merge.json`, or move to `openapi-merge.yaml`? — **decided: rename, with fallback**
+
+The loader (`readYamlOrJSON` in `file-loading.ts`) parses either format
+regardless of extension, so a `.json` file containing YAML would technically
+still load. But shipping a `#`-commented file with no braces, named `.json`,
+is actively misleading: editors syntax-highlight and lint it as JSON, and a
+diff labelled `openapi-merge.json` full of YAML will confuse the exact users
+this feature is trying to help.
+
+**Recommendation:** rename the file `init` writes to `openapi-merge.yaml`,
+and make `loadConfiguration`'s no-`-c` lookup try `openapi-merge.yaml`
+first, falling back to `openapi-merge.json` if that's not present. This is
+additive for *loading* — anyone with an existing `openapi-merge.json` keeps
+working without touching anything.
+
+It is **not** automatically additive for *`init`'s overwrite guard*, and
+this is the part worth being deliberate about. Today's guard is
+`fs.existsSync(STANDARD_CONFIG_FILE)` against one name. If the target
+becomes `openapi-merge.yaml`, a user with a hand-edited `openapi-merge.json`
+would get no refusal at all — `init` would happily write a second file next
+to it. Nothing is deleted, but because the loader now prefers `.yaml`, the
+freshly generated file silently *shadows* the hand-written `.json` on the
+very next merge. That is the same failure 33 §4 called "the one
+unrecoverable thing this command can do," just with a longer fuse before it
+is noticed.
+
+So the guard has to change alongside the rename: `init` refuses (without
+`--force`) if **either** `openapi-merge.yaml` or `openapi-merge.json`
+already exists. With `--force` it writes `openapi-merge.yaml` and leaves any
+existing `openapi-merge.json` in place untouched — the console output says
+so explicitly, including that the old file is now inert because `.yaml` is
+preferred on load. If both names exist at ordinary load time (no `-c`),
+`loadConfiguration` logs which one it chose.
+
+Loose end noticed while reading the code: `STANDARD_CONFIG_FILE` is
+currently defined twice — once exported from `init-command.ts`, and again as
+a separate local constant inside `load-configuration.ts` that isn't imported
+from the first. Worth collapsing to one constant while this file is open
+regardless of which way 3.1 goes.
+
+### 3.2 Per-input options: repeat the block on every input, or show it once? — **decided**
+
+`dispute`, `pathModification`, `operationSelection`, `description`,
+`duplicatePathHandling`, and `tag` are all *per input*, not top-level. A
+directory with five specs gets five `inputs` entries — does each one carry
+its own ~25-line commented block, or does the block appear once?
+
+**Recommendation:** show the full commented block under the *first* input
+only. Every subsequent input gets a single comment line pointing back to it
+(`# per-input options — see the commented block above the first input; the
+same fields apply here`). The fields are identical regardless of which input
+they're attached to, so nothing is lost by cross-referencing instead of
+repeating, and the file stays readable no matter how many inputs are found.
+With zero inputs found (today's placeholder case), the block goes on the one
+placeholder input, same shape as now.
+
+### 3.3 How much explanation per field?
+
+**Recommendation:** one short comment line per field (or per field group,
+for nested objects like `formatting.indent`), lifted from the existing TSDoc
+in `data.ts` rather than written fresh — that TSDoc is already the
+authoritative wording, and hand-duplicating it in two places invites drift.
+A worked example, not just a bare key:
+
+```yaml
+  # Combine each input's securitySchemes, or take only the first input's (issue #33).
+  # securitySchemesStrategy: merge # merge | first | error
+```
+
+### 3.4 How is this actually generated?
+
+`js-yaml`'s `dump()` has no notion of a comment attached to a key — comments
+cannot survive an object round-trip, so this can't be "build a
+`Configuration`, dump it, done" the way today's JSON output is. It has to be
+assembled as a template: the *real* `inputs`/`output` (computed exactly as
+today via `buildConfiguration`) rendered normally, interleaved with
+hand-written commented sections for everything optional.
+
+**Recommendation:** a new pure function alongside the existing ones in
+`init-command.ts` — call it `renderInitYaml(configuration, options)` — kept
+testable the same way `buildConfiguration` already is: assert on the
+returned string, no temp directory needed. `index.ts` keeps doing only the
+file I/O around it, unchanged in kind.
+
+**What was actually built** differs from the sketch above in two small ways.
+The signature ended up `renderInitYaml(chosenInputs, output)` — a list of
+input paths and the output path, not a full `Configuration` and an options
+bag — because the caller (`runInit`) already had exactly those two values
+and there was nothing an options bag would have carried. `chosenInputs`
+(the "use the placeholder if nothing was found" decision) was pulled out of
+`buildConfiguration` into its own exported function so `runInit` could
+compute the same input list once and hand it to both `buildConfiguration`
+(for `.output`) and `renderInitYaml`, rather than the two ever being able to
+disagree.
+
+A design alternative — typing each optional field's data as a real object
+dumped through `js-yaml` instead of a hand-written YAML string, keyed by
+field name so a future `Configuration` field is a compile error until
+documented — was raised mid-implementation and evaluated in
+[35](35-proposal-commented-yaml-section-type.md). Decided against for now
+(Option C there): the hand-written-string version below is what shipped,
+validated per-field and validated *in its actual rendered position* (§6).
+
+## 4. Scope of the change
+
+Touches:
+
+- `init-command.ts` — new rendering function; `STANDARD_CONFIG_FILE`
+  probably becomes `openapi-merge.yaml` (§3.1).
+- `index.ts` — write the rendered string instead of
+  `JSON.stringify(configuration, null, 2)`.
+- `load-configuration.ts` — default lookup tries `.yaml` then falls back to
+  `.json`, logging which it picked; the duplicate `STANDARD_CONFIG_FILE`
+  constant goes away.
+- `exit-codes.ts` — its doc comment names `openapi-merge.json` specifically
+  and should mention the `.yaml` default too.
+- `README.md` — the "Getting started: `init`" section shows JSON output
+  today and needs updating to match.
+- Tests — `init-command.test.ts` and the `init` tests in
+  `cli-invocation.test.ts` assume JSON (e.g. the `JSON.parse` of the
+  generated file, and the overwrite-refusal tests that pre-write
+  `openapi-merge.json`). These need to target whichever filename `init`
+  defaults to, plus a new case covering the `.yaml`-then-`.json` fallback if
+  3.1 is accepted.
+
+Not touched: the merge algorithm, the `Configuration` type itself (no new
+fields — this only documents existing ones), the JSON Schema, or how
+user-supplied configs are loaded (`-c` keeps accepting JSON or YAML exactly
+as it does today).
+
+**Two files this section didn't predict**, found while implementing:
+
+- `config-file-names.ts` — new. `STANDARD_CONFIG_FILE` was duplicated
+  between `init-command.ts` and `load-configuration.ts` (§3.1's loose end);
+  rather than pick one owner and have the other import it, both now import
+  `STANDARD_CONFIG_FILE_YAML` / `STANDARD_CONFIG_FILE_JSON` /
+  `STANDARD_CONFIG_FILE_CANDIDATES` from a third, dependency-free module.
+- `__tests__/_helpers/cli-harness.ts` — the shared CLI test harness
+  discarded `console.log` entirely (`console.log = (): void => undefined`).
+  Testing the new "using `X`" / "`Y` is no longer used" log lines needed
+  stdout captured the same way `stderr()` already was; added a `stdout()`
+  accessor alongside it. Purely additive — every existing caller of the
+  harness is unaffected.
+- `AGENTS.md` — its description of the CLI's default config filename was
+  also stale and got the same one-line update as `exit-codes.ts`.
+
+## 5. Not doing
+
+- Interactive prompts — still out of scope, per 33 §3 Option D.
+- Recursive directory scanning — still out of scope, per 33 §3 Option E.
+- Requiring YAML for hand-written configs, or changing what `-c` accepts.
+  JSON configs keep working exactly as they do today; this only changes what
+  `init` itself writes.
+
+## 6. Verification
+
+Everything below is what actually ran, not a plan — the "planned" heading
+this section had before implementation is gone per this directory's
+convention of updating proposals with results.
+
+- **Structure**: `renderInitYaml` tested for zero inputs (placeholder case),
+  one input, and several inputs, including that the full per-input block
+  appears exactly once regardless of input count (§3.2) and that a scanned
+  path containing YAML-special characters (`./a: b.yaml`) still round-trips
+  through `yamlScalar()` to something that parses and validates.
+- **The active part is inert**: `loadYaml(rendered)` deep-equals
+  `buildConfiguration(inputs)` exactly — not just "the whole file
+  validates," which would pass even if a comment leaked stray text into the
+  active document.
+- **Per-field validity, not "uncomment everything."** The fields don't form
+  one valid document when all uncommented at once — `dispute` is `prefix`
+  XOR `suffix`, an input is `inputFile` XOR `inputURL` — so a single
+  all-uncommented pass would fail ajv for reasons that have nothing to do
+  with whether the generator did its job. Each block is uncommented in
+  isolation instead, merged into a base document, and validated against the
+  real `configuration.schema.json` via ajv — the same schema
+  `loadConfiguration` uses.
+- **That validity check closes the loop through the real rendered text, not
+  just the source string.** An earlier pass of this testing validated
+  `block.yaml` — the hand-written source — directly, which cannot catch a
+  bug in how `renderCommentedBlock` actually applies indentation. A
+  follow-up test takes the literal string `init` writes, strips the
+  comment marker off one block *in place* (top-level, zero indent; and
+  per-input, the `+4` hop into a list item that a naive `+2`-per-level
+  renderer would get wrong — see 35 §3.2), and validates the whole
+  resulting document. Confirmed to actually catch that regression: forcing
+  the per-input indent constant from 4 spaces to 2 and rerunning turned this
+  test red while every other test (including the block-in-isolation ones)
+  stayed green.
+- **Coverage** is asserted with an explicit list of expected field names,
+  cross-checked by hand against `data.ts`'s `Configuration` and
+  `ConfigurationInputBase`/`DisputeV2` — the fallback §6 anticipated, taken
+  because the JSON Schema's `oneOf` branches
+  (`ConfigurationInputV1`/`V2`, `DisputePrefix`/`Suffix`) made walking the
+  *generated schema's* property keys awkward.
+- **Idempotence**: `init` then `init --force` with unchanged inputs produces
+  byte-identical output (33's invariant, re-checked now that a second run
+  needs `--force` to get there at all).
+- **The round trip**: `init` then merge the result unedited, kept from 33
+  and re-pointed at `openapi-merge.yaml`.
+- **The overwrite guard** (§3.1): refuses when only `.yaml` exists, when
+  only a legacy `.json` exists, and when both do (message names both);
+  `--force` writes `.yaml`, leaves a pre-existing `.json` byte-for-byte
+  untouched, and logs that it is no longer used.
+- **The default lookup** (`loadConfiguration`, no `-c`): resolves `.json`
+  when it's the only one present, prefers `.yaml` when both are present
+  (proved by checking *which config's `output` got written*, not just the
+  log line), and names both candidates in the not-found error.
+- Manual end-to-end smoke test outside the test suite: real temp directory,
+  real files, `init` → inspect the generated YAML → merge it unedited →
+  inspect the merged output. Run twice (single input, and two inputs with
+  distinct paths) to eyeball the actual generated comments, not just their
+  parsed structure.
+- Full package suite: 198 tests (up from the pre-existing baseline),
+  100% function coverage and 98.89% line coverage on
+  `packages/openapi-merge-cli`. Whole-workspace `bun run test` (both
+  packages, 421 + 198 tests) and `bun run lint` (ESLint + `tsgo
+  --noEmit` for both packages) green.
+
+## 7. A known characteristic: blanket-uncommenting a block breaks
+
+Each block's explanation line and its YAML share one comment marker (`# `),
+with no visual distinction between "prose, meant to stay a comment" and
+"YAML, meant to be uncommented." A person selecting a whole block — the
+explanation line included — and running their editor's toggle-line-comment
+on all of it gets a document `loadYaml` cannot parse:
+
+```
+error: can not read a block mapping entry; a multiline key may not be an
+implicit key
+```
+
+(Confirmed directly: stripping `# ` from an explanation line followed by
+`formatting:` produces exactly this error, because the explanation reads as
+an implicit top-level scalar key ahead of a mapping.)
+
+Left as-is, for three reasons. It matches a common config-file convention —
+`postgresql.conf`, most `docker-compose.yml` references — where a prose
+comment sits above a single commented setting line and only the setting
+line is meant to be touched; a person used to that convention already knows
+not to uncomment the sentence above the key. It fails loud: a YAML parse
+error with a line number, not a silent misconfiguration — the sort of
+mistake a first run of the tool catches immediately, not one that ships. And
+fixing it structurally (giving explanation and data different comment
+markers, e.g. `##` for prose that must stay commented) reopens exactly the
+`Section`-shaped redesign evaluated and declined in
+[35](35-proposal-commented-yaml-section-type.md) §6 Option C. Worth
+revisiting only if this turns out to bite people in practice.

--- a/ai-planning/35-proposal-commented-yaml-section-type.md
+++ b/ai-planning/35-proposal-commented-yaml-section-type.md
@@ -1,0 +1,272 @@
+# Evaluation: A `Section`/`CommentedYaml` Type for `init`'s Generated File
+
+**Status:** Evaluation, requested mid-implementation of
+[34](34-proposal-init-yaml-commented-options.md). **Decided: Option C** —
+keep the current (string-based) implementation as already built; no further
+change to `init-command.ts`'s internals. Kept for the record of the
+trade-offs considered, in case a future field addition makes Option A worth
+revisiting.
+**Type:** CLI / developer experience — refactor of `init-command.ts`
+**Scope:** `packages/openapi-merge-cli`
+**Date:** 2026-08-01
+
+---
+
+## 1. The question
+
+While implementing 34, each optional field is a hand-typed YAML string:
+
+```ts
+export type OptionalFieldBlock = {
+  name: string;
+  explanation: string;
+  yaml: string;    // <- hand-written YAML text, e.g. "formatting:\n  indent:\n..."
+};
+```
+
+`renderInitYaml` splits `yaml` on `\n` and prefixes every line with `# `.
+It works — every block round-trips through a real ajv validation in the
+current smoke test — but it works *by discipline*: nothing stops a block
+from having a typo, a missing required sub-field, or simply not existing
+for a field `data.ts` adds next month. The proposal was: replace the string
+with a typed object dumped through `js-yaml`, wrapped in a `Section` that
+also carries whether it's commented and what comment sits above it, with
+the whole document built from `Section`s.
+
+**Verdict: yes, it works, and it's worth doing** — with three extensions to
+the shape as originally described. The best part of it isn't tidiness, it's
+that one version of it turns a test-time safety net into a *compile-time*
+one. §2 covers where it works as-is; §3 covers what has to be added; §4 is
+the concrete shape; §5 is the one part of the current design it doesn't
+replace.
+
+## 2. Where the idea works exactly as described
+
+Swap `yaml: string` for `data: Record<string, unknown>`, dumped through
+`js-yaml` instead of hand-typed:
+
+```ts
+{
+  name: 'tag',
+  comment: "Add a tag to every operation from this input...",
+  commented: true,
+  data: { tag: { name: 'service-a', description: 'Endpoints from this input' } },
+}
+```
+
+`dumpYaml(data)` produces the exact block currently hand-written, with three
+concrete wins:
+
+- **No hand-typed YAML syntax.** `dumpYaml` handles indentation and scalar
+  quoting itself (it's already trusted for exactly this — `yamlScalar()` in
+  the current code leans on the same mechanism for `inputFile` paths). A
+  stray tab or misaligned `-` in a hand-typed string is a class of bug this
+  removes outright.
+- **Required sub-fields are enforced by the compiler, not just a test.**
+  Type `data.description` as `DescriptionMergeBehaviour` (from `data.ts`)
+  and TypeScript refuses to compile a block missing `append` — the exact
+  failure mode 34's advisor review caught in the string-based version,
+  now caught before `bun test` even runs.
+- **Verified key ordering is preserved.** Checked empirically (`js-yaml`
+  `dump()` on an object with keys in declaration order, no `sortKeys`
+  configured) — insertion order survives, so a `Section`'s `data` renders
+  fields in the order they're declared, matching the hand-typed version.
+
+## 3. Where the literal `{ data, commented, comment }` shape falls short
+
+Three gaps, found by mapping all twelve current blocks onto it, not by
+inspection alone:
+
+### 3.1 Per-line trailing comments have nowhere to live
+
+Several blocks annotate one *specific* dumped line, not the block as a
+whole:
+
+```
+    style: spaces # spaces | tabs (tabs are JSON-output only -- YAML forbids tab indentation)
+```
+
+`comment` in the proposed shape sits *above* the section; there's no slot
+for a comment trailing a line inside `dumpYaml(data)`'s own output.
+
+**Resolution:** fold the option list into the header comment instead of
+keeping it inline:
+
+```
+# How the merged output file is indented. style: spaces or tabs (tabs are
+# JSON-output only -- YAML forbids tab indentation). Defaults to 2 spaces.
+# formatting:
+#   indent:
+#     style: spaces
+#     width: 2
+```
+
+Loses a little locality (the options are one line up instead of on the same
+line) but costs nothing structurally, and reads fine — checked against all
+five enum-valued blocks (`formatting.indent.style`, `serversStrategy`,
+`securitySchemesStrategy`, `duplicatePathHandling`, and the
+`prefix`/`suffix` note on `dispute`). A per-key `inlineComments` side table
+was considered and rejected for now — it's more machinery for a readability
+difference this small; revisit only if a future block genuinely needs it.
+
+### 3.2 The per-input block isn't a peer of the top-level ones — it's nested
+
+`pathModification`, `tag`, `dispute`, etc. don't sit at the document's top
+level; they sit *inside* the first `inputs[]` entry, indented under
+`- inputFile: ...`. A flat `Section[]` has nowhere to express "these six
+sections render one level deeper, under this specific list item, and only
+under the first one."
+
+**Resolution:** `Section` needs a `children?: Section[]` slot, and the
+`inputs` entry itself becomes a `Section` whose children are attached only
+to the first item. Bounded, not open-ended — but the indent arithmetic has
+a wrinkle worth being precise about, checked empirically rather than
+assumed: `js-yaml dump()` on a two-key map inside a list item puts a
+sibling key at **4** spaces (`- inputFile: x` / `    tag: ...`), not 2 —
+the `- ` sequence marker itself consumes 2 columns beyond the ordinary
+1-level-in map nesting of 2. Below that first hop, further nesting *is* a
+flat +2 per level (`tag:` → `  name:` is 4 → 6). So the renderer needs one
+fixed **+4** step for "entering a sequence item's map" and an ordinary +2
+for every level after — not a uniform +2 throughout, which is what the
+current code's `PER_INPUT_BLOCK_INDENT = '    '` constant already encodes
+correctly. A recursive renderer built on a uniform +2 assumption would
+misindent the very first block it renders.
+
+### 3.3 `inputs`/`output` are real data, not a static example — and only one of them is a list
+
+Every current `Section` is a fixed example (`serviceA_`, `1.0.0`, ...).
+`inputs`/`output` are *computed* from what the scan found, and `inputs` is a
+*sequence* of items that can each carry different children, not a single
+map. Modelling `inputs` as one `Section` requires either a `SequenceSection`
+variant alongside the map-shaped one, or accepting that the required
+skeleton stays hand-rendered and only the optional parts become `Section`s
+(§5).
+
+## 4. The shape that closes the gaps
+
+A first cut wrote `data: Record<string, unknown>` — that compiles for
+*anything*, so it does not actually catch a missing `description.append`;
+`Record<string, unknown>` was the mistake to avoid, not the fix. Getting
+real enforcement means keying the section tables by field name with a
+**mapped type**, so each entry's `data` is pinned to that field's actual
+(non-optional) type from `data.ts`:
+
+```ts
+type TopLevelOptionalKey = Exclude<keyof Configuration, 'inputs' | 'output'>;
+
+type TopLevelSections = {
+  [K in TopLevelOptionalKey]: { comment: string; data: { [P in K]-?: Configuration[P] } };
+};
+
+const TOP_LEVEL_SECTIONS: TopLevelSections = {
+  outputRoot: { comment: '...', data: { outputRoot: '.' } },
+  formatting: { comment: '...', data: { formatting: { indent: { style: 'spaces', width: 2 } } } },
+  serversStrategy: { comment: '...', data: { serversStrategy: 'first' } },
+  securitySchemesStrategy: { comment: '...', data: { securitySchemesStrategy: 'merge' } },
+  pruneUnusedComponents: { comment: '...', data: { pruneUnusedComponents: false } },
+  info: { comment: '...', data: { info: { title: 'My Merged API', version: '1.0.0', description: '...' } } },
+};
+
+type PerInputOptionalKey = keyof ConfigurationInputBase | keyof DisputeV2;
+// pathModification | operationSelection | description | duplicatePathHandling | tag | dispute
+// (not `Exclude<keyof ConfigurationInputBase, 'inputFile' | 'inputURL'>` -- those two keys live on
+// ConfigurationInputFromFile / ConfigurationInputFromUrl, not on ConfigurationInputBase, so excluding
+// them from it would be a no-op)
+
+type PerInputSections = {
+  [K in PerInputOptionalKey]: { comment: string; data: { [P in K]-?: (ConfigurationInputBase & DisputeV2)[P] } };
+};
+```
+
+Two things follow from `{ [P in K]-?: ... }` rather than `Record<string, unknown>`:
+
+- **`TopLevelSections`/`PerInputSections` force every key to be present** —
+  the exhaustiveness win described below.
+- **Each entry's `data` is typed as the real field**, so a nested required
+  sub-field is enforced transitively for free. `data.description` is typed
+  `DescriptionMergeBehaviour`, which requires `append`; a literal missing
+  it is a compile error. `data.formatting` is typed `OutputFormatting`,
+  so `indent: { style: 'spaces', width: 2 }` has `width` enforced by
+  `SpaceIndent` the same way. This is the actual mechanism — not
+  `Record<string, unknown>` — for the "compiler catches a missing
+  required field" claim in §2.
+
+The renderer type is separate from the table type and stays closer to the
+first draft, since *it* only needs to walk a tree and doesn't need per-key
+precision:
+
+```ts
+type RenderNode = { comment: string; commented: boolean; data: Record<string, unknown>; children?: RenderNode[] };
+```
+
+`TOP_LEVEL_SECTIONS`/`PER_INPUT_SECTIONS` are the source of truth (typed,
+exhaustive); a thin `Object.values(...)` conversion turns them into
+`RenderNode[]` for the actual walk. The exhaustiveness lives in the table's
+type, not the renderer's.
+
+**Exhaustiveness enforced by the compiler, not a hand-maintained list.** If
+`data.ts` gains a new optional `Configuration` field tomorrow,
+`TopLevelSections` gains a new required key and `TOP_LEVEL_SECTIONS`
+**fails to typecheck** until an entry is added for it. The current
+(string-based) design's equivalent safeguard is the coverage test planned
+in 34 §6 — an explicit list of field names, cross-checked by hand against
+`data.ts` when either changes. That test still catches a forgotten field,
+but only when someone remembers to run it and notices the failure; the
+mapped type catches it at `bun run typecheck`, before a test is even
+written.
+
+This is the one part of the idea that's a strict upgrade, not a wash: it
+converts "a human has to remember to update two places" into "the build
+breaks if they don't" — at the cost of the mapped-type machinery above,
+which is real but confined to two type declarations.
+
+## 5. What doesn't move: the required skeleton
+
+`inputs`/`output` with their *real*, scan-derived values stay
+purpose-written rendering (a `SequenceSection` with dynamic `data`, or just
+the current direct string-building — either works). The `Section` model's
+value is entirely in the *optional, commented* two-thirds of the file; it
+was never going to also simplify "print what the scanner actually found,"
+which has no comments and no static example to model.
+
+## 6. Recommendation: three options, not one
+
+The exhaustiveness win (§4) does not actually require the `Section`/tree
+refactor — it only requires the *tables* being keyed by field name with a
+mapped type. That's separable from switching the block bodies from
+hand-typed YAML strings to `dumpYaml`-rendered objects. Worth naming as its
+own option rather than bundling it into "adopt or don't":
+
+**Option A — exhaustiveness only, keep hand-typed YAML strings.**
+Re-key the existing `OptionalFieldBlock[]` arrays as
+`Record<TopLevelOptionalKey, OptionalFieldBlock>` /
+`Record<PerInputOptionalKey, OptionalFieldBlock>`. ~10 lines of change
+against code that already works and already passes ajv for all 12 blocks.
+Gets the build-breaks-on-a-forgotten-field guarantee; does not remove
+hand-typed YAML syntax as a source of typos (still caught, just at test
+time via 34 §6's per-field validity test, not at compile time).
+
+**Option B — full refactor to typed `data` + `RenderNode` tree (§4/§5).**
+Gets Option A's guarantee *and* removes hand-typed YAML syntax, at the cost
+of: the mapped-type table declarations, the `RenderNode` tree and its
+recursive renderer, the sequence-vs-map distinction for `inputs` (§3.3),
+and moving five inline enum-option comments into header prose (§3.1) —
+which means the README snippet already written for 34 needs a matching
+edit, since it currently shows the inline style. Larger, but the current
+implementation is not yet under test, so nothing this touches is load-
+bearing elsewhere in the codebase — the cost is confined to
+`init-command.ts` and its (not-yet-written) tests.
+
+**Option C — neither; keep 34's implementation as already built.**
+Already implemented, already validated against the real schema by the
+throwaway smoke test used while building it. Zero further cost, and 34
+never promised more than "correct," which it is.
+
+**No default recommendation here** — this is a design-taste call between a
+small guaranteed win (A), a larger but more thorough one (B), and shipping
+what already works (C), and it was Robert's instinct that prompted this
+evaluation in the first place. Whichever is chosen, 34 §6's test plan
+applies unchanged in what it asserts (uncomment one field in isolation,
+validate against the real schema) regardless of how the block bodies are
+produced — so the tests can be written once, now, against whichever shape
+is chosen, rather than written twice.

--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -64,6 +64,8 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`29-proposal-node-runtime-verification.md`](29-proposal-node-runtime-verification.md) | ✅ Building with Bun while proving the artifacts run on Node |
 | [`30-proposal-bundle-the-cli.md`](30-proposal-bundle-the-cli.md) | ✅ Bundling the CLI so it runs under both Node and Bun; reduces 29 |
 | [`33-proposal-cli-init-command.md`](33-proposal-cli-init-command.md) | ✅ An `init` command that writes a starter configuration, scanning for inputs |
+| [`34-proposal-init-yaml-commented-options.md`](34-proposal-init-yaml-commented-options.md) | ✅ `init` writes YAML with every optional field present, commented out |
+| [`35-proposal-commented-yaml-section-type.md`](35-proposal-commented-yaml-section-type.md) | Evaluates a typed `Section`/`CommentedYaml` refactor of how 34's generator builds that file |
 | [`issue-triage-value-vs-effort.md`](issue-triage-value-vs-effort.md) | Value/effort scoring of every open issue; the index into `issues/` |
 | [`spec-edge-case-findings.md`](spec-edge-case-findings.md) | Divergences between the merge and the spec, found by edge-case testing |
 | [`bun-tsgo-migration-build-timings.md`](bun-tsgo-migration-build-timings.md) | Measured build timings for the Bun + tsgo migration |

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -10,7 +10,9 @@ used for most use cases, some of the feature decisions are tailored for that spe
 ## Getting started
 
 In order to use this merging cli tool you need to have one or more OpenAPI 3.0 files that you wish to merge. Then you need to create a configuration file,
-called `openapi-merge.json` by default, in your current directory. It should look something like this:
+called `openapi-merge.yaml` by default (`openapi-merge.json` is also read, for configurations written before this tool wrote YAML), in your current directory.
+The [`init`](#getting-started-init) command below writes a starting point for you, with every setting documented and commented out. Written by hand, it
+should look something like this:
 
 ``` json
 {
@@ -102,14 +104,42 @@ To write that configuration file for you, run:
 npx openapi-merge-cli init
 ```
 
-It creates `openapi-merge.json` in the current directory, pre-filled with any
+It creates `openapi-merge.yaml` in the current directory, pre-filled with any
 OpenAPI 3.x files it finds alongside it:
 
 ```
-## Wrote openapi-merge.json with 2 inputs:
+## Wrote openapi-merge.yaml with 2 inputs:
 ##   ./service-a.yaml
 ##   ./service-b.yaml
-## Edit openapi-merge.json, then run openapi-merge-cli to produce './openapi.yaml'.
+##   Every other setting is included, commented out -- uncomment what you need.
+## Edit openapi-merge.yaml, then run openapi-merge-cli to produce './openapi.yaml'.
+```
+
+The generated file is not just `inputs` and `output` -- every optional setting
+this tool supports, both per-input (`dispute`, `pathModification`,
+`operationSelection`, `description`, `duplicatePathHandling`, `tag`) and
+top-level (`outputRoot`, `formatting`, `serversStrategy`,
+`securitySchemesStrategy`, `pruneUnusedComponents`, `info`), is written out
+commented, with a one-line explanation and a working example. Uncomment a
+block and it is immediately valid -- nothing else to fill in:
+
+```yaml
+inputs:
+  - inputFile: ./service-a.yaml
+    # Per-input options (all optional, all commented out below).
+    # Rewrite this input's paths before merging: strip a prefix, then prepend one.
+    # pathModification:
+    #   stripStart: /v1
+    #   prepend: /service-a
+    # ... operationSelection, description, duplicatePathHandling, tag, dispute ...
+  - inputFile: ./service-b.yaml
+    # Per-input options: see the commented block under the first input above -- the same fields apply here.
+output: ./openapi.yaml
+
+# Defence in depth: refuse to write the merged output anywhere outside this directory.
+# outputRoot: .
+
+# ... formatting, serversStrategy, securitySchemesStrategy, pruneUnusedComponents, info ...
 ```
 
 Details worth knowing:
@@ -121,8 +151,11 @@ Details worth knowing:
 * **It scans the current directory only.** Not recursive: descending would mean
   guessing which directories to skip, and picking up a vendored copy of somebody
   else's API is a worse outcome than finding nothing.
-* **It will not overwrite an existing `openapi-merge.json`** unless you pass
-  `--force`.
+* **It will not overwrite an existing configuration** -- `openapi-merge.yaml`
+  *or* `openapi-merge.json` -- unless you pass `--force`. `--force` only ever
+  writes `openapi-merge.yaml`; a pre-existing `openapi-merge.json` is left in
+  place (and the command tells you it is no longer used, since `.yaml` is
+  preferred on load).
 * **Swagger 2.0 files are named, not silently skipped**, so you know the scan saw
   them and why they were left out. Convert them with `swagger2openapi` first.
 * **It warns if the files it found declare different OpenAPI minor versions**,

--- a/packages/openapi-merge-cli/src/__tests__/_helpers/cli-harness.ts
+++ b/packages/openapi-merge-cli/src/__tests__/_helpers/cli-harness.ts
@@ -33,6 +33,8 @@ export type CliHarness = {
   dir: () => string;
   /** Lines captured from console.error during the current test. */
   stderr: () => string[];
+  /** Lines captured from console.log (LogWithMillisDiff) during the current test. */
+  stdout: () => string[];
   /** Run `main()` with these argv entries; resolves to the exit code. */
   run: (...args: string[]) => Promise<number>;
   /** Write a file into the temp dir, returning its absolute path. */
@@ -47,7 +49,8 @@ export type CliHarness = {
 
 export function installCliHarness(): CliHarness {
   let tmpDir = '';
-  let captured: string[] = [];
+  let capturedErr: string[] = [];
+  let capturedOut: string[] = [];
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const realExit = process.exit;
@@ -57,13 +60,16 @@ export function installCliHarness(): CliHarness {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openapi-merge-cli-'));
-    captured = [];
+    capturedErr = [];
+    capturedOut = [];
     (process as any).exit = (code?: number): never => {
       throw new ExitError(code ?? 0);
     };
-    console.log = (): void => undefined;
+    console.log = (...args: unknown[]): void => {
+      capturedOut.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    };
     console.error = (...args: unknown[]): void => {
-      captured.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+      capturedErr.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
     };
   });
 
@@ -78,7 +84,8 @@ export function installCliHarness(): CliHarness {
 
   return {
     dir: () => tmpDir,
-    stderr: () => captured,
+    stderr: () => capturedErr,
+    stdout: () => capturedOut,
     run: async (...args: string[]): Promise<number> => {
       process.argv = ['node', 'openapi-merge-cli', ...args];
       try {

--- a/packages/openapi-merge-cli/src/__tests__/cli-invocation.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-invocation.test.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import { load as loadYaml } from 'js-yaml';
 import { ExitCode } from '../index';
 import { getPath, installCliHarness, oas } from './_helpers/cli-harness';
 
@@ -13,6 +14,31 @@ import { getPath, installCliHarness, oas } from './_helpers/cli-harness';
  */
 
 const cli = installCliHarness();
+
+/** A minimal OpenAPI 3.x document with one operation, for scanning tests. */
+const spec = (version: string, pathName: string) => ({
+  openapi: version,
+  info: { title: 'T', version: '1.0.0' },
+  paths: { [pathName]: getPath(pathName.slice(1)) },
+});
+
+/** Runs the CLI with `cli.dir()` as the process cwd, so default (no `-c`) lookups resolve there. */
+const runInDir = async (...args: string[]): Promise<number> => {
+  const previous = process.cwd();
+  process.chdir(cli.dir());
+  try {
+    return await cli.run(...args);
+  } finally {
+    process.chdir(previous);
+  }
+};
+
+/** Reads back whatever `init` wrote to `openapi-merge.yaml` in the temp dir. */
+const generated = (): { inputs: Array<{ inputFile: string }>; output: string } =>
+  loadYaml(fs.readFileSync(path.join(cli.dir(), 'openapi-merge.yaml'), 'utf8')) as {
+    inputs: Array<{ inputFile: string }>;
+    output: string;
+  };
 
 describe('main - option isolation between invocations', () => {
   // Regression test for the commander singleton: options are stored on the
@@ -57,25 +83,6 @@ describe('main - option isolation between invocations', () => {
  * before the program is built, and the first test here is what says so.
  */
 describe('init command', () => {
-  const spec = (version: string, pathName: string) => ({
-    openapi: version,
-    info: { title: 'T', version: '1.0.0' },
-    paths: { [pathName]: getPath(pathName.slice(1)) },
-  });
-
-  const runInDir = async (...args: string[]): Promise<number> => {
-    const previous = process.cwd();
-    process.chdir(cli.dir());
-    try {
-      return await cli.run(...args);
-    } finally {
-      process.chdir(previous);
-    }
-  };
-
-  const generated = (): { inputs: Array<{ inputFile: string }>; output: string } =>
-    JSON.parse(fs.readFileSync(path.join(cli.dir(), 'openapi-merge.json'), 'utf8'));
-
   it('still merges when invoked with no arguments at all', async () => {
     // The guard against the subcommand regression. If `init` is ever
     // registered with `.command()`, this fails.
@@ -134,8 +141,8 @@ describe('init command', () => {
     expect(Object.keys(merged.paths).sort()).toEqual(['/a', '/b']);
   });
 
-  it('refuses to overwrite an existing configuration', async () => {
-    cli.writeJson('openapi-merge.json', { inputs: [{ inputFile: './hand-written.yaml' }], output: './out.json' });
+  it('refuses to overwrite an existing openapi-merge.yaml', async () => {
+    cli.write('openapi-merge.yaml', 'inputs:\n  - inputFile: ./hand-written.yaml\noutput: ./out.json\n');
 
     expect(await runInDir('init')).toBe(ExitCode.ErrorLoadingConfig);
     // The hand-written file is untouched -- clobbering it is the one
@@ -143,9 +150,35 @@ describe('init command', () => {
     expect(generated().inputs).toEqual([{ inputFile: './hand-written.yaml' }]);
   });
 
+  it('refuses to run at all when only a legacy openapi-merge.json exists, even though it would write .yaml', async () => {
+    // Without this, init would happily write a fresh openapi-merge.yaml next to
+    // a hand-edited openapi-merge.json -- nothing is deleted, but because the
+    // default lookup now prefers .yaml, the hand-written file would silently
+    // stop being read on the very next merge. Same failure as an overwrite,
+    // just with a longer fuse.
+    const jsonPath = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './hand-written.yaml' }],
+      output: './out.json',
+    });
+
+    expect(await runInDir('init')).toBe(ExitCode.ErrorLoadingConfig);
+    expect(cli.exists('openapi-merge.yaml')).toBe(false);
+    expect(JSON.parse(fs.readFileSync(jsonPath, 'utf8')).inputs).toEqual([{ inputFile: './hand-written.yaml' }]);
+  });
+
+  it('mentions both filenames when both a stale .yaml and .json already exist', async () => {
+    cli.write('openapi-merge.yaml', 'inputs:\n  - inputFile: ./a.yaml\noutput: ./out.yaml\n');
+    cli.writeJson('openapi-merge.json', { inputs: [{ inputFile: './b.yaml' }], output: './out.json' });
+
+    expect(await runInDir('init')).toBe(ExitCode.ErrorLoadingConfig);
+    const message = cli.stderr().join('\n');
+    expect(message).toContain('openapi-merge.yaml');
+    expect(message).toContain('openapi-merge.json');
+  });
+
   it('overwrites when --force is given', async () => {
     cli.writeJson('api.json', spec('3.0.3', '/a'));
-    cli.writeJson('openapi-merge.json', { inputs: [{ inputFile: './stale.yaml' }], output: './out.json' });
+    cli.write('openapi-merge.yaml', 'inputs:\n  - inputFile: ./stale.yaml\noutput: ./out.json\n');
 
     expect(await runInDir('init', '--force')).toBe(ExitCode.Success);
     expect(generated().inputs).toEqual([{ inputFile: './api.json' }]);
@@ -153,10 +186,28 @@ describe('init command', () => {
 
   it('accepts -f as well as --force', async () => {
     cli.writeJson('api.json', spec('3.0.3', '/a'));
-    cli.writeJson('openapi-merge.json', { inputs: [{ inputFile: './stale.yaml' }], output: './out.json' });
+    cli.write('openapi-merge.yaml', 'inputs:\n  - inputFile: ./stale.yaml\noutput: ./out.json\n');
 
     expect(await runInDir('init', '-f')).toBe(ExitCode.Success);
     expect(generated().inputs).toEqual([{ inputFile: './api.json' }]);
+  });
+
+  it('--force always writes .yaml and leaves a pre-existing .json in place, calling it out as inert', async () => {
+    cli.writeJson('api.json', spec('3.0.3', '/a'));
+    const jsonPath = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './stale.yaml' }],
+      output: './out.json',
+    });
+
+    expect(await runInDir('init', '--force')).toBe(ExitCode.Success);
+
+    // The fresh .yaml is written...
+    expect(generated().inputs).toEqual([{ inputFile: './api.json' }]);
+    // ...but the stale .json is neither deleted nor rewritten...
+    expect(JSON.parse(fs.readFileSync(jsonPath, 'utf8')).inputs).toEqual([{ inputFile: './stale.yaml' }]);
+    // ...and the command says so, since it will no longer be read by default.
+    expect(cli.stdout().join('\n')).toContain('openapi-merge.json');
+    expect(cli.stdout().join('\n')).toContain('no longer used');
   });
 
   it('writes a usable placeholder when the directory has no specs', async () => {
@@ -182,5 +233,57 @@ describe('init command', () => {
 
     expect(await runInDir('init')).toBe(ExitCode.Success);
     expect(generated().inputs).toHaveLength(2);
+  });
+});
+
+/**
+ * `init`'s idempotence, and how a bare (no `-c`) merge invocation resolves
+ * the default config file now that there are two candidate names.
+ */
+describe('init idempotence and the default config lookup', () => {
+  it('init then init --force with unchanged inputs produces byte-identical output', async () => {
+    // 33's "twice in a row is identical" invariant, re-checked now that a
+    // second run needs --force: the guard changes how you get there, not
+    // what you get.
+    cli.writeJson('a.json', spec('3.0.3', '/a'));
+    cli.writeJson('b.json', spec('3.0.3', '/b'));
+
+    expect(await runInDir('init')).toBe(ExitCode.Success);
+    const first = fs.readFileSync(path.join(cli.dir(), 'openapi-merge.yaml'), 'utf8');
+
+    expect(await runInDir('init', '--force')).toBe(ExitCode.Success);
+    const second = fs.readFileSync(path.join(cli.dir(), 'openapi-merge.yaml'), 'utf8');
+
+    expect(second).toBe(first);
+  });
+
+  it('a bare invocation finds a legacy openapi-merge.json when no .yaml is present', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    cli.writeJson('openapi-merge.json', { inputs: [{ inputFile: './a.json' }], output: './output.json' });
+
+    expect(await runInDir()).toBe(ExitCode.Success);
+    expect(cli.stdout().join('\n')).toContain("Using 'openapi-merge.json'");
+    expect(cli.exists('output.json')).toBe(true);
+  });
+
+  it('a bare invocation prefers openapi-merge.yaml when both are present', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    cli.writeJson('b.json', oas({ '/b': getPath('getB') }));
+    cli.write('openapi-merge.yaml', 'inputs:\n  - inputFile: ./a.json\noutput: ./from-yaml.json\n');
+    cli.writeJson('openapi-merge.json', { inputs: [{ inputFile: './b.json' }], output: './from-json.json' });
+
+    expect(await runInDir()).toBe(ExitCode.Success);
+    expect(cli.stdout().join('\n')).toContain("Using 'openapi-merge.yaml'");
+    // Proof it actually used the .yaml config, not just that it logged so: the
+    // .yaml config's output was written, the .json config's was not.
+    expect(cli.exists('from-yaml.json')).toBe(true);
+    expect(cli.exists('from-json.json')).toBe(false);
+  });
+
+  it('reports both filenames when neither default config exists', async () => {
+    expect(await runInDir()).toBe(ExitCode.ErrorLoadingConfig);
+    const message = cli.stderr().join('\n');
+    expect(message).toContain('openapi-merge.yaml');
+    expect(message).toContain('openapi-merge.json');
   });
 });

--- a/packages/openapi-merge-cli/src/__tests__/init-command.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/init-command.test.ts
@@ -1,6 +1,12 @@
 import {
-  buildConfiguration, CandidateFile, classify, isScannable, PLACEHOLDER_INPUT, selectInputs, suggestedOutput,
+  buildConfiguration, CandidateFile, chosenInputs, classify, isScannable, OptionalFieldBlock, PER_INPUT_OPTIONAL_BLOCKS,
+  PLACEHOLDER_INPUT, renderInitYaml, selectInputs, suggestedOutput, TOP_LEVEL_OPTIONAL_BLOCKS,
 } from '../init-command';
+import { load as loadYaml } from 'js-yaml';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import ConfigurationSchema from '../configuration.schema.json';
+import { Configuration } from '../data';
 
 /**
  * The decisions behind `openapi-merge-cli init` (see init-command.ts).
@@ -66,7 +72,10 @@ describe('init scanning (isScannable)', () => {
     expect(['a.ts', 'a.md', 'README', 'a.jsonc', 'a.yaml.bak'].some(isScannable)).toBe(false);
   });
 
-  it('never scans the configuration file it is about to write', () => {
+  it('never scans either default configuration filename', () => {
+    // Not just the one `init` currently writes -- a leftover openapi-merge.json
+    // from before this tool wrote YAML is not an OpenAPI document either.
+    expect(isScannable('openapi-merge.yaml')).toBe(false);
     expect(isScannable('openapi-merge.json')).toBe(false);
   });
 });
@@ -171,6 +180,193 @@ describe('init configuration', () => {
       // The output follows the placeholder's extension, exactly as it follows
       // real inputs -- the rule does not change just because nothing was found.
       output: './openapi.yaml',
+    });
+  });
+});
+
+/**
+ * `renderInitYaml` -- the file `init` actually writes.
+ *
+ * The comments are the whole point of 34, so "it produces a string" is not
+ * enough: these tests check that the comments are inert (the active part is
+ * exactly what `buildConfiguration` would have produced), and that every
+ * commented block, uncommented in isolation, is something the real schema
+ * accepts -- not just plausible-looking YAML.
+ */
+describe('init YAML rendering (renderInitYaml)', () => {
+  const ajv = new Ajv();
+  addFormats(ajv);
+  const validate = ajv.compile(ConfigurationSchema);
+
+  /** Parses just the active (uncommented) part of a rendered file. */
+  function parseActive(rendered: string): unknown {
+    return loadYaml(rendered);
+  }
+
+  function render(inputs: ReadonlyArray<string>): string {
+    return renderInitYaml(chosenInputs(inputs), buildConfiguration(inputs).output);
+  }
+
+  describe('the active part is inert -- comments add nothing to what is parsed', () => {
+    it('with several inputs', () => {
+      const inputs = ['./service-a.yaml', './service-b.yaml'];
+      expect(parseActive(render(inputs))).toEqual(buildConfiguration(inputs));
+    });
+
+    it('with a single input', () => {
+      const inputs = ['./only.yaml'];
+      expect(parseActive(render(inputs))).toEqual(buildConfiguration(inputs));
+    });
+
+    it('with no inputs -- the placeholder case', () => {
+      expect(parseActive(render([]))).toEqual(buildConfiguration([]));
+    });
+  });
+
+  it('the active document validates against the real configuration schema', () => {
+    expect(validate(parseActive(render(['./a.yaml', './b.yaml', './c.yaml'])))).toBe(true);
+  });
+
+  it('is deterministic -- the same inputs render the same bytes twice', () => {
+    const inputs = ['./a.yaml', './b.yaml'];
+    expect(render(inputs)).toBe(render(inputs));
+  });
+
+  it('quotes an input path with YAML-special characters so the file still parses as a scalar', () => {
+    // Unquoted, js-yaml would read "a: b.yaml" as a nested mapping key rather
+    // than a plain string -- this is what yamlScalar() exists to prevent.
+    const inputs = ['./a: b.yaml'];
+    const rendered = render(inputs);
+    const parsed = parseActive(rendered) as Configuration;
+
+    expect(parsed.inputs).toEqual([{ inputFile: './a: b.yaml' }]);
+    expect(validate(parsed)).toBe(true);
+  });
+
+  it('shows the full per-input block exactly once, regardless of how many inputs were found', () => {
+    const rendered = render(['./a.yaml', './b.yaml', './c.yaml']);
+
+    for (const block of PER_INPUT_OPTIONAL_BLOCKS) {
+      const occurrences = rendered.split(`# ${block.name}:`).length - 1;
+      expect(occurrences).toBe(1);
+    }
+    // Every input after the first points back at it instead of repeating it.
+    const pointerOccurrences = rendered.split('see the commented block under the first input above').length - 1;
+    expect(pointerOccurrences).toBe(2);
+  });
+
+  it('attaches the per-input block to the one placeholder input when nothing was found', () => {
+    const rendered = render([]);
+
+    for (const block of PER_INPUT_OPTIONAL_BLOCKS) {
+      expect(rendered).toContain(`# ${block.name}:`);
+    }
+  });
+
+  describe('field coverage matches data.ts', () => {
+    it('every optional top-level Configuration field is represented', () => {
+      // Cross-checked by hand against Configuration in data.ts. Update this list
+      // (and TOP_LEVEL_OPTIONAL_BLOCKS) if a field is added, renamed or removed.
+      const expected = [
+        'outputRoot', 'formatting', 'serversStrategy', 'securitySchemesStrategy', 'pruneUnusedComponents', 'info',
+      ];
+      expect(TOP_LEVEL_OPTIONAL_BLOCKS.map(block => block.name).sort()).toEqual([...expected].sort());
+    });
+
+    it('every optional per-input field (ConfigurationInputBase + DisputeV2) is represented', () => {
+      // Cross-checked by hand against ConfigurationInputBase and DisputeV2 in
+      // data.ts. Update this list (and PER_INPUT_OPTIONAL_BLOCKS) if a field is
+      // added, renamed or removed. Deliberately excludes the deprecated
+      // `disputePrefix` (DisputeV1) -- see the note on TOP_LEVEL_OPTIONAL_BLOCKS.
+      const expected = ['pathModification', 'operationSelection', 'description', 'duplicatePathHandling', 'tag', 'dispute'];
+      expect(PER_INPUT_OPTIONAL_BLOCKS.map(block => block.name).sort()).toEqual([...expected].sort());
+    });
+  });
+
+  describe('every commented block is independently valid once uncommented', () => {
+    // Not "uncomment everything at once": `dispute` is prefix XOR suffix, and
+    // an input is inputFile XOR inputURL, so an all-uncommented document would
+    // fail ajv for reasons that have nothing to do with whether any individual
+    // block is correct. Each block is tested in isolation instead, merged into
+    // an otherwise-minimal, otherwise-valid base document.
+
+    const baseInputs = ['./a.yaml', './b.yaml'];
+    const baseConfig = buildConfiguration(baseInputs) as Configuration;
+
+    for (const block of TOP_LEVEL_OPTIONAL_BLOCKS) {
+      it(`top-level: ${block.name}`, () => {
+        const fragment = loadYaml(block.yaml) as Partial<Configuration>;
+        const doc = { ...baseConfig, ...fragment };
+
+        expect(validate(doc)).toBe(true);
+      });
+    }
+
+    for (const block of PER_INPUT_OPTIONAL_BLOCKS) {
+      it(`per-input: ${block.name}`, () => {
+        const fragment = loadYaml(block.yaml) as Record<string, unknown>;
+        const doc: Configuration = {
+          ...baseConfig,
+          inputs: [{ ...baseConfig.inputs[0], ...fragment }, ...baseConfig.inputs.slice(1)],
+        };
+
+        expect(validate(doc)).toBe(true);
+      });
+    }
+  });
+
+  describe('a block uncommented in place in the real rendered file, not just in isolation', () => {
+    // The two describe blocks above validate `block.yaml` at zero indent --
+    // the *source* string, which never actually passes through
+    // renderCommentedBlock. What they cannot catch is a rendering bug in how
+    // much indent gets applied where -- in particular the +4 (not +2) hop
+    // from a list item's own line to its sibling keys
+    // (PER_INPUT_BLOCK_INDENT). These tests take the literal string `init`
+    // writes, strip the comment marker off one block's own YAML lines --
+    // leaving its explanation line commented, the way a person editing the
+    // file would actually uncomment a setting -- and parse and validate the
+    // *whole resulting document*.
+
+    function findBlock(blocks: ReadonlyArray<OptionalFieldBlock>, name: string): OptionalFieldBlock {
+      const found = blocks.find(block => block.name === name);
+      if (found === undefined) {
+        throw new Error(`No block named '${name}'`);
+      }
+      return found;
+    }
+
+    /** Strips the `indent + '# '` prefix from exactly one block's YAML lines within a rendered file. */
+    function uncommentBlockInPlace(rendered: string, block: OptionalFieldBlock, indent: string): string {
+      const yamlLines = block.yaml.split('\n');
+      const commentedLines = yamlLines.map(line => `${indent}# ${line}`);
+      const uncommentedLines = yamlLines.map(line => `${indent}${line}`);
+
+      const lines = rendered.split('\n');
+      const start = lines.findIndex((_line, i) => commentedLines.every((expected, j) => lines[i + j] === expected));
+      if (start === -1) {
+        throw new Error(`Could not find '${block.name}' rendered at indent ${JSON.stringify(indent)}`);
+      }
+
+      lines.splice(start, commentedLines.length, ...uncommentedLines);
+      return lines.join('\n');
+    }
+
+    it('a top-level block (zero indent)', () => {
+      const block = findBlock(TOP_LEVEL_OPTIONAL_BLOCKS, 'formatting');
+      const rendered = render(['./a.yaml']);
+
+      const doc = loadYaml(uncommentBlockInPlace(rendered, block, ''));
+
+      expect(validate(doc)).toBe(true);
+    });
+
+    it('a per-input block (the +4 hop into a list item)', () => {
+      const block = findBlock(PER_INPUT_OPTIONAL_BLOCKS, 'tag');
+      const rendered = render(['./a.yaml', './b.yaml']);
+
+      const doc = loadYaml(uncommentBlockInPlace(rendered, block, '    '));
+
+      expect(validate(doc)).toBe(true);
     });
   });
 });

--- a/packages/openapi-merge-cli/src/__tests__/load-configuration.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/load-configuration.test.ts
@@ -101,12 +101,23 @@ describe('loadConfiguration - file errors', () => {
     expect(message).toContain('nope.json');
   });
 
-  it('defaults to openapi-merge.json when no location is given', async () => {
-    // Nothing named openapi-merge.json exists in the test process's cwd, so this
-    // exercises the default-path branch through its failure message.
-    const message = expectError(await loadConfiguration());
+  it('defaults to openapi-merge.yaml, falling back to openapi-merge.json, when no location is given', async () => {
+    // Exercises the default-lookup branch (try .yaml, then .json) through its
+    // failure message, which names both candidates it tried. Runs from the
+    // empty temp dir rather than the test process's ambient cwd -- relying on
+    // "nothing named openapi-merge.* happens to exist in the package root
+    // right now" would make this test's outcome depend on what else is lying
+    // around there.
+    const previousCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      const message = expectError(await loadConfiguration());
 
-    expect(message).toContain('openapi-merge.json');
+      expect(message).toContain('openapi-merge.yaml');
+      expect(message).toContain('openapi-merge.json');
+    } finally {
+      process.chdir(previousCwd);
+    }
   });
 
   it('surfaces a parse failure for a file that is neither JSON nor YAML', async () => {

--- a/packages/openapi-merge-cli/src/config-file-names.ts
+++ b/packages/openapi-merge-cli/src/config-file-names.ts
@@ -1,0 +1,16 @@
+/**
+ * The default configuration filenames, in lookup/preference order.
+ *
+ * `init` writes {@link STANDARD_CONFIG_FILE_YAML}; `openapi-merge.json` is
+ * kept as a fallback so a config written before this file existed keeps
+ * loading without `-c`. Defined once here rather than in both
+ * `init-command.ts` (which writes the file) and `load-configuration.ts`
+ * (which reads it), so the two cannot drift apart.
+ */
+export const STANDARD_CONFIG_FILE_YAML = 'openapi-merge.yaml';
+
+/** @deprecated in favour of {@link STANDARD_CONFIG_FILE_YAML}; still read for backwards compatibility. */
+export const STANDARD_CONFIG_FILE_JSON = 'openapi-merge.json';
+
+/** Every default filename `init` and the no-`-c` lookup know about, preference order first. */
+export const STANDARD_CONFIG_FILE_CANDIDATES = [STANDARD_CONFIG_FILE_YAML, STANDARD_CONFIG_FILE_JSON] as const;

--- a/packages/openapi-merge-cli/src/exit-codes.ts
+++ b/packages/openapi-merge-cli/src/exit-codes.ts
@@ -37,10 +37,11 @@ export enum ExitCode {
   /**
    * The configuration file could not be found, read, parsed, or validated.
    *
-   * Covers the whole config-loading stage: a missing `openapi-merge.json`, a
-   * file that is neither valid JSON nor valid YAML, a document that fails the
-   * generated JSON Schema, and the cross-field semantic checks that the schema
-   * cannot express (currently: tab indentation paired with a YAML output).
+   * Covers the whole config-loading stage: a missing `openapi-merge.yaml` (or,
+   * as a fallback, `openapi-merge.json`), a file that is neither valid JSON
+   * nor valid YAML, a document that fails the generated JSON Schema, and the
+   * cross-field semantic checks that the schema cannot express (currently: tab
+   * indentation paired with a YAML output).
    *
    * Nothing has been read or written by the time this fires, so it is always
    * safe to retry after fixing the config.

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -1,8 +1,9 @@
 import { ConfigurationInput, isConfigurationInputFromFile } from "./data";
 import { loadConfiguration } from "./load-configuration";
 import {
-  buildConfiguration, CandidateFile, isScannable, PLACEHOLDER_INPUT, selectInputs, STANDARD_CONFIG_FILE,
+  buildConfiguration, CandidateFile, chosenInputs, isScannable, PLACEHOLDER_INPUT, renderInitYaml, selectInputs,
 } from "./init-command";
+import { STANDARD_CONFIG_FILE_CANDIDATES, STANDARD_CONFIG_FILE_JSON, STANDARD_CONFIG_FILE_YAML } from "./config-file-names";
 import { Command } from 'commander';
 // package.json sits outside tsconfig's rootDir, so it cannot be imported as a
 // module without widening the compilation. require() is the pragmatic option.
@@ -59,12 +60,15 @@ function buildProgram(): Command {
   // so `--help` still documents it.
   program.addHelpText('after', `
 Commands:
-  init [--force]             Write a starter openapi-merge.json in the current
+  init [--force]             Write a starter openapi-merge.yaml in the current
                              directory, filled in with any OpenAPI 3.x files
-                             found alongside it. Refuses to overwrite an
-                             existing configuration unless --force is given.
+                             found alongside it, and every optional setting
+                             shown commented out. Refuses to overwrite an
+                             existing configuration (openapi-merge.yaml or
+                             openapi-merge.json) unless --force is given.
 
-Run with no arguments to perform the merge described by openapi-merge.json.`);
+Run with no arguments to perform the merge described by openapi-merge.yaml
+(or openapi-merge.json, if that is the only one present).`);
 
   return program;
 }
@@ -77,12 +81,22 @@ Run with no arguments to perform the merge described by openapi-merge.json.`);
  * command exists to create.
  */
 async function runInit(force: boolean, logger: LogWithMillisDiff): Promise<ExitCode> {
-  const targetPath = path.resolve(process.cwd(), STANDARD_CONFIG_FILE);
+  const targetPath = path.resolve(process.cwd(), STANDARD_CONFIG_FILE_YAML);
 
-  if (fs.existsSync(targetPath) && !force) {
+  // Refuse if *either* default name is present, not just the one this writes.
+  // `init` now prefers `.yaml`, so a stray hand-edited `.json` that got no
+  // refusal would simply stop being used the moment a fresh `.yaml` landed
+  // next to it -- the config wouldn't be deleted, just silently shadowed on
+  // the very next merge. That is the same failure an overwrite would cause,
+  // with a longer fuse.
+  const existingConfigFiles = STANDARD_CONFIG_FILE_CANDIDATES.filter(fileName =>
+    fs.existsSync(path.resolve(process.cwd(), fileName)));
+
+  if (existingConfigFiles.length > 0 && !force) {
     console.error(
-      `'${STANDARD_CONFIG_FILE}' already exists in ${process.cwd()}. ` +
-        `Pass --force to overwrite it, or edit the existing file.`,
+      `${existingConfigFiles.map(fileName => `'${fileName}'`).join(' and ')} already ` +
+        `exist${existingConfigFiles.length === 1 ? 's' : ''} in ${process.cwd()}. ` +
+        `Pass --force to overwrite, or edit the existing file.`,
     );
     return ExitCode.ErrorLoadingConfig;
   }
@@ -111,15 +125,17 @@ async function runInit(force: boolean, logger: LogWithMillisDiff): Promise<ExitC
   const { inputs, swagger2, minorVersions } = selectInputs(candidates);
   const configuration = buildConfiguration(inputs);
 
-  fs.writeFileSync(targetPath, `${JSON.stringify(configuration, null, 2)}\n`);
+  fs.writeFileSync(targetPath, renderInitYaml(chosenInputs(inputs), configuration.output));
 
   if (inputs.length > 0) {
-    logger.log(`## Wrote ${STANDARD_CONFIG_FILE} with ${inputs.length} input${inputs.length === 1 ? '' : 's'}:`);
+    logger.log(`## Wrote ${STANDARD_CONFIG_FILE_YAML} with ${inputs.length} input${inputs.length === 1 ? '' : 's'}:`);
     inputs.forEach(input => logger.log(`##   ${input}`));
   } else {
-    logger.log(`## Wrote ${STANDARD_CONFIG_FILE}. No OpenAPI 3.x files were found here, so it contains a`);
+    logger.log(`## Wrote ${STANDARD_CONFIG_FILE_YAML}. No OpenAPI 3.x files were found here, so it contains a`);
     logger.log(`##   placeholder input -- replace '${PLACEHOLDER_INPUT}' before running the merge.`);
   }
+
+  logger.log(`##   Every other setting is included, commented out -- uncomment what you need.`);
 
   if (swagger2.length > 0) {
     // Named rather than ignored: people do try to merge 2.0 documents (issue
@@ -137,7 +153,15 @@ async function runInit(force: boolean, logger: LogWithMillisDiff): Promise<ExitC
     logger.log('##   before running the merge.');
   }
 
-  logger.log(`## Edit ${STANDARD_CONFIG_FILE}, then run openapi-merge-cli to produce '${configuration.output}'.`);
+  if (existingConfigFiles.includes(STANDARD_CONFIG_FILE_JSON)) {
+    // `--force` overwrote nothing named `.json` -- it can't have, the target is
+    // always `.yaml`. Said explicitly because the old file is now inert: the
+    // default lookup in load-configuration.ts prefers `.yaml`, so the `.json`
+    // file will simply never be read again unless it's passed via `-c`.
+    logger.log(`## '${STANDARD_CONFIG_FILE_JSON}' still exists but is no longer used -- '${STANDARD_CONFIG_FILE_YAML}' is preferred now. Delete it, or keep it as a backup.`);
+  }
+
+  logger.log(`## Edit ${STANDARD_CONFIG_FILE_YAML}, then run openapi-merge-cli to produce '${configuration.output}'.`);
 
   return ExitCode.Success;
 }
@@ -335,7 +359,9 @@ export async function main(): Promise<void> {
   const options = program.opts<CliOptions>();
   logger.log(`## ${process.argv[0]}: Running v${pjson.version}`);
 
-  const config = await loadConfiguration(options.config);
+  const config = await loadConfiguration(options.config, fileName => {
+    logger.log(`## Using '${fileName}' from ${process.cwd()}`);
+  });
 
   if (typeof config === 'string') {
     console.error(config);

--- a/packages/openapi-merge-cli/src/init-command.ts
+++ b/packages/openapi-merge-cli/src/init-command.ts
@@ -1,5 +1,7 @@
 import path from 'path';
+import { dump as dumpYaml } from 'js-yaml';
 import { Configuration } from './data';
+import { STANDARD_CONFIG_FILE_CANDIDATES } from './config-file-names';
 
 /**
  * Building a starter configuration from the files already in a directory.
@@ -124,15 +126,23 @@ export function suggestedOutput(inputs: ReadonlyArray<string>): string {
 export const PLACEHOLDER_INPUT = './replace-me.openapi.yaml';
 
 /**
- * Builds the configuration to write.
+ * The inputs that will actually be written, given what the scan found.
  *
- * With no candidates this still emits one placeholder input rather than an
+ * With no candidates this still returns one placeholder input rather than an
  * empty list. `inputs` is `@minItems 1` in the schema, so an empty array would
  * produce a file that fails validation on the very next run -- a generator
  * whose output its own tool rejects.
+ *
+ * Shared between {@link buildConfiguration} and {@link renderInitYaml} so
+ * the "what counts as chosen" decision is made in exactly one place.
  */
+export function chosenInputs(inputs: ReadonlyArray<string>): string[] {
+  return inputs.length > 0 ? [...inputs] : [PLACEHOLDER_INPUT];
+}
+
+/** Builds the configuration to write. */
 export function buildConfiguration(inputs: ReadonlyArray<string>): Configuration {
-  const chosen = inputs.length > 0 ? [...inputs] : [PLACEHOLDER_INPUT];
+  const chosen = chosenInputs(inputs);
 
   return {
     inputs: chosen.map(inputFile => ({ inputFile })),
@@ -140,10 +150,199 @@ export function buildConfiguration(inputs: ReadonlyArray<string>): Configuration
   };
 }
 
+/**
+ * A single optional field (or optional group of fields) shown commented-out
+ * in the file `init` writes.
+ *
+ * `yaml` is written as if it were top-level, valid YAML on its own -- it is
+ * what you get by taking the leading `# ` off every line `render` produces
+ * for this block. That is the property the per-field tests rely on: each
+ * block, uncommented in isolation and merged into a minimal base document,
+ * must pass the real configuration schema. In particular every *required*
+ * sub-field of an optional object (`description.append`, `tag.name`,
+ * `dispute.prefix`, `formatting.indent.style`+`width`) is present, not just
+ * the optional leaves -- a block that only shows the optional parts of a
+ * required shape would fail validation the moment it is uncommented, which
+ * defeats the point of generating it.
+ */
+export type OptionalFieldBlock = {
+  /** Identifies the field for tests; not shown to the user. */
+  name: string;
+  /** One-line (or one-line-per-sub-field) explanation, condensed from the TSDoc in data.ts. */
+  explanation: string;
+  /** The field's YAML, uncommented, at zero indentation. */
+  yaml: string;
+};
+
+/**
+ * `Configuration`'s optional fields (data.ts), in the order they appear
+ * there. Deliberately excludes the deprecated `disputePrefix` -- only the
+ * current `dispute` shape (`DisputeV2`) is worth showing to a new user.
+ */
+export const TOP_LEVEL_OPTIONAL_BLOCKS: ReadonlyArray<OptionalFieldBlock> = [
+  {
+    name: 'outputRoot',
+    explanation: 'Defence in depth: refuse to write the merged output anywhere outside this directory.',
+    yaml: 'outputRoot: .',
+  },
+  {
+    name: 'formatting',
+    explanation: 'How the merged output file is indented. Defaults to 2 spaces.',
+    yaml: [
+      'formatting:',
+      '  indent:',
+      '    style: spaces # spaces | tabs (tabs are JSON-output only -- YAML forbids tab indentation)',
+      '    width: 2',
+    ].join('\n'),
+  },
+  {
+    name: 'serversStrategy',
+    explanation: "How to combine the top-level 'servers' array across inputs.",
+    yaml: 'serversStrategy: first # first (default, keep only the first input\'s servers) | concat (keep every input\'s, deduplicated)',
+  },
+  {
+    name: 'securitySchemesStrategy',
+    explanation: 'How to combine components.securitySchemes across inputs.',
+    yaml: 'securitySchemesStrategy: merge # merge (default, rename clashes) | first (drop the rest) | error (fail on a clash)',
+  },
+  {
+    name: 'pruneUnusedComponents',
+    explanation: 'Drop components that nothing in the merged output references. Off by default -- pruning is destructive.',
+    yaml: 'pruneUnusedComponents: false',
+  },
+  {
+    name: 'info',
+    explanation: "Override fields of the merged 'info' object instead of taking it from the first input.",
+    yaml: [
+      'info:',
+      '  title: My Merged API',
+      '  version: 1.0.0',
+      '  description: A description for the merged document.',
+    ].join('\n'),
+  },
+];
+
+/**
+ * `ConfigurationInputBase` and `DisputeV2`'s optional fields (data.ts), in
+ * the order they appear there. Shown once, under the first input -- see
+ * {@link renderInitYaml}.
+ */
+export const PER_INPUT_OPTIONAL_BLOCKS: ReadonlyArray<OptionalFieldBlock> = [
+  {
+    name: 'pathModification',
+    explanation: "Rewrite this input's paths before merging: strip a prefix, then prepend one.",
+    yaml: [
+      'pathModification:',
+      '  stripStart: /v1',
+      '  prepend: /service-a',
+    ].join('\n'),
+  },
+  {
+    name: 'operationSelection',
+    explanation: 'Only keep operations with these tags, or drop operations with these tags (exclusion wins on conflict).',
+    yaml: [
+      'operationSelection:',
+      '  includeTags: [public]',
+      '  excludeTags: [internal]',
+    ].join('\n'),
+  },
+  {
+    name: 'description',
+    explanation: "Fold this input's info.description into the merged document's description.",
+    yaml: [
+      'description:',
+      '  append: true',
+      '  title:',
+      "    value: A title for this input's section",
+      '    headingLevel: 2',
+    ].join('\n'),
+  },
+  {
+    name: 'duplicatePathHandling',
+    explanation: 'What to do when this input declares a path another input already contributed.',
+    yaml: 'duplicatePathHandling: error # error (default) | skip-later | prefer-later | merge-operations',
+  },
+  {
+    name: 'tag',
+    explanation: "Add a tag to every operation from this input, so the merged document shows which service it came from.",
+    yaml: [
+      'tag:',
+      '  name: service-a',
+      '  description: Endpoints from this input',
+    ].join('\n'),
+  },
+  {
+    name: 'dispute',
+    explanation: "If a component name clashes with another input's, disambiguate with this prefix (or 'suffix' instead of 'prefix').",
+    yaml: [
+      'dispute:',
+      '  prefix: serviceA_',
+      '  alwaysApply: false',
+    ].join('\n'),
+  },
+];
+
+/** Renders one {@link OptionalFieldBlock} as commented-out lines at the given indent. */
+function renderCommentedBlock(block: OptionalFieldBlock, indent: string): string {
+  const lines = [`${indent}# ${block.explanation}`, ...block.yaml.split('\n').map(line => `${indent}# ${line}`)];
+  return lines.join('\n');
+}
+
+/** Indent of a second-or-later key inside an `inputs` list item, matching js-yaml's own 2-space nesting. */
+const PER_INPUT_BLOCK_INDENT = '    ';
+
+/** A YAML scalar for `value`, quoted exactly as js-yaml would quote it -- so paths with special characters stay valid. */
+function yamlScalar(value: string): string {
+  return dumpYaml(value).trimEnd();
+}
+
+/**
+ * Renders the full file `init` writes: real `inputs`/`output`, computed
+ * exactly as {@link buildConfiguration} does, interleaved with every
+ * optional field from `Configuration` and `ConfigurationInputBase`,
+ * commented out.
+ *
+ * Not built by serialising a `Configuration` object -- js-yaml's `dump()`
+ * has no notion of a comment attached to a key, so comments cannot survive
+ * an object round-trip through it. This assembles the file as a template
+ * instead: real lines for the values `init` actually found, hand-written
+ * commented lines for everything it did not.
+ *
+ * The per-input block ({@link PER_INPUT_OPTIONAL_BLOCKS}) is shown in full
+ * only under the *first* input, with every later input pointing back to it.
+ * The fields are identical regardless of which input they are attached to,
+ * so repeating the block under every input would only add noise -- most
+ * directories this scans have more than one file.
+ */
+export function renderInitYaml(chosenInputs: ReadonlyArray<string>, output: string): string {
+  const inputLines = chosenInputs.flatMap((inputFile, index) => {
+    const line = `  - inputFile: ${yamlScalar(inputFile)}`;
+    if (index === 0) {
+      const blocks = PER_INPUT_OPTIONAL_BLOCKS.map(block => renderCommentedBlock(block, PER_INPUT_BLOCK_INDENT));
+      return [line, `${PER_INPUT_BLOCK_INDENT}# Per-input options (all optional, all commented out below).`, ...blocks];
+    }
+    return [line, `${PER_INPUT_BLOCK_INDENT}# Per-input options: see the commented block under the first input above -- the same fields apply here.`];
+  });
+
+  const topLevelLines = TOP_LEVEL_OPTIONAL_BLOCKS.flatMap(block => ['', renderCommentedBlock(block, '')]);
+
+  return [
+    '# openapi-merge-cli configuration.',
+    '#',
+    "# Everything from here down to 'output:' is required; everything after it",
+    '# is optional and commented out. Uncomment a block to turn it on.',
+    '# Full documentation: https://github.com/robertmassaioli/openapi-merge/wiki/README',
+    '',
+    'inputs:',
+    ...inputLines,
+    `output: ${yamlScalar(output)}`,
+    ...topLevelLines,
+    '',
+  ].join('\n');
+}
+
 /** Extensions worth opening. Everything else cannot be a specification. */
 const SCANNABLE_EXTENSIONS: ReadonlySet<string> = new Set(['.json', '.yaml', '.yml']);
-
-export const STANDARD_CONFIG_FILE = 'openapi-merge.json';
 
 /**
  * Whether a directory entry is worth reading.
@@ -153,7 +352,15 @@ export const STANDARD_CONFIG_FILE = 'openapi-merge.json';
  * and every such list is wrong for somebody. A predictable shallow scan the
  * user can correct by hand beats a clever deep one that quietly pulls in a
  * vendored copy of somebody else's API.
+ *
+ * Both default config filenames are excluded, not just the one `init`
+ * currently writes: a leftover `openapi-merge.json` from before this file
+ * existed is not an OpenAPI document either, and scanning it would be a
+ * waste even though `classify` would reject it anyway.
  */
 export function isScannable(fileName: string): boolean {
-  return fileName !== STANDARD_CONFIG_FILE && SCANNABLE_EXTENSIONS.has(path.extname(fileName).toLowerCase());
+  return (
+    !(STANDARD_CONFIG_FILE_CANDIDATES as readonly string[]).includes(fileName)
+    && SCANNABLE_EXTENSIONS.has(path.extname(fileName).toLowerCase())
+  );
 }

--- a/packages/openapi-merge-cli/src/load-configuration.ts
+++ b/packages/openapi-merge-cli/src/load-configuration.ts
@@ -7,6 +7,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import ConfigurationSchema from './configuration.schema.json';
 import { readFileAsString, readYamlOrJSON } from "./file-loading";
+import { STANDARD_CONFIG_FILE_CANDIDATES } from "./config-file-names";
 import process from 'process';
 
 const YAML_EXTENSIONS = ['.yaml', '.yml'];
@@ -62,11 +63,12 @@ async function validateConfiguration(rawData: string): Promise<Configuration | s
   }
 }
 
-const STANDARD_CONFIG_FILE = 'openapi-merge.json';
-
-export async function loadConfiguration(configLocation?: string): Promise<Configuration | string> {
-  const configFile = configLocation === undefined ? STANDARD_CONFIG_FILE : configLocation;
-
+/**
+ * Loads the configuration from an explicit path (`-c`, or a path a caller
+ * already resolved). One file, one attempt -- unlike the no-`-c` default
+ * below, there is nothing to fall back to.
+ */
+async function loadFromExplicitPath(configFile: string): Promise<Configuration | string> {
   try {
     const rawData = await readFileAsString(configFile);
 
@@ -76,4 +78,37 @@ export async function loadConfiguration(configLocation?: string): Promise<Config
     // which path was tried and from where.
     return `Could not find or read '${configFile}' in the current directory: ${process.cwd()}`;
   }
+}
+
+/**
+ * Resolves the no-`-c` default: try `openapi-merge.yaml` first, then fall
+ * back to `openapi-merge.json` (`STANDARD_CONFIG_FILE_CANDIDATES`, in that
+ * order) for anyone with a configuration written before `init` moved to
+ * YAML. Only a *missing or unreadable* candidate falls through -- a
+ * candidate that exists but fails to parse or validate is reported as-is,
+ * rather than silently trying the next name and masking the real problem.
+ */
+export async function loadConfiguration(
+  configLocation?: string,
+  onDefaultResolved?: (fileName: string) => void,
+): Promise<Configuration | string> {
+  if (configLocation !== undefined) {
+    return loadFromExplicitPath(configLocation);
+  }
+
+  for (const candidate of STANDARD_CONFIG_FILE_CANDIDATES) {
+    let rawData: string;
+    try {
+      rawData = await readFileAsString(candidate);
+    } catch {
+      continue;
+    }
+    onDefaultResolved?.(candidate);
+    return await validateConfiguration(rawData);
+  }
+
+  return (
+    `Could not find or read '${STANDARD_CONFIG_FILE_CANDIDATES.join("' or '")}' ` +
+    `in the current directory: ${process.cwd()}`
+  );
 }


### PR DESCRIPTION
## Summary

- `init` now writes `openapi-merge.yaml` (not `.json`), with every optional `Configuration` field shown commented-out -- per-input (`dispute`, `pathModification`, `operationSelection`, `description`, `duplicatePathHandling`, `tag`) and top-level (`outputRoot`, `formatting`, `serversStrategy`, `securitySchemesStrategy`, `pruneUnusedComponents`, `info`) -- each with a one-line explanation and a working example. Uncommenting a block always produces something the schema accepts.
- `openapi-merge.json` still loads as a fallback when no `.yaml` is present. `init` refuses to run, even without `--force`, if *either* default filename already exists, so a hand-edited `.json` can't be silently shadowed by a freshly generated `.yaml` on the next merge. `--force` always writes `.yaml` and leaves a pre-existing `.json` untouched, explicitly noting it's no longer read by default.
- Design proposals: [`ai-planning/34-proposal-init-yaml-commented-options.md`](ai-planning/34-proposal-init-yaml-commented-options.md) (this feature, written before implementation and updated with results) and [`ai-planning/35-proposal-commented-yaml-section-type.md`](ai-planning/35-proposal-commented-yaml-section-type.md) (an evaluated, declined-for-now alternative design raised mid-implementation).

## Test plan

- [x] `bun run test` -- whole workspace, 421 + 198 tests, green
- [x] `bun run lint` (ESLint + `tsgo --noEmit`) -- both packages, clean
- [x] 100% function coverage / 98.89% line coverage on the changed `openapi-merge-cli` files
- [x] Manual end-to-end smoke test: real temp directory, `init` -> inspect generated YAML -> merge unedited -> inspect output (run twice, single- and multi-input)
- [x] Verified the new per-input-indent test actually catches a regression (forced the indent constant wrong, confirmed the test goes red, reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)