### PR TITLE
feat(merge): resolve cross-document $refs (#104) with opt-in external bundling (#10)

### DIFF
--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -58,9 +58,9 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`23-proposal-dependency-updates.md`](23-proposal-dependency-updates.md) | Dependency audit and the phased upgrade path |
 | [`24-proposal-openapi-3.2-support.md`](24-proposal-openapi-3.2-support.md) | What it would take to support OpenAPI 3.1 / 3.2 |
 | [`25-proposal-mixed-version-inputs.md`](25-proposal-mixed-version-inputs.md) | Policy for inputs of differing versions, and automatic upgrading |
-| [`26-proposal-oas-phase1-version-checking.md`](26-proposal-oas-phase1-version-checking.md) | Phase 1: detect the input versions and refuse mixed majors |
-| [`27-proposal-oas-phase2-31-support.md`](27-proposal-oas-phase2-31-support.md) | Phase 2: merging OpenAPI 3.1, including webhooks |
-| [`28-proposal-oas-phase3-32-support.md`](28-proposal-oas-phase3-32-support.md) | Phase 3: merging OpenAPI 3.2 |
+| [`26-proposal-oas-phase1-version-checking.md`](26-proposal-oas-phase1-version-checking.md) | ✅ Phase 1: detect the input versions and refuse mixed majors |
+| [`27-proposal-oas-phase2-31-support.md`](27-proposal-oas-phase2-31-support.md) | ✅ Phase 2: merging OpenAPI 3.1, including webhooks |
+| [`28-proposal-oas-phase3-32-support.md`](28-proposal-oas-phase3-32-support.md) | ✅ Phase 3: merging OpenAPI 3.2 |
 | [`29-proposal-node-runtime-verification.md`](29-proposal-node-runtime-verification.md) | ✅ Building with Bun while proving the artifacts run on Node |
 | [`30-proposal-bundle-the-cli.md`](30-proposal-bundle-the-cli.md) | ✅ Bundling the CLI so it runs under both Node and Bun; reduces 29 |
 | [`33-proposal-cli-init-command.md`](33-proposal-cli-init-command.md) | ✅ An `init` command that writes a starter configuration, scanning for inputs |

--- a/ai-planning/issue-triage-value-vs-effort.md
+++ b/ai-planning/issue-triage-value-vs-effort.md
@@ -82,13 +82,13 @@ Higher is better; ties broken by lower effort first.
 | 19 | [#61](https://github.com/robertmassaioli/openapi-merge/issues/61) | Authorization config for `inputURL` | 3 | 2 | **4** | Quick Win | 📝 [17-proposal-61-input-url-auth.md](issues/17-proposal-61-input-url-auth.md) |
 | 20 | [#94](https://github.com/robertmassaioli/openapi-merge/issues/94) | `excludeTags` does not remove unreferenced schemas | 3 | 3 | **3** | Big Bet (low) | — |
 | 21 | [#75](https://github.com/robertmassaioli/openapi-merge/issues/75) | `atlassian-openapi` types incompatible with `openapi-types` | 3 | 3 | **3** | Big Bet (low) | — |
-| 22 | [#104](https://github.com/robertmassaioli/openapi-merge/issues/104) | Incorrect `$ref` paths in bundled file | 4 | 4 | **4** | Big Bet | — |
+| 22 | [#104](https://github.com/robertmassaioli/openapi-merge/issues/104) | Incorrect `$ref` paths in bundled file | 4 | 3 | **4** | Big Bet (low) | ✅ [36-proposal-104-external-ref-rewriting.md](issues/36-proposal-104-external-ref-rewriting.md) |
 | 23 | [#8](https://github.com/robertmassaioli/openapi-merge/issues/8) | Merge duplicate OAS paths using `disputePrefix` | 4 | 4 | **4** | Big Bet | — |
 | 24 | [#109](https://github.com/robertmassaioli/openapi-merge/issues/109) | Conflict-resolution strategies for duplicate paths | 4 | 4 | **4** | Big Bet | — |
 | 25 | [#110](https://github.com/robertmassaioli/openapi-merge/issues/110) | Swagger 2 "definitions" not included | 2 | 3 | **1** | Fill-in / Defer | — |
-| 26 | [#10](https://github.com/robertmassaioli/openapi-merge/issues/10) | Resolve / bundle external `$ref`s | 5 | 5 | **5** | Big Bet | — |
-| 27 | [#113](https://github.com/robertmassaioli/openapi-merge/issues/113) | Add support for OpenAPI 3.1.x | 5 | 5 | **5** | Big Bet | — |
-| 28 | [#96](https://github.com/robertmassaioli/openapi-merge/issues/96) | OpenAPI 3.1 `webhook` support | 3 | 4 | **2** | Big Bet | — |
+| 26 | [#10](https://github.com/robertmassaioli/openapi-merge/issues/10) | Resolve / bundle external `$ref`s | 5 | 5 | **5** | Big Bet | ✅ [37-proposal-10-external-ref-bundling.md](issues/37-proposal-10-external-ref-bundling.md) (Option 2-refined) |
+| 27 | [#113](https://github.com/robertmassaioli/openapi-merge/issues/113) | Add support for OpenAPI 3.1.x | 5 | 5 | **5** | Big Bet | ✅ [26](issues/26-proposal-oas-phase1-version-checking.md)/[27](issues/27-proposal-oas-phase2-31-support.md)/[28](issues/28-proposal-oas-phase3-32-support.md) |
+| 28 | [#96](https://github.com/robertmassaioli/openapi-merge/issues/96) | OpenAPI 3.1 `webhook` support | 3 | 4 | **2** | Big Bet | ✅ Closed 2026-08-01, shipped with #113 |
 
 ---
 
@@ -123,10 +123,13 @@ mappings + callbacks, then route both through `dispute.applyDispute` with
 matching tests in `__tests__/components.test.ts`.
 
 ### 3.3 Big Bets (high value, high effort) — quarter-sized investments
-- **#113** OpenAPI 3.1 support — touches every module because 3.1 reintroduces
-  webhooks, removes `nullable`, allows JSON Schema 2020-12, etc. Likely
-  requires a major version bump and a parallel codepath or upgrade of
-  `atlassian-openapi`.
+- ~~**#113** OpenAPI 3.1 support~~ — ✅ **Done.** Landed as the phase 1/2/3
+  work in [26](issues/26-proposal-oas-phase1-version-checking.md)/
+  [27](issues/27-proposal-oas-phase2-31-support.md)/
+  [28](issues/28-proposal-oas-phase3-32-support.md) (3.1 *and* 3.2, plus
+  webhooks — this bucket undersold it). This entry stayed marked as
+  unstarted "major 2.0" work well after it shipped; caught while triaging
+  #104/#96 and corrected here rather than left to drift further.
 - **#10** Resolve / bundle external `$ref`s — explicitly designed-around in the
   current architecture (the README of #10 notes that `merge()` is intentionally
   synchronous). Big change either way; could be delegated to a pre-pass /
@@ -134,8 +137,11 @@ matching tests in `__tests__/components.test.ts`.
 - **#8 / #109 / #71** Duplicate-path handling family — needs a configurable
   policy (`error` | `skip` | `merge` | `prefix`) with care to preserve the
   current strict semantics for users who rely on them.
-- **#104** Incorrect `$ref` paths after bundling. Requires reproducing the
-  multi-file CLI bundling scenario; may overlap with #10.
+- **#104** Incorrect `$ref` paths after bundling. Reproduced (still broken on
+  `main`) and does **not** need #10: every broken ref in the report points at
+  a file that's already a declared merge input, which is a narrower,
+  separately fixable problem. See
+  [36-proposal-104-external-ref-rewriting.md](issues/36-proposal-104-external-ref-rewriting.md).
 
 ### 3.4 Fill-ins (low value, low effort) — only if convenient
 - **#102** Global title/description override — small CLI config patch.
@@ -149,8 +155,8 @@ matching tests in `__tests__/components.test.ts`.
 - **#110** "Definitions not included" — user is on Swagger 2; project is OAS
   3.x only and Swagger 2 support has already been declined (closed issue #6).
   Recommend closing with a pointer to a v2→v3 converter.
-- **#96** OpenAPI 3.1 webhooks — completely dependent on #113. Should be
-  rolled in there rather than tackled alone.
+- ~~**#96** OpenAPI 3.1 webhooks~~ — ✅ **Done and closed.** Shipped with
+  #113's phase 2 work; re-verified end-to-end and closed 2026-08-01.
 
 ---
 
@@ -296,9 +302,16 @@ behind the value/effort scores, and a suggested implementation pointer.
 ### Tier 3 — Big Bets
 
 #### [#104 — Incorrect `$ref` in bundled file](https://github.com/robertmassaioli/openapi-merge/issues/104)
-- **Value 4 / Effort 4 / ROI 4**
-- May be tightly coupled to #10 (external refs). Needs a reproducer test
-  using the user's exact file layout.
+- **Value 4 / Effort 3 / ROI 4** *(revised from 4/4 after reproducing it —
+  see below)*
+- **Not** tightly coupled to #10, as this doc originally guessed. Reproduced
+  with the user's exact pattern (stripped down): every broken `$ref` in
+  their example points at a file that is itself already a declared merge
+  input. That's fixable by extending the existing per-input dispute/rename
+  rewriting to also recognise refs pre-qualified with a file path matching
+  another input, entirely inside this tool -- no general external-bundling
+  (#10) required. See
+  [36-proposal-104-external-ref-rewriting.md](issues/36-proposal-104-external-ref-rewriting.md).
 
 #### [#8 — Merge duplicate OAS paths using disputePrefix](https://github.com/robertmassaioli/openapi-merge/issues/8)
 - **Value 4 / Effort 4 / ROI 4**
@@ -315,18 +328,32 @@ behind the value/effort scores, and a suggested implementation pointer.
 
 #### [#10 — Resolve / bundle external references](https://github.com/robertmassaioli/openapi-merge/issues/10)
 - **Value 5 / Effort 5 / ROI 5**
-- The issue itself describes two implementation strategies and the
-  maintainer's preference. Pursuing Option 1 (pre-bundle via another tool)
-  would limit changes to the CLI.
+- The issue itself describes three implementation strategies (not two —
+  Robert's own note sketches a distinct "synchronous pre-resolved map"
+  design alongside the two he explicitly weighs) and a stated preference
+  for pre-bundling via another tool, limiting changes to the CLI. Full
+  evaluation, including how it relates to #104's narrower fix, in
+  [37-proposal-10-external-ref-bundling.md](issues/37-proposal-10-external-ref-bundling.md) —
+  kept at options-and-tradeoffs altitude rather than a design spec, since
+  the first open question is whether to take this on at all.
 
 #### [#113 — Add support for OpenAPI 3.1.x](https://github.com/robertmassaioli/openapi-merge/issues/113)
 - **Value 5 / Effort 5 / ROI 5**
-- Likely a 2.x major release. Requires version-aware merging, webhook
-  support (subsumes #96), and updated type definitions.
+- ✅ **Done.** Shipped as three phases —
+  [26](issues/26-proposal-oas-phase1-version-checking.md) (version
+  detection, refuse mixed majors),
+  [27](issues/27-proposal-oas-phase2-31-support.md) (3.1 merging, including
+  webhooks — subsumed #96 as predicted below), and
+  [28](issues/28-proposal-oas-phase3-32-support.md) (3.2). This tier's
+  "likely a 2.x major release" framing didn't happen; it shipped as normal
+  minor-version work instead.
 
 #### [#96 — OAS 3.1 webhook](https://github.com/robertmassaioli/openapi-merge/issues/96)
 - **Value 3 / Effort 4 / ROI 2**
-- Subsumed by #113; track as a child task.
+- ✅ **Done, as predicted here — subsumed by #113's phase 2.** Re-verified
+  against `main` (dedicated `webhooks.test.ts` coverage, plus a fresh
+  end-to-end CLI run merging webhooks from two 3.1 inputs) and closed
+  2026-08-01.
 
 ### Tier 5 — Defer
 
@@ -358,9 +385,14 @@ behind the value/effort scores, and a suggested implementation pointer.
 - #45 (no-config), #61 (auth headers), #60 (x-tagGroups), #102 (global
   info), #100 (docs), #94 (schema pruning).
 
-### Major release 2.0 — "OpenAPI 3.1"
-- #113 + #96 + #10 + #104 + #75. This is a multi-month effort; consider a
-  parallel `v2` branch with a separate `@next` dist-tag for early adopters.
+### ~~Major release 2.0 — "OpenAPI 3.1"~~ — done, and not as a major release
+- #113 and #96 both shipped (see above) as normal minor-version work, not
+  the parallel `v2` branch this roadmap entry planned for. #10 and #75
+  remain open and don't need 3.1 support as a prerequisite anymore — #10
+  now has its own evaluation ([37](issues/37-proposal-10-external-ref-bundling.md)),
+  kept deliberately unbucketed pending the "should we become a bundler"
+  decision it's actually blocked on. #104 was never in this bucket to begin
+  with (see 36) and doesn't need to wait on any of this.
 
 ---
 

--- a/ai-planning/issues/36-proposal-104-external-ref-rewriting.md
+++ b/ai-planning/issues/36-proposal-104-external-ref-rewriting.md
@@ -1,0 +1,418 @@
+# Implementation Proposal: Issue #104 — Incorrect `$ref` in Bundled File
+
+**Issue:** [#104 — Incorrect `$ref` in bundled file](https://github.com/robertmassaioli/openapi-merge/issues/104)
+
+**Status:** ✅ Implemented — on branch `feature/external-ref-resolution`,
+**together with #10** (Option 2-refined, see
+[37](37-proposal-10-external-ref-bundling.md)) in one change, at Robert's
+explicit direction. §10 originally recommended shipping this independently
+of #10; that recommendation was overtaken by events, not wrong given what
+was known at the time -- see §10 for what actually happened and why building
+them together turned out fine.
+
+**Value:** 4 | **Effort:** 3 *(revised down from the triage doc's 4 — see §4)*
+
+---
+
+## 1. Issue summary
+
+The reporter merges several OpenAPI files that share components across
+files via `$ref`s to *other files on disk* — e.g. one input's response
+schema is:
+
+```yaml
+$ref: "./../common/ServerError.yml#/components/schemas/ServerError"
+```
+
+`ServerError.yml` is itself one of the declared merge inputs. After
+merging, the output still contains that exact string, character for
+character:
+
+```yaml
+$ref: ./../common/ServerError.yml#/components/schemas/ServerError
+```
+
+which is broken: the merged document lives in a different location, the
+relative path no longer resolves to anything meaningful relative to it, and
+in any case the schema it wants is already present, correctly, at
+`#/components/schemas/ServerError` in the very same merged document.
+
+## 2. Reproduction — confirmed, still broken today
+
+Stripped down (per the reporter's own comment that the original report has
+far more YAML than the bug needs) and run against this repo's current
+`main` via the built CLI:
+
+```
+specs/common/ServerError.yml:
+  openapi: "3.0.0"
+  components:
+    schemas:
+      ServerError: { type: object }
+
+specs/a/Api.yml:
+  openapi: "3.0.0"
+  info: { version: 1.0.0, title: A }
+  paths:
+    /a:
+      get:
+        operationId: getA
+        responses:
+          "200": { description: ok }
+          default:
+            description: server error
+            content:
+              application/json:
+                schema:
+                  $ref: "../common/ServerError.yml#/components/schemas/ServerError"
+
+openapi-merge.json:
+  { "inputs": [{ "inputFile": "./specs/common/ServerError.yml" },
+                { "inputFile": "./specs/a/Api.yml" }],
+    "output": "./bundle.yml" }
+```
+
+Output:
+
+```yaml
+openapi: 3.0.0
+paths:
+  /a:
+    get:
+      operationId: getA
+      responses:
+        '200': { description: ok }
+        default:
+          description: server error
+          content:
+            application/json:
+              schema:
+                $ref: ../common/ServerError.yml#/components/schemas/ServerError   # <- unchanged, broken
+components:
+  schemas:
+    ServerError: { type: object }   # <- right here, un-referenced by the broken $ref above
+```
+
+Confirmed by running the actual CLI end to end, not by reading the code.
+
+## 3. Root cause
+
+Two facts about the current architecture, both confirmed by reading the
+code rather than assumed:
+
+- **The `openapi-merge` library has zero knowledge of file paths.** It has
+  no dependency on Node's `path` module (checked: no `import ... from
+  'path'` anywhere in `packages/openapi-merge/src`) and `SingleMergeInput`
+  (`data.ts`) carries only an already-parsed `oas` document plus merge
+  options — nothing that identifies *where that document came from*. This
+  is deliberate: the library is meant to be portable (usable outside Node),
+  and file I/O is entirely the CLI's job (`loadOasForInput` in
+  `openapi-merge-cli/src/index.ts`).
+- **`$ref` rewriting only recognises the exact bare form
+  `#/components/<type>/<name>`, per input.** `paths-and-components.ts`
+  builds one `referenceModification` map per input (`{ '#/components/schemas/Dog':
+  '#/components/schemas/Dog1', ... }`, populated only when *that input's
+  own* component was renamed for a clash) and calls
+  `walkAllReferences(oas, ref => ...)` **inside the same per-input loop
+  iteration**, rewriting only refs that exact-match (or are a sub-path of)
+  a key in *that input's own* map. A ref shaped
+  `../common/ServerError.yml#/components/schemas/ServerError` never matches
+  any key in any map — the lookup is pure string comparison against
+  `#/components/...` strings — so it falls through the `walkAllReferences`
+  callback unchanged. This isn't a bug in that logic; that logic was never
+  asked to consider anything other than a bare in-document pointer.
+
+There is no step anywhere that resolves a `$ref`'s file-path portion
+against anything, because nothing downstream of file-loading carries a file
+path at all.
+
+## 4. Scope — narrower than the prior triage assumed
+
+The triage doc (`issue-triage-value-vs-effort.md`) flagged #104 as possibly
+needing #10 (general external-reference *bundling* — resolving a `$ref`
+into **any** file on disk, whether or not it was ever given to the tool as
+an input) first, and filed it as a "Big Bet" for a hypothetical 2.0. That
+was written before reproducing it.
+
+Having reproduced it: **every broken `$ref` in the reporter's own example
+points at a file that is itself already a declared merge input.**
+`ServerError.yml`, `GetInstrumentByCriteriaRequestBody.yml`, and
+`InstrumentDetails.yml` are all in their `inputs` list. That is very likely
+the common case in practice too — it's the natural shape for a team that
+splits one API's components across files and hands *all* of them to this
+tool.
+
+That means the fix does not need general bundling (#10) at all. It needs
+only: **recognise when a `$ref`'s file-path portion resolves to a file that
+is already one of this merge's own inputs, and rewrite it to point at
+wherever that input's component ended up in the merged document** —
+exactly the same kind of rewrite the dispute/rename machinery already does
+for in-document refs, just extended to also recognise refs that arrive
+pre-qualified with a file path. A `$ref` into a file that was *not* given as
+an input is explicitly out of scope here (§8) — that is genuinely #10's
+territory, and stays exactly as broken/unsupported as it is today.
+
+## 5. Design
+
+### 5.1 The CLI computes an identity per file input, and normalises cross-input refs against it
+
+`loadOasForInput` (`openapi-merge-cli/src/index.ts:241`) already computes
+`fullPath = resolveConfigPath(basePath, input.inputFile)` — the resolved
+absolute path — for every file input; it's just discarded after the read.
+Two additions:
+
+1. Attach it to the `SingleMergeInput` the CLI builds, as a new **optional**
+   field on `SingleMergeInputBase` in the library — `sourceIdentity?: string`.
+   Deliberately opaque to the library: it never parses or resolves this
+   string, only compares it for exact equality against other inputs'
+   `sourceIdentity`. (Named `sourceIdentity`, not `sourcePath` or `filePath`
+   — `inputURL` inputs can carry one too; see §6.2.)
+2. Before handing each input's `oas` to the library, walk its `$ref`s
+   (reusing the library's own `walkAllReferences`, exported from
+   `reference-walker.ts` — confirmed importable the same way the CLI
+   already deep-imports `openapi-merge/dist/data` and
+   `openapi-merge/dist/oas31`, i.e. `openapi-merge/dist/reference-walker`;
+   no new traversal code needed) and, for any ref that does **not** start
+   with `#` (i.e. has a file-path portion):
+   - **Resolve, but rewrite only on a confirmed match.** A ref like
+     `https://example.com/spec.yaml#/components/schemas/X` also doesn't
+     start with `#`; naively resolving it with `path.resolve` against a
+     local directory produces garbage (`/abs/dir/https:/example.com/...`),
+     and if that garbage were written back into the document unconditionally,
+     an absolute-URL ref that works perfectly well *today* would come out
+     corrupted. The fix: resolve the candidate path, then only rewrite the
+     `$ref` string if that resolved path exactly matches another input's
+     `sourceIdentity` (computed once the *whole* input set is known, i.e.
+     this really has to run after every input's `fullPath` has been
+     collected, not per-input in isolation). No match — including anything
+     that isn't a plausible relative/absolute filesystem path at all, like a
+     URL or `urn:` — leaves the ref completely untouched, exactly as today.
+   - **A ref with no fragment is a whole-document reference and is left
+     untouched.** `$ref: "./common/ServerError.yml"` (no `#`) legally means
+     "the entire document at that path." Splitting on `#` for a ref with
+     none yields no fragment to rewrite, and there is no single local
+     pointer in the merged output that means "that whole input" — so this
+     case is explicitly excluded from rewriting, not treated as a
+     degenerate case of the fragment logic.
+
+   Everything that *does* match becomes `<resolved-absolute-path>#<fragment>`
+   in the input document before it reaches the library, so the library never
+   needs `path` semantics of its own — it only ever compares strings for
+   exact equality against `sourceIdentity`.
+
+### 5.2 The library gets a second, cross-input rewriting pass
+
+Today, `mergePathsAndComponents`'s single loop does, per input: rename
+components, rewrite that input's own bare refs using that input's own
+rename map, copy the (now-correct) paths/webhooks into `result`. That local
+step is **unchanged** — every existing test keeps passing unmodified.
+
+Added, after the loop (once *every* input's rename map is known — this has
+to wait, because input A might reference input C, which is processed
+*after* A, and C's renames aren't known until C's own turn in the loop
+completes):
+
+1. Keep each input's `referenceModification` map (currently discarded at
+   the end of each loop iteration) in an outer
+   `Record<sourceIdentity, { [original: string]: string }>`.
+2. Build `identityToInput: Record<sourceIdentity, inputIndex>` from every
+   input that declared one. **An identity claimed by more than one input is
+   treated as unmatched, not as "the first/last one wins."** The config
+   format allows the same file to be listed twice (e.g. with different
+   `pathModification` per copy), which would otherwise make
+   `identityToInput` silently resolve to whichever input happened to be
+   processed last, and a cross-file ref intending the *other* copy would
+   get rewritten against the wrong rename map with no error. There's no
+   principled way to guess which copy a ref meant, so refs matching an
+   ambiguous identity are left exactly as they are today (§8) rather than
+   guessed at.
+3. `walkAllReferences(result, ref => ...)` **once**, over the fully
+   assembled `result` (which already satisfies the shape
+   `walkAllReferences` wants — `paths`/`webhooks`/`components`). For a ref
+   not starting with `#`: split it into `[identity, fragment]` on the first
+   `#`. If `identity` isn't in `identityToInput` (absent, or ambiguous per
+   the previous point), leave the ref exactly as it is today (§8 — not one
+   of this merge's inputs, or not resolvably one of them). If it is,
+   resolve `fragment` against *that target input's own*
+   `referenceModification` map — same lookup logic already used for local
+   refs (exact match, then the existing "longest matching prefix" fallback
+   for a nested path) — and rewrite the ref to the resulting local
+   `#/components/...` string.
+
+This is a genuine, if bounded, restructuring of the merge loop's central
+function — not a two-line patch — which is why this is a proposal rather
+than a fix straight to a PR. It touches the one function everything else in
+the library is built on top of.
+
+### 5.3 Ordering with `pruneUnusedComponents`
+
+Falls out for free: `pruneUnusedComponents` (issue #94) runs as a
+completely separate, later step in `merge()`'s top-level orchestration,
+walking `$ref`s in the *finished* document to decide what's reachable.
+Because §5.2's rewrite already turned every resolvable cross-file ref into
+a normal `#/components/...` ref before that point, pruning sees a correctly
+reachable graph without any changes of its own. (Verified by reading — not
+yet by a test; that's part of §9.)
+
+## 6. Decisions
+
+### 6.1 Always on, or a new config flag? — recommend: always on, no flag
+
+Unlike `pruneUnusedComponents` (destructive — might discard components a
+consumer still wants) or `securitySchemesStrategy` (a genuine behavioural
+choice with three defensible answers), this only ever *fires* when a `$ref`
+resolves to a file that is itself a declared input — a state that is
+**already unconditionally broken** today (a dangling reference in the
+output). There is no existing behaviour worth preserving behind a flag:
+nobody can be relying on today's output being a working document. Recommend
+shipping this as unconditional, correctness-fixing behaviour, the same way
+issue #106's discriminator-mapping rewrite or #99's rename-propagation
+were — no new `Configuration` field.
+
+### 6.2 `inputURL` inputs — in scope now, or deferred? — **overtaken: shipped from the start**
+
+The same mechanism generalises: an `inputURL` input's `sourceIdentity`
+would be the URL itself, and a relative cross-reference from it resolves
+with `new URL(refFilePart, inputURL).href` instead of `path.resolve`. It's
+not a large amount of extra code, but it is untested territory (no existing
+coverage exercises `$ref`s inside a URL-loaded input at all) and it widens
+what a first PR has to prove correct. **Recommend deferring** — ship §5 for
+file inputs first, note URL inputs as explicitly unsupported by this pass,
+and pick it up as a small, obvious follow-on once the file-input path has
+landed and proven itself. Flag if you'd rather have both from the start.
+
+**What actually happened:** building this together with #10 (§10) meant the
+identity/resolution machinery had to handle both files and URLs from day one
+regardless — #10's discovery worklist needs to load documents over HTTP
+either way, so `inputURL` support for #104's narrower declared-input case
+came along for free rather than as separate follow-on work. Covered by a
+real in-process HTTP server test (`cli-external-references.test.ts`, matching
+the existing `cli-remote-inputs.test.ts` pattern), not left untested as this
+section worried it might be.
+
+### 6.3 A cross-file ref that matches no declared input — silent, or a warning?
+
+Out of scope for rewriting either way (§8), but two options for what the
+CLI *says*: leave it exactly as silent as today, or have the CLI log a
+one-line notice (`## Note: input N has a $ref to 'X', which is not one of
+this merge's inputs -- left unresolved`) so a user gets a hint rather than
+discovering a dangling ref by opening the output. **Recommend the notice**
+— it's a few lines in `convertInputs`, costs nothing when it doesn't fire,
+and turns "nothing happened where I expected a fix" into an actionable
+message. Happy to drop it and stay silent if you'd rather keep `init`-style
+output terse.
+
+## 7. Scope of the change
+
+- `packages/openapi-merge/src/data.ts` — new optional
+  `sourceIdentity?: string` on `SingleMergeInputBase`.
+- `packages/openapi-merge/src/paths-and-components.ts` — retain per-input
+  `referenceModification` maps across the loop; add the pass-2 walk
+  described in §5.2.
+- `packages/openapi-merge-cli/src/index.ts` — `loadOasForInput`/
+  `convertInputs` gains the ref-normalisation pre-pass (§5.1) and populates
+  `sourceIdentity`; the §6.3 notice, if wanted.
+- Possibly a small new module (e.g. `ref-normalisation.ts` in the CLI) to
+  keep the file-path-resolution logic out of `index.ts`'s already-large
+  surface, consistent with how `path-resolution.ts` and `file-loading.ts`
+  are already split out.
+
+Not touched: `duplicatePathHandling`, dispute/rename logic itself
+(reused, not changed), `operationSelection`, security schemes, the CLI's
+config file format (no new `Configuration` field per §6.1).
+
+## 8. Not doing
+
+- **General external-reference bundling (issue #10)** — resolving a `$ref`
+  into a file that was never given to the tool as an input. That needs
+  fetching and parsing arbitrary additional files, deciding how *their*
+  refs and name clashes get folded in, and is the actual "Big Bet" the
+  triage doc was gesturing at. This proposal deliberately does not attempt
+  it — §4 is the finding that #104 doesn't require it.
+- Recursive resolution through a chain of external files (A refs B refs C).
+  Only refs pointing directly at one of the merge's own inputs are handled;
+  each input is still expected to be parseable as a standalone document
+  (paired with its own intra-document refs) the way the tool has always
+  assumed.
+- Rewriting refs inside a component's *own* definition differently from
+  refs inside paths/webhooks — `walkAllReferences` already covers both
+  uniformly; no special-casing needed.
+
+## 9. Verification
+
+Everything below ran, rather than being planned:
+
+- The exact reproducer from §2, run through the real CLI end to end
+  (`cli-external-references.test.ts`): the response schema's `$ref` comes out
+  as `#/components/schemas/ServerError`, resolved and localised, with no
+  `resolveExternalReferences` flag set at all.
+- Cross-file ref to a component that *did* get renamed for a clash in the
+  target input — `external-references.test.ts`'s
+  `'resolves a ref to a component that was renamed for a clash in the target
+  input'`.
+- A cross-file ref to a file that is genuinely not an input, with discovery
+  off: left unresolved (§8) — see the CLI test named for exactly this.
+- A cross-file ref into `securitySchemes`: left unresolved, no crash —
+  matches the local-rename carve-out from issue #33/#94.
+- Forward reference (input 0 refs input 2, not yet processed) and backward
+  reference (input 2 refs input 0, already processed) — both pass, the
+  entire reason §5.2 is a second pass rather than folded into the loop.
+- `pruneUnusedComponents: true` combined with a cross-document ref — the
+  pulled-in component survives pruning because it really is referenced,
+  confirming §5.3's "falls out for free" claim empirically.
+- The same file listed as two separate inputs: any cross-file ref naming it
+  is left untouched (§5.2's ambiguous-identity rule), not resolved against
+  whichever copy was processed last.
+- **§5.1's "byte-for-byte unchanged" prediction was wrong, and worth
+  recording rather than quietly fixing.** An unmatched cross-document ref
+  does *not* survive untouched end-to-end through the CLI — it comes out
+  normalised to an absolute path (or URL), just not resolved to a local
+  pointer. This falls out of the mechanism itself: normalising every
+  declared input's own refs to a comparable absolute form is *how* #104
+  matching works at all, and that normalisation runs before anything checks
+  whether a match exists. Decided this was worth keeping rather than
+  special-casing back to the original string: an absolute-but-unresolved
+  path is more useful for debugging why a `$ref` didn't resolve than the
+  original relative spelling, and it doesn't change whether the ref
+  resolves, only what the leftover string looks like when it doesn't. The
+  *library's* own contract is unaffected and still holds exactly as
+  written: given an already-external-shaped ref and no matching
+  `externalDocuments` entry, `merge()` itself leaves it untouched (see
+  `external-references.test.ts`'s regression guard for that boundary
+  specifically). What changed is a layer up, in what the CLI hands to
+  `merge()` in the first place.
+- Full workspace green: 439 library tests (18 files) and 186 CLI tests (14
+  files), lint and typecheck clean in both packages. Coverage on the new
+  files: 90%/97.04% (funcs/lines) on `external-references.ts`, 100%/98.85%
+  on `external-reference-discovery.ts` — the remaining gaps are defensive
+  branches unreachable from any real call site (mirrors a handful of
+  already-accepted gaps elsewhere in `paths-and-components.ts`'s equivalent
+  local-rename logic).
+
+## 10. Relationship to #10
+
+Issue #10 (general external-reference bundling — §8's "genuinely #10's
+territory") has its own evaluation:
+[37-proposal-10-external-ref-bundling.md](37-proposal-10-external-ref-bundling.md).
+That document works through Robert's own 2021 design note on #10, reads it
+as three architectures rather than two, and recommends "Option 2, refined"
+— the CLI pre-resolves synchronously, `merge()` stays synchronous and
+consults what it's given — while noting this proposal's own mechanism is a
+narrower special case of exactly that option (37 §3).
+
+**Decided (by Robert, directly) after both documents were written: build
+both together, in one change**, rather than shipping this independently as
+§8 originally recommended. That original recommendation was not wrong given
+what was known writing it — declared-input matching genuinely doesn't need
+general bundling, and is correct and shippable on its own. But once both
+proposals existed side by side, unifying them turned out straightforward
+rather than risky: the identity map, the deferred second pass, and the
+per-target rename-resolution logic §3 predicted would be reused, *were*
+reused without modification — `createCrossDocumentResolver` in
+`external-references.ts` handles a `$ref` into a declared input and a `$ref`
+into a `MergeOptions.externalDocuments` entry through the same recursive
+function, distinguished only by which map the identity is found in. One
+mechanism, not two coordinating ones. §6.2's `inputURL` deferral was the one
+casualty of building them together — see that section for why it stopped
+being worth deferring once #10's discovery worklist needed URL loading
+regardless.

--- a/ai-planning/issues/37-proposal-10-external-ref-bundling.md
+++ b/ai-planning/issues/37-proposal-10-external-ref-bundling.md
@@ -1,0 +1,338 @@
+# Implementation Proposal: Issue #10 — Resolve and/or Bundle External References
+
+**Issue:** [#10 — Resolve and/or bundle external references](https://github.com/robertmassaioli/openapi-merge/issues/10)
+
+**Status:** ✅ Implemented — Option 2-refined (§2), chosen and built together
+with [36](36-proposal-104-external-ref-rewriting.md) (issue #104) in one
+change, at Robert's explicit direction, on branch
+`feature/external-ref-resolution`. This document was written to stay at
+options-and-tradeoffs altitude (§0) precisely because "should we become a
+bundler at all" hadn't been decided yet; §9 records what was actually built
+once it was.
+
+**Value:** 5 | **Effort:** 5 *(unchanged from the triage doc — this is
+genuinely the "Big Bet" it was filed as; §4 shows why #104 is a materially
+smaller, separable problem, not a stepping stone that shrinks this one)*
+
+---
+
+## 0. What kind of document this is
+
+Issue #104's proposal (36) ends with a concrete design because the fix is
+small and bounded: extend machinery that already exists. This one is
+deliberately kept at the level of **options and tradeoffs**. The reason:
+the real first decision here isn't "how do we resolve external refs", it's
+"should `openapi-merge` become a bundler at all" — and that decision has
+a stated, three-year-old answer from Robert (§2) that a design spec would
+just be presuming past. This document lays out the design space, checks
+Robert's stated preference against how the codebase has changed since 2021,
+and flags what a spike would need to prove — not a plan to execute.
+
+## 1. Issue summary
+
+> Many people define references in OpenAPI files such that those references
+> are not internal to the OpenAPI file. As a result, they expect that when
+> they use the `openapi-merge` library or CLI tool, that it will merge
+> everything together for them.
+
+Unlike #104, this is not scoped to refs pointing at files that happen to
+already be declared merge inputs — it's the general case: a `$ref` to
+*any* file (or URL) on disk, whether or not the user ever told this tool
+about it.
+
+## 2. What Robert already said, in 2021
+
+The issue body isn't just a report — it's a design note with a stated
+preference and an explicit rejection of the naive alternative. Worth
+quoting rather than paraphrasing, since the exact reasoning matters:
+
+> We could solve this problem in one of two ways:
+> 1. Pre-bundle all of the references into each individual OpenAPI file and
+>    then rely upon de-duplication to end up with a minimal OpenAPI file.
+> 2. Support external references such that the merging algorithm can load
+>    them all itself and then bundle only the components that are required.
+>
+> At this point in time. I think that I have a preference for Option 1
+> because it means that we can offload this problem to another tool and
+> then just ask people to integrate that together instead to form a
+> cohesive whole. [...] We can also then just make the CLI tool integrate
+> that by default so that the CLI tool works like people expect.
+>
+> It is also worth noting that the `merge` function currently expects all
+> of the OpenAPI files to be pre-downloaded, that allows that function to
+> be synchronous [...]. Attempting to load the schemas while we [merged]
+> would be an architectural mistake, because it would be a poor separation
+> of concerns. Instead the `merge` function could be modified to have a
+> pre-downloaded mapping of `Reference => Schema` that it can use in a
+> synchronous manner.
+
+That's genuinely **three** distinct architectures, not two — the third is
+buried in the "it's also worth noting" paragraph, describing how Option 2
+would have to be built *if* it were ever chosen, not a restatement of
+Option 1:
+
+- **Option 1** (Robert's stated preference): run an existing, off-the-shelf
+  bundler over *each input independently*, before it ever reaches
+  `openapi-merge`. Each input becomes self-contained (no external refs);
+  the library's existing cross-input deduplication does the rest.
+  **Zero changes to the `openapi-merge` library.**
+- **Option 2, as rejected**: `merge()` itself does file/network I/O to chase
+  external refs while merging. Ruled out explicitly — breaks the
+  synchronous, separation-of-concerns design the library has always had.
+- **Option 2, refined** (Robert's own alternative if native support is ever
+  wanted): keep `merge()` synchronous, but have the *caller* (the CLI) do
+  all the async loading up front, producing a `Reference => Schema` map
+  that `merge()` consults while it does its own path/component copying.
+  Unlike Option 1, this keeps `openapi-merge` itself in the business of
+  understanding what an external reference is and how to fold it in.
+
+**Proposal 36 (#104) is a fourth point in this space** — a much narrower
+special case of "Option 2, refined": the CLI still pre-resolves
+synchronously and hands the library an identity map, but *only* for refs
+matching files the user already declared as inputs. It never discovers or
+loads a new file on the strength of a `$ref` alone. That's precisely why
+36 is small enough to spec concretely and this one isn't.
+
+## 3. Does #104 (Option "4") make this smaller? — Mostly, in one direction
+
+Tempting conclusion: since 36 already builds the identity-matching and
+cross-input rename-resolution machinery, doesn't "real" bundling reduce to
+just widening it to *undeclared* files too? Traced through:
+
+**For Option 1 (bundle per input, no library changes), no — it's an
+entirely separate mechanism.** Bundling doesn't touch `openapi-merge` at
+all; it runs before an input is even handed to `convertInputs`. 36's
+identity/rename machinery is irrelevant to it. Building 36 first buys
+nothing here except a smaller, already-solved special case of the same
+user complaint, and possibly a faster ship for the common declared-input
+pattern while a full bundler is still being evaluated.
+
+**For Option 2-refined (native support inside `openapi-merge`), yes —
+36 is a genuine down-payment.** The identity map, the deferred two-pass
+rewrite (needed regardless of whether identities come from declared inputs
+or discovered files, since forward/backward references are the same
+problem either way), and the per-target rename-resolution logic would all
+be reused; "widening" would mean: the CLI's identity set is no longer
+fixed to `configInputs` up front, but grows as new external refs are
+discovered, requiring a fixed-point loop (keep resolving until no new
+external files are found) rather than 36's single pass over a known list.
+
+So the honest answer depends entirely on which of the two live options (1
+or 2-refined) gets chosen — which is precisely why this proposal doesn't
+pick one yet.
+
+## 4. Does Option 1 (bundle-then-dedup) actually fix #104's case?
+
+Traced through the exact #104 repro (36 §2): bundling `Api.yml` would
+inline the referenced `ServerError` schema directly into `Api.yml`'s own
+`components.schemas.ServerError`, rewriting its `$ref` to a local one. When
+`merge()` then processes the separately-declared `ServerError.yml` input,
+`processComponents`' deduplication (`component-equivalence.ts`) compares
+the two `ServerError` definitions and — **if `deepEquality` finds them
+equivalent** — collapses them into one, leaving `Api.yml`'s now-local ref
+correctly pointing at the survivor.
+
+**Correctness holds; minimality does not, automatically.** Read
+`deepEquality` rather than assumed: it's more forgiving than a naive
+`_.isEqual` on the raw JSON — it resolves `$ref`s on *both* sides via each
+document's own `SwaggerLookup` and compares the resolved structures
+recursively, with cycle protection (`ReferenceRecord`), so bundling
+artefact differences that only affect *how* something is referenced (not
+its resolved shape) wash out. But it is still exact structural equality of
+the resolved content, key-for-key (`arraysEquivalent(Object.keys(x),
+Object.keys(y))` then a per-key recursive compare). It will **not** treat
+two schemas as equivalent if the bundler's inlined copy differs from the
+separately-declared input's version in any way that survives resolution —
+an added `example`, a stripped `description`, different key ordering
+doesn't matter but different *content* does — or if `Api.yml` already
+declares its own clashing `ServerError` (forcing the bundler to invent a
+disambiguated name before `openapi-merge` ever sees it), or if the input
+carries `dispute.alwaysApply`.
+
+In all of those cases the result is **correct but duplicated**: two
+`ServerError`-shaped schemas under two names, both consistently referenced,
+neither dangling. Strictly better than today's broken output, but not the
+"minimal" result Robert's note assumes as automatic. Worth stating plainly
+rather than promising a clean collapse every time.
+
+## 5. What Option 1 actually costs, and what it would open up
+
+Kept at the tradeoff level deliberately (§0) — these aren't blockers, they're
+what a "yes, do this" decision needs to account for:
+
+- **A new dependency, and a shift in what this tool is.** Today
+  `openapi-merge-cli` reads exactly the files a config names. Option 1 means
+  it also reads whatever those files' own `$ref`s point at, transitively —
+  materially more surface, and a real (if small) supply-chain and
+  maintenance commitment to whichever bundling library is chosen.
+- **Failure behaviour changes.** Today a `$ref` to a missing/unreachable
+  external file produces a broken-but-written output (the bug this and #104
+  are both about). Bundling turns that into a **hard failure before any
+  output is written** — arguably more correct, but a behaviour change worth
+  naming, not just inheriting silently.
+- **The input side gains the same class of risk the output side already
+  took seriously.** Issue #93 restricted `outputRoot` with a realpath-based
+  containment check (`path-resolution.ts`) specifically to stop a symlink
+  or crafted relative path from writing outside an intended directory.
+  Following `$ref`s out of untrusted input files is the mirror image on the
+  *read* side — nothing today stops a config's inputs from reading anything
+  the process can see, and bundling would make that reach transitive and
+  automatic rather than confined to what's explicitly listed in `inputs`.
+  Any real implementation needs a comparable containment story (an
+  `inputRoot`-style restriction, or at minimum, explicit documentation of
+  the trust boundary) before shipping this as an on-by-default behaviour
+  the way Robert's note suggests ("make the CLI tool integrate that by
+  default").
+
+## 6. Library comparison for Option 1 (evidence, not a spec)
+
+Two credible off-the-shelf bundlers, checked rather than assumed from
+memory, since library capabilities drift:
+
+- **`@redocly/openapi-core`** — exposes `bundle` / `bundleFromString`:
+  resolves external `$ref`s, keeps internal ones. Redocly's own CLI
+  (built on this package) advertises full OpenAPI 3.2, 3.1, 3.0 and Swagger
+  2.0 support, current as of their 3.2 coverage post. That matters
+  specifically for this repo, which has already invested three proposals
+  (26/27/28) in clean 3.1/3.2 merge support — a bundler with a 3.1 gap would
+  quietly undermine that work for exactly the inputs that use it.
+- **`@apidevtools/swagger-parser`** — exposes `.bundle()` (external refs
+  resolved and inlined, internal refs preserved) versus `.dereference()`
+  (everything inlined, no refs survive — the wrong one for this use case,
+  since `openapi-merge`'s own dedup depends on refs surviving). Very
+  widely used (~2.4M weekly downloads, actively maintained per its own
+  npm listing), but multiple community reports describe OpenAPI 3.1
+  parsing gaps for this specific package. **Some of what surfaced in
+  research was the separate, Java-based `swagger-api/swagger-parser`
+  project, which is not this package** — the JS-specific claim needs a
+  hands-on spike against a real 3.1 document before it's trusted either
+  way, not another search.
+
+Neither comparison is a recommendation to build against yet. It's evidence
+that **the library choice is not a rubber stamp** — it needs to be spiked
+against this repo's own 3.0/3.1/3.2 test fixtures before Option 1 is
+committed to, given how much of this codebase's recent history is about
+getting exactly that version support right.
+
+## 7. Not resolved here *(at the time this was written — see §9 for what was decided)*
+
+- Whether Option 1 or Option 2-refined is the right long-term shape. Robert's
+  2021 preference is strong input, not a settled answer — it predates 3.1/3.2
+  support, webhooks, and the current dedup/dispute machinery, all of which
+  change the cost side of the comparison in §3.
+- Whether Option 1 should be on-by-default (per the issue's suggestion) or
+  opt-in behind a new `Configuration` flag. Given §5's failure-mode and
+  trust-boundary changes, opt-in seems the safer starting point regardless
+  of which option is chosen, but that's a decision for whoever picks up
+  implementation, not this document.
+- A containment/allow-list design for the input-side trust boundary (§5) —
+  flagged as necessary, not designed.
+- Naming/collision strategy for auto-discovered components under either
+  option — sketched in passing (§4), not specified.
+
+## 8. Relationship to #104
+
+[36](36-proposal-104-external-ref-rewriting.md) is not superseded by this
+document and shouldn't wait on it. It solves a real, narrower slice of this
+same complaint — refs to files that are already declared inputs — with no
+new dependency, no new failure mode, no new trust-boundary question, and a
+concrete design ready to build. Whichever way #10 eventually goes, 36
+remains correct and useful; at most, a future Option 1 or Option 2-refined
+implementation might make 36's specific mechanism *redundant* (§3) rather
+than wrong. Recommend treating them as independent: ship 36 on its own
+merits, revisit this document separately when there's appetite for the
+larger "should we become a bundler" decision.
+
+They also don't conflict if both eventually ship, in either order. If
+Option 1 (bundling) lands after 36: a bundler runs before `merge()` ever
+sees an input, so by the time 36's cross-input pass walks the merged
+result, every ref it would have rewritten is already local — its pass
+simply finds nothing left to do. Inert, not wrong.
+
+*(§8 was written when "eventually" was still an open question. §9 records
+what happened when Robert decided not to wait.)*
+
+## 9. What was actually decided and built
+
+Robert's call, made directly after reading both this document and 36:
+**build Option 2-refined, and build it so it also handles #104's narrower
+case in the same mechanism, in one change.** Not Option 1 — no bundling
+library dependency was added; `openapi-merge` still does no file I/O of its
+own. The two open questions §7 left for "whoever picks up implementation"
+were resolved as follows.
+
+### 9.1 Option 1 vs Option 2-refined — Option 2-refined, and it worked cleanly
+
+The library gained exactly what Robert's 2021 note sketched: `merge()`
+stays fully synchronous, and `MergeOptions` gains `externalDocuments:
+Record<identity, OpenApiDocument>` — a pre-loaded mapping the caller builds
+with all its async I/O already done. Internally this is closer to
+"`Reference => Schema`, resolved lazily and recursively" than a flat
+pre-resolved map: `merge()` still has to walk into a pulled-in component's
+*own* references (possibly into a third document, possibly back into a
+declared input) itself, because only `merge()` knows where a declared
+input's components ultimately land after deduplication. §3's prediction
+held: the identity map, the deferred two-pass rewrite, and the per-target
+rename-resolution logic that 36 needed for its narrower case were reused
+without modification for the general case — one resolver
+(`createCrossDocumentResolver` in `external-references.ts`), not two
+coordinating mechanisms.
+
+### 9.2 On-by-default vs opt-in — split, deliberately
+
+Not one answer, but two, matching the always-on / opt-in split 36 itself
+argued for at the mechanism level:
+
+- Resolving a `$ref` into an **already-declared input** (#104's case): always
+  on, no flag. Unconditionally safe, per 36 §6.1's reasoning — it only ever
+  fires on a `$ref` that is already broken today.
+- **Discovering** a `$ref` into a file or URL nobody declared as an input
+  (#10's actual ask): gated behind a new opt-in `Configuration` field,
+  `resolveExternalReferences` (default `false`). This is the one that
+  changes the CLI's read surface and failure semantics (§5), so it stays a
+  deliberate choice rather than a silent default -- even though the issue's
+  own text suggested making it automatic.
+
+### 9.3 The containment/allow-list gap — still open, flagged rather than fixed
+
+**Not built.** §5 named this as a real concern and §7 explicitly deferred
+designing it; nothing in this implementation closes that gap. With
+`resolveExternalReferences: true`, a `$ref`'s relative path is resolved and
+read with no restriction on how far outside the input's own directory it
+may point -- the same way a declared `inputFile` itself has never been
+restricted (there is no read-side equivalent of `outputRoot`). Turning the
+flag on does not introduce a new *kind* of unrestricted read, but it does
+make the reachable set transitive and automatic rather than confined to
+what `inputs` explicitly lists, which is exactly the widening §5 called out.
+Mitigated only by the flag being opt-in and the README (`## Security`)
+saying so plainly -- an actual containment mechanism (an `inputRoot`, or a
+realpath-based check mirroring `path-resolution.ts`'s existing
+`outputRoot` guard) remains genuinely undesigned. Worth its own pass if
+`resolveExternalReferences` sees use against less-trusted configurations.
+
+### 9.4 Naming/collision strategy — the existing fallback, unmodified
+
+§4 sketched this only in passing. What shipped: a pulled-in component has
+no per-input `dispute` configuration to consult (it was never a declared
+input), so a name clash falls back to exactly the numeric-suffix
+disambiguation `processComponents` already applies when no dispute is
+configured (`ServerError`, `ServerError1`, ...) — no new disambiguation
+logic, no new config surface.
+
+### 9.5 Verification
+
+Full workspace green (439 library tests across 18 files, 186 CLI tests
+across 14 files), lint and typecheck clean in both packages. Beyond what 36
+§9 already covers for the always-on declared-input case: recursive pull-in
+across a chain of undeclared documents; a genuine cyclic external reference
+reported as a clean `cyclic-external-reference` merge error rather than a
+stack overflow, including confirming a component with two references stops
+processing the second once the first has already failed; a file-level cycle
+between two discovered documents (mutual reference, no component-level
+cycle) resolving fine, distinct from the genuine-cycle case above; a
+discovered document that fails to load (missing file, and — via a real
+in-process HTTP server, not a mocked `fetch`, matching this repo's existing
+`cli-remote-inputs.test.ts` convention — an unreachable URL) producing a
+warning and an unresolved (not corrupted, not fatal) ref rather than failing
+the whole merge; and `resolveExternalReferences` rejected by the schema when
+given a non-boolean value.

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -188,6 +188,41 @@ configuration file. Absolute paths (e.g. `/tmp/merged.yaml`,
 `C:\build\out.json`) are used as-is. This means you can safely write the
 merged spec into directories like `/tmp` or `/var/build/...` from CI.
 
+## Cross-document `$ref`s
+
+If one input's `$ref` points at *another file* rather than somewhere inside
+itself -- `$ref: "../common/Errors.yml#/components/schemas/ServerError"` --
+two different things can happen, depending on whether that file is one of
+your declared `inputs`:
+
+* **It's one of your `inputs` already.** The `$ref` is rewritten to point at
+  wherever that component ended up in the merged document, automatically and
+  unconditionally -- no configuration needed. This is always correct to do:
+  the alternative is a `$ref` that is already broken in the merged output,
+  since the original relative path means nothing once the inputs are combined
+  into one document (issue #104).
+* **It isn't one of your `inputs`.** By default the `$ref` is left as-is
+  (now resolved to an absolute path or URL, so at least it's unambiguous, but
+  still not something the merged document can resolve). Set
+  `"resolveExternalReferences": true` in your configuration to have the CLI
+  follow it: load that file (or URL), pull in *just* the component the `$ref`
+  asked for, and rewrite the `$ref` to point at it locally -- following
+  further `$ref`s the same way, however many files deep, with cycles
+  detected and reported rather than hanging (issue #10).
+
+```json
+{
+  "inputs": [{ "inputFile": "./api.yaml" }],
+  "output": "./bundle.yaml",
+  "resolveExternalReferences": true
+}
+```
+
+A `$ref` this discovers but cannot load -- a missing file, a failed fetch, a
+document that doesn't parse -- is left exactly as written and reported as a
+warning, not a hard failure, the same way an unresolvable `$ref` into a
+declared input is also left alone rather than erroring.
+
 ## Security
 
 `openapi-merge-cli` reads, merges, and writes files using the paths specified
@@ -196,6 +231,12 @@ configuration file is **trusted**, the same way you trust a `Makefile`,
 `package.json`, or `webpack.config.js` in your repository. Do not run the CLI
 against a configuration file from an untrusted source without restricting the
 output location.
+
+`resolveExternalReferences` widens what gets *read*, not just written: with
+it on, the files and URLs the CLI loads are no longer limited to what
+`inputs` names -- it follows wherever a `$ref` in *any* loaded document
+points, transitively. Leave it off (the default) unless your inputs are
+trusted to the same degree the configuration file itself is.
 
 For defence-in-depth in less-trusted contexts (for example a server that
 accepts user-supplied configs), you can restrict where the CLI will write the
@@ -223,7 +264,7 @@ branch on them.
 | `0` | Success — the merge completed and the output was written |
 | `1` | Failed to load or parse the configuration file |
 | `2` | Failed to load one or more inputs (missing file, unreachable URL, unparseable content) |
-| `3` | The merge itself failed (duplicate paths, unresolvable `operationId` conflicts, …) |
+| `3` | The merge itself failed (duplicate paths, unresolvable `operationId` conflicts, a cyclic cross-document `$ref` chain, …) |
 | `4` | An uncaught exception escaped the CLI |
 | `5` | The resolved output path escaped `outputRoot` / `--restrict-output-to` |
 | `6` | An `inputURL` responded with a **4xx** status |

--- a/packages/openapi-merge-cli/src/__tests__/_helpers/cli-harness.ts
+++ b/packages/openapi-merge-cli/src/__tests__/_helpers/cli-harness.ts
@@ -33,6 +33,8 @@ export type CliHarness = {
   dir: () => string;
   /** Lines captured from console.error during the current test. */
   stderr: () => string[];
+  /** Lines captured from console.log (LogWithMillisDiff) during the current test. */
+  stdout: () => string[];
   /** Run `main()` with these argv entries; resolves to the exit code. */
   run: (...args: string[]) => Promise<number>;
   /** Write a file into the temp dir, returning its absolute path. */
@@ -47,7 +49,8 @@ export type CliHarness = {
 
 export function installCliHarness(): CliHarness {
   let tmpDir = '';
-  let captured: string[] = [];
+  let capturedErr: string[] = [];
+  let capturedOut: string[] = [];
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const realExit = process.exit;
@@ -57,13 +60,16 @@ export function installCliHarness(): CliHarness {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openapi-merge-cli-'));
-    captured = [];
+    capturedErr = [];
+    capturedOut = [];
     (process as any).exit = (code?: number): never => {
       throw new ExitError(code ?? 0);
     };
-    console.log = (): void => undefined;
+    console.log = (...args: unknown[]): void => {
+      capturedOut.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    };
     console.error = (...args: unknown[]): void => {
-      captured.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+      capturedErr.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
     };
   });
 
@@ -78,7 +84,8 @@ export function installCliHarness(): CliHarness {
 
   return {
     dir: () => tmpDir,
-    stderr: () => captured,
+    stderr: () => capturedErr,
+    stdout: () => capturedOut,
     run: async (...args: string[]): Promise<number> => {
       process.argv = ['node', 'openapi-merge-cli', ...args];
       try {
@@ -93,11 +100,13 @@ export function installCliHarness(): CliHarness {
     },
     write: (fileName, contents) => {
       const filePath = path.join(tmpDir, fileName);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, contents);
       return filePath;
     },
     writeJson: (fileName, value) => {
       const filePath = path.join(tmpDir, fileName);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
       return filePath;
     },

--- a/packages/openapi-merge-cli/src/__tests__/cli-external-references.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-external-references.test.ts
@@ -1,0 +1,282 @@
+import http from 'http';
+import { ExitCode } from '../index';
+import { installCliHarness } from './_helpers/cli-harness';
+
+/**
+ * Cross-document `$ref` resolution driven through the real CLI end to end
+ * (issues #104 and #10).
+ *
+ * Two behaviours, deliberately tested apart:
+ * - Resolving a `$ref` into another *declared* input (#104) is unconditional
+ *   -- no config flag needed, and it must keep working even with
+ *   `resolveExternalReferences` absent.
+ * - Discovering and loading a `$ref` into a file/URL nobody declared as an
+ *   input (#10) only happens when `resolveExternalReferences: true` is set.
+ */
+
+const cli = installCliHarness();
+
+describe('#104 -- refs into another declared input (unconditional)', () => {
+  it('resolves the reported repro with resolveExternalReferences absent from the config', async () => {
+    cli.write('specs/common/ServerError.yml', [
+      'openapi: "3.0.0"',
+      'components:',
+      '  schemas:',
+      '    ServerError:',
+      '      type: object',
+      '',
+    ].join('\n'));
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'paths:',
+      '  /a:',
+      '    get:',
+      '      operationId: getA',
+      '      responses:',
+      '        "200": { description: ok }',
+      '        default:',
+      '          description: server error',
+      '          content:',
+      '            application/json:',
+      '              schema:',
+      '                $ref: "../common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/common/ServerError.yml' }, { inputFile: './specs/a/Api.yml' }],
+      output: './bundle.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.paths['/a'].get.responses.default.content['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/ServerError',
+    });
+    expect(output.components.schemas.ServerError).toEqual({ type: 'object' });
+  });
+
+  it('leaves a ref to a file that is NOT a declared input normalised but unresolved, with the flag absent', async () => {
+    // Normalising to an absolute identity happens unconditionally (it's how
+    // #104 matching works at all) -- but with no matching declared input and
+    // discovery off, nothing further happens: the component is not pulled in.
+    cli.write('specs/common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "../common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a/Api.yml' }],
+      output: './bundle.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.components.schemas.Widget.$ref).not.toBe('#/components/schemas/ServerError');
+    expect(output.components.schemas.Widget.$ref).toContain('ServerError.yml#/components/schemas/ServerError');
+    expect(output.components.schemas.ServerError).toBeUndefined();
+  });
+});
+
+describe('#10 -- discovering files nobody declared as an input (resolveExternalReferences: true)', () => {
+  it('pulls in a component from a file that is not a declared input', async () => {
+    cli.write('specs/common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "../common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a/Api.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.components.schemas.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+    expect(output.components.schemas.ServerError).toEqual({ type: 'object' });
+  });
+
+  it('follows a chain of discovery across more than one undeclared file', async () => {
+    cli.write('specs/c.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    Inner:\n      type: string\n');
+    cli.write('specs/b.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    Wrapper:\n      $ref: "./c.yml#/components/schemas/Inner"\n');
+    cli.write('specs/a.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "./b.yml#/components/schemas/Wrapper"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.components.schemas.Widget).toEqual({ $ref: '#/components/schemas/Wrapper' });
+    expect(output.components.schemas.Wrapper).toEqual({ $ref: '#/components/schemas/Inner' });
+    expect(output.components.schemas.Inner).toEqual({ type: 'string' });
+  });
+
+  it('does not hang when two discovered files reference each other (file-level, not component-level, cycle)', async () => {
+    // b.yml and a.yml refer to each other's *different* components -- normal
+    // in a shared-components layout, and not the same thing as a component
+    // transitively referencing itself.
+    cli.write('specs/b.yml', [
+      'openapi: "3.0.0"',
+      'components:',
+      '  schemas:',
+      '    FromB:',
+      '      type: string',
+      '    BackToA:',
+      '      $ref: "./a.yml#/components/schemas/FromA"',
+      '',
+    ].join('\n'));
+    cli.write('specs/a.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    FromA:',
+      '      type: string',
+      '    Widget:',
+      '      $ref: "./b.yml#/components/schemas/FromB"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.components.schemas.Widget).toEqual({ $ref: '#/components/schemas/FromB' });
+  });
+
+  it('reports a merge error (not a hang or crash) for a genuinely cyclic component reference', async () => {
+    cli.write('specs/x.yml', [
+      'openapi: "3.0.0"',
+      'components:',
+      '  schemas:',
+      '    A:',
+      '      $ref: "#/components/schemas/B"',
+      '    B:',
+      '      $ref: "#/components/schemas/A"',
+      '',
+    ].join('\n'));
+    cli.write('specs/a.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "./x.yml#/components/schemas/A"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorMerging);
+    expect(cli.stderr().join('\n')).toContain('cyclic-external-reference');
+  });
+
+  it('warns and leaves the ref unresolved when a discovered file cannot be loaded, without failing the merge', async () => {
+    cli.write('specs/a.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "./does-not-exist.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.components.schemas.Widget.$ref).toContain('does-not-exist.yml#/components/schemas/ServerError');
+    expect(cli.stdout().join('\n')).toContain('WARNING');
+    expect(cli.stdout().join('\n')).toContain('does-not-exist.yml');
+  });
+
+  it('discovers and loads a component from a URL referenced by a file input', async () => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/errors.yaml') {
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end('openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+      } else {
+        res.writeHead(404);
+        res.end('not found');
+      }
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : 0;
+
+      cli.write('specs/a.yml', [
+        'openapi: "3.0.0"',
+        'info: { title: A, version: "1.0" }',
+        'components:',
+        '  schemas:',
+        '    Widget:',
+        `      $ref: "http://127.0.0.1:${port}/errors.yaml#/components/schemas/ServerError"`,
+        '',
+      ].join('\n'));
+      const config = cli.writeJson('openapi-merge.json', {
+        inputs: [{ inputFile: './specs/a.yml' }],
+        output: './bundle.json',
+        resolveExternalReferences: true,
+      });
+
+      expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+
+      const output = JSON.parse(cli.read('bundle.json'));
+      expect(output.components.schemas.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+      expect(output.components.schemas.ServerError).toEqual({ type: 'object' });
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+});
+
+describe('resolveExternalReferences schema validation', () => {
+  it('rejects a non-boolean value', async () => {
+    cli.write('a.json', JSON.stringify({ openapi: '3.0.3', info: { title: 'T', version: '1' }, paths: {} }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './out.json',
+      resolveExternalReferences: 'yes',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingConfig);
+  });
+});

--- a/packages/openapi-merge-cli/src/__tests__/external-reference-discovery.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/external-reference-discovery.test.ts
@@ -1,0 +1,102 @@
+import {
+  DocumentReference, normalizeCrossDocumentRefs, resolveCrossDocumentIdentity,
+} from '../external-reference-discovery';
+import { OpenApiDocument } from 'openapi-merge/dist/oas31';
+
+/**
+ * The pure identity-classification/resolution logic behind cross-document
+ * `$ref` discovery (issues #104, #10), tested directly rather than through a
+ * mocked `fetch` -- these are plain functions with no I/O, and the URL-vs-file
+ * classification is exactly the part most worth pinning down precisely.
+ */
+describe('resolveCrossDocumentIdentity', () => {
+  const fileRef = (identity: string): DocumentReference => ({ identity, kind: 'file' });
+  const urlRef = (identity: string): DocumentReference => ({ identity, kind: 'url' });
+
+  it('resolves a relative path from a file relative to that file\'s own directory', () => {
+    const result = resolveCrossDocumentIdentity('../common/Errors.yml', fileRef('/repo/specs/a/Api.yml'));
+    expect(result).toEqual({ identity: '/repo/specs/common/Errors.yml', kind: 'file' });
+  });
+
+  it('resolves a same-directory relative path from a file', () => {
+    const result = resolveCrossDocumentIdentity('./Sibling.yml', fileRef('/repo/specs/a/Api.yml'));
+    expect(result).toEqual({ identity: '/repo/specs/a/Sibling.yml', kind: 'file' });
+  });
+
+  it('treats an absolute URL found inside a file input as a URL identity, not a path', () => {
+    const result = resolveCrossDocumentIdentity('https://example.com/errors.yaml', fileRef('/repo/specs/a/Api.yml'));
+    expect(result).toEqual({ identity: 'https://example.com/errors.yaml', kind: 'url' });
+  });
+
+  it('resolves a relative reference from a URL against that URL', () => {
+    const result = resolveCrossDocumentIdentity('../common/Errors.yml', urlRef('https://example.com/specs/a/Api.yml'));
+    expect(result).toEqual({ identity: 'https://example.com/specs/common/Errors.yml', kind: 'url' });
+  });
+
+  it('resolves an absolute URL reference from a URL to itself, unchanged', () => {
+    const result = resolveCrossDocumentIdentity('https://other.example.com/errors.yaml', urlRef('https://example.com/specs/a/Api.yml'));
+    expect(result).toEqual({ identity: 'https://other.example.com/errors.yaml', kind: 'url' });
+  });
+
+  it('two different relative spellings of the same file resolve to the same identity', () => {
+    const a = resolveCrossDocumentIdentity('../common/Errors.yml', fileRef('/repo/specs/a/Api.yml'));
+    const b = resolveCrossDocumentIdentity('../../common/Errors.yml', fileRef('/repo/specs/a/nested/Api.yml'));
+    expect(a.identity).toBe(b.identity);
+    expect(a.identity).toBe('/repo/specs/common/Errors.yml');
+  });
+});
+
+describe('normalizeCrossDocumentRefs', () => {
+  const self: DocumentReference = { identity: '/repo/specs/a/Api.yml', kind: 'file' };
+
+  function doc(schemas: Record<string, unknown>): OpenApiDocument {
+    return { openapi: '3.0.3', info: { title: 'T', version: '1' }, components: { schemas } } as unknown as OpenApiDocument;
+  }
+
+  it('rewrites a relative cross-document ref to an absolute identity, in place', () => {
+    const document = doc({ Widget: { $ref: '../common/Errors.yml#/components/schemas/ServerError' } });
+
+    normalizeCrossDocumentRefs(document, self);
+
+    expect((document.components?.schemas?.Widget as { $ref: string }).$ref)
+      .toBe('/repo/specs/common/Errors.yml#/components/schemas/ServerError');
+  });
+
+  it('returns the distinct identities discovered', () => {
+    const document = doc({
+      A: { $ref: '../common/Errors.yml#/components/schemas/X' },
+      B: { $ref: '../common/Errors.yml#/components/schemas/Y' },
+      C: { $ref: '../other/Thing.yml#/components/schemas/Z' },
+    });
+
+    const found = normalizeCrossDocumentRefs(document, self);
+
+    expect(found.map(f => f.identity).sort()).toEqual([
+      '/repo/specs/common/Errors.yml',
+      '/repo/specs/other/Thing.yml',
+    ]);
+  });
+
+  it('leaves a bare same-document ref untouched', () => {
+    const document = doc({
+      A: { type: 'object' },
+      B: { $ref: '#/components/schemas/A' },
+    });
+
+    const found = normalizeCrossDocumentRefs(document, self);
+
+    expect((document.components?.schemas?.B as { $ref: string }).$ref).toBe('#/components/schemas/A');
+    expect(found).toEqual([]);
+  });
+
+  it('leaves a whole-document ref (no fragment) untouched and does not report it as discovered', () => {
+    // Legal OpenAPI, but there is no single local pointer that could stand in
+    // for "that whole document" -- deliberately out of scope (issue #104 §5.1).
+    const document = doc({ Widget: { $ref: '../common/Errors.yml' } });
+
+    const found = normalizeCrossDocumentRefs(document, self);
+
+    expect((document.components?.schemas?.Widget as { $ref: string }).$ref).toBe('../common/Errors.yml');
+    expect(found).toEqual([]);
+  });
+});

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -332,6 +332,30 @@ export type Configuration = {
    * field, so setting only `title` does not require restating `version`.
    */
   info?: ConfigurationInfoOverride;
+
+  /**
+   * Follow `$ref`s that point outside the declared inputs -- to a file or URL
+   * this configuration never named -- and pull in just the specific
+   * components they ask for (issue #10).
+   *
+   * Defaults to `false`. A `$ref` into one of the *declared* `inputs` is
+   * always resolved correctly regardless of this setting (issue #104) --
+   * that fix is unconditional, since it only ever affects a `$ref` that is
+   * already broken today. This setting is what additionally lets a `$ref`
+   * discover and load documents nobody listed in `inputs`.
+   *
+   * Off by default because it changes what this tool reads: with it on, the
+   * files and URLs actually loaded are no longer limited to what `inputs`
+   * names, transitively following wherever a `$ref` in *any* loaded document
+   * points. Turn it on deliberately, for configurations whose inputs are
+   * trusted to the same degree the config file itself is.
+   *
+   * A `$ref` this discovers but cannot load (missing file, failed fetch,
+   * unparseable content) is left exactly as written and logged as a warning
+   * -- not a hard failure, matching how a `$ref` into a declared input that
+   * cannot be resolved is also left untouched rather than erroring.
+   */
+  resolveExternalReferences?: boolean;
 };
 
 /**

--- a/packages/openapi-merge-cli/src/exit-codes.ts
+++ b/packages/openapi-merge-cli/src/exit-codes.ts
@@ -69,8 +69,9 @@ export enum ExitCode {
    *
    * Raised by the merge library rather than the CLI: duplicate paths across
    * inputs, an `operationId` conflict that no `dispute` setting could resolve,
-   * or a component that could not be deduplicated. The message names the
-   * offending element and the input index it came from.
+   * a component that could not be deduplicated, or a cross-document `$ref`
+   * chain that refers back to itself. The message names the offending
+   * element and the input index it came from.
    *
    * These are authoring problems, not transient ones -- retrying without
    * changing the inputs or the `dispute` configuration produces the same

--- a/packages/openapi-merge-cli/src/external-reference-discovery.ts
+++ b/packages/openapi-merge-cli/src/external-reference-discovery.ts
@@ -1,0 +1,197 @@
+import path from 'path';
+import { OpenApiDocument } from 'openapi-merge/dist/oas31';
+import { walkAllReferences } from 'openapi-merge/dist/reference-walker';
+import { readFileAsString, readYamlOrJSON } from './file-loading';
+import { resolveConfigPath } from './path-resolution';
+
+/**
+ * Discovering and loading `$ref`-only documents (issue #10) -- files or URLs
+ * nobody named in `inputs`, reached only by following a `$ref` from something
+ * that *was* loaded.
+ *
+ * Kept entirely in the CLI, not the library: `openapi-merge` deliberately has
+ * no file-path or network awareness (see proposal 36 §3), so all of the async
+ * I/O and path/URL resolution happens here, synchronously handed off to
+ * `merge()` as a plain `Record<identity, OpenApiDocument>` once it's done --
+ * exactly the "pre-downloaded mapping" shape issue #10's own note describes.
+ */
+
+export type DocumentKind = 'file' | 'url';
+
+export type DocumentReference = {
+  identity: string;
+  kind: DocumentKind;
+};
+
+const ABSOLUTE_URL = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Resolves the identity a cross-document `$ref`'s non-fragment portion names,
+ * given the identity and kind of the document *containing* that `$ref`.
+ *
+ * Pure and side-effect free (no file reads, no network) so it is unit
+ * testable without mocking `fetch` or touching the filesystem -- the exact
+ * classification/resolution logic this feature depends on getting right for
+ * both files and URLs, isolated from the I/O around it.
+ *
+ * - From a **file**: an absolute URL in the ref is a URL identity; anything
+ *   else is a file path resolved relative to the referencing file's own
+ *   directory (not the config's `basePath` -- matching what the ref's author
+ *   meant by a path like `../common/Errors.yml`).
+ * - From a **URL**: resolved via `new URL(ref, referencingIdentity)`, which
+ *   correctly handles both a relative ref and one that is itself absolute.
+ */
+export function resolveCrossDocumentIdentity(refTarget: string, referencing: DocumentReference): DocumentReference {
+  if (referencing.kind === 'url') {
+    return { identity: new URL(refTarget, referencing.identity).href, kind: 'url' };
+  }
+
+  if (ABSOLUTE_URL.test(refTarget)) {
+    return { identity: new URL(refTarget).href, kind: 'url' };
+  }
+
+  return { identity: path.resolve(path.dirname(referencing.identity), refTarget), kind: 'file' };
+}
+
+/**
+ * Splits a cross-document `$ref` into its target and (`#`-prefixed) fragment.
+ * `undefined` for a bare same-document ref (`#/...`) or a whole-document ref
+ * with no fragment -- both left alone by the normalisation pass below,
+ * exactly as the library's own `splitCrossDocumentRef` leaves them alone.
+ */
+function splitRefTarget(ref: string): { target: string; fragment: string } | undefined {
+  if (ref.startsWith('#')) {
+    return undefined;
+  }
+  const hashIndex = ref.indexOf('#');
+  if (hashIndex === -1) {
+    return undefined;
+  }
+  return { target: ref.slice(0, hashIndex), fragment: `#${ref.slice(hashIndex + 1)}` };
+}
+
+/**
+ * Rewrites every cross-document `$ref` in `doc` to `<absolute identity>#<fragment>`,
+ * mutating it in place, and returns the distinct identities it named.
+ *
+ * Every document this feature touches -- declared inputs and discovered
+ * documents alike -- goes through this exactly once, immediately after being
+ * parsed. That is what lets a `$ref` found *inside* a discovered document
+ * resolve correctly later: by the time anything downstream reads it, its
+ * cross-document refs are already absolute, not relative to a directory
+ * nothing downstream knows about.
+ */
+export function normalizeCrossDocumentRefs(doc: OpenApiDocument, self: DocumentReference): DocumentReference[] {
+  const discovered = new Map<string, DocumentReference>();
+
+  walkAllReferences(doc, ref => {
+    const split = splitRefTarget(ref);
+    if (split === undefined) {
+      return ref;
+    }
+
+    const target = resolveCrossDocumentIdentity(split.target, self);
+    if (!discovered.has(target.identity)) {
+      discovered.set(target.identity, target);
+    }
+
+    return `${target.identity}${split.fragment}`;
+  });
+
+  return [...discovered.values()];
+}
+
+async function loadDocument(reference: DocumentReference): Promise<OpenApiDocument> {
+  if (reference.kind === 'url') {
+    const response = await fetch(reference.identity);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return (await readYamlOrJSON(await response.text())) as OpenApiDocument;
+  }
+  return (await readYamlOrJSON(await readFileAsString(reference.identity))) as OpenApiDocument;
+}
+
+export type DiscoveryWarning = {
+  reference: DocumentReference;
+  message: string;
+};
+
+export type DiscoveryResult = {
+  externalDocuments: Record<string, OpenApiDocument>;
+  warnings: DiscoveryWarning[];
+};
+
+/**
+ * The declared-input identity for a file input, matching what
+ * `loadOasForInput` already resolves it to.
+ */
+export function fileInputIdentity(basePath: string, inputFile: string): DocumentReference {
+  return { identity: resolveConfigPath(basePath, inputFile), kind: 'file' };
+}
+
+/** The declared-input identity for a URL input -- the URL itself. */
+export function urlInputIdentity(inputURL: string): DocumentReference {
+  return { identity: inputURL, kind: 'url' };
+}
+
+/**
+ * Normalises every declared input's own cross-document refs (unconditional
+ * -- this is issue #104, always on), then, if `enableDiscovery` is set,
+ * follows any newly-named identity that is not itself a declared input:
+ * loads it, normalises *its* refs the same way, and keeps following whatever
+ * that turns up, until nothing new remains (issue #10).
+ *
+ * A discovered identity that fails to load is warned about and left out of
+ * `externalDocuments` -- any `$ref` naming it is then simply unresolved by
+ * the library, exactly as a `$ref` to a declared input that does not exist
+ * would be.
+ */
+export async function discoverExternalDocuments(
+  declaredInputs: ReadonlyArray<{ document: OpenApiDocument; reference: DocumentReference }>,
+  enableDiscovery: boolean,
+): Promise<DiscoveryResult> {
+  const known = new Set(declaredInputs.map(input => input.reference.identity));
+  const externalDocuments: Record<string, OpenApiDocument> = {};
+  const warnings: DiscoveryWarning[] = [];
+
+  const worklist: DocumentReference[] = [];
+  for (const input of declaredInputs) {
+    const found = normalizeCrossDocumentRefs(input.document, input.reference);
+    if (enableDiscovery) {
+      for (const target of found) {
+        if (!known.has(target.identity)) {
+          known.add(target.identity);
+          worklist.push(target);
+        }
+      }
+    }
+  }
+
+  while (enableDiscovery && worklist.length > 0) {
+    // Shift, not pop: breadth-first, so documents are loaded in roughly the
+    // order they were first referenced -- easier to reason about than an
+    // arbitrary order, though nothing downstream depends on it.
+    const next = worklist.shift();
+    if (next === undefined) {
+      break;
+    }
+
+    try {
+      const document = await loadDocument(next);
+      externalDocuments[next.identity] = document;
+
+      const found = normalizeCrossDocumentRefs(document, next);
+      for (const target of found) {
+        if (!known.has(target.identity)) {
+          known.add(target.identity);
+          worklist.push(target);
+        }
+      }
+    } catch (e) {
+      warnings.push({ reference: next, message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  return { externalDocuments, warnings };
+}

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -18,6 +18,7 @@ import { dump as dumpYaml } from 'js-yaml';
 import { readFileAsString, readYamlOrJSON } from "./file-loading";
 import { ExitCode } from "./exit-codes";
 import { assertOutputContained, OutputOutsideRootError, resolveConfigPath } from "./path-resolution";
+import { discoverExternalDocuments, DocumentReference, fileInputIdentity, urlInputIdentity } from "./external-reference-discovery";
 import { indentToJsonStringifyArg, indentToYamlArg } from "./formatting";
 import { DEFAULT_INDENT, Indent } from "./data";
 
@@ -230,6 +231,13 @@ async function loadOasForInput(basePath: string, input: ConfigurationInput, inpu
   }
 }
 
+/** The identity a declared input is known by for cross-document `$ref` resolution (issues #104, #10). */
+function inputIdentity(basePath: string, input: ConfigurationInput): DocumentReference {
+  return isConfigurationInputFromFile(input)
+    ? fileInputIdentity(basePath, input.inputFile)
+    : urlInputIdentity(input.inputURL);
+}
+
 type InputConversionError = {
   message: string;
   exitCode: ExitCode;
@@ -248,13 +256,20 @@ function isSingleMergeInput(i: SingleMergeInput | InputConversionError): i is Si
   return !isConversionError(i);
 }
 
-async function convertInputs(basePath: string, configInputs: ConfigurationInput[], logger: LogWithMillisDiff): Promise<MergeInput | InputConversionErrors> {
+type ConvertedInputs = {
+  inputs: MergeInput;
+  /** Same order as `inputs` -- each input's own identity for cross-document `$ref` resolution. */
+  references: DocumentReference[];
+};
+
+async function convertInputs(basePath: string, configInputs: ConfigurationInput[], logger: LogWithMillisDiff): Promise<ConvertedInputs | InputConversionErrors> {
   const results = await Promise.all(configInputs.map<Promise<SingleMergeInput | InputConversionError>>(async (input, inputIndex) => {
     try {
       const oas = await loadOasForInput(basePath, input, inputIndex, logger);
 
       const output: SingleMergeInput = {
         oas,
+        sourceIdentity: inputIdentity(basePath, input).identity,
         pathModification: input.pathModification,
         operationSelection: input.operationSelection,
         description: input.description,
@@ -294,7 +309,8 @@ async function convertInputs(basePath: string, configInputs: ConfigurationInput[
     return { errors: errors.map(e => e.message), exitCode: errors[0].exitCode };
   }
 
-  return results.filter(isSingleMergeInput);
+  const inputs = results.filter(isSingleMergeInput);
+  return { inputs, references: configInputs.map(input => inputIdentity(basePath, input)) };
 }
 
 function isYamlExtension(filePath: string): boolean {
@@ -347,13 +363,30 @@ export async function main(): Promise<void> {
 
   const basePath = path.dirname(options.config || './');
 
-  const inputs = await convertInputs(basePath, config.inputs, logger);
+  const converted = await convertInputs(basePath, config.inputs, logger);
 
-  if ('errors' in inputs) {
-    inputs.errors.forEach(error => console.error(error));
-    process.exit(inputs.exitCode);
+  if ('errors' in converted) {
+    converted.errors.forEach(error => console.error(error));
+    process.exit(converted.exitCode);
     return;
   }
+
+  const { inputs, references } = converted;
+
+  // Cross-document `$ref` resolution (issues #104, #10). Normalising each
+  // input's own refs and resolving anything that names *another* declared
+  // input runs unconditionally -- that fix is always safe, since it only
+  // ever affects a `$ref` that would otherwise be silently broken.
+  // `resolveExternalReferences` controls only whether a `$ref` naming a file
+  // or URL nobody declared as an input gets followed and loaded.
+  const discovery = await discoverExternalDocuments(
+    inputs.map((input, i) => ({ document: input.oas, reference: references[i] })),
+    config.resolveExternalReferences === true,
+  );
+
+  discovery.warnings.forEach(warning => {
+    logger.log(`## WARNING: could not load '${warning.reference.identity}', referenced via $ref -- left unresolved. (${warning.message})`);
+  });
 
   logger.log(`## Loaded the inputs into memory, merging the results.`);
 
@@ -361,6 +394,7 @@ export async function main(): Promise<void> {
     serversStrategy: config.serversStrategy,
     securitySchemesStrategy: config.securitySchemesStrategy,
     pruneUnusedComponents: config.pruneUnusedComponents,
+    externalDocuments: discovery.externalDocuments,
     info: config.info,
   });
 

--- a/packages/openapi-merge/src/__tests__/external-references.test.ts
+++ b/packages/openapi-merge/src/__tests__/external-references.test.ts
@@ -1,0 +1,330 @@
+import _ from 'lodash';
+import { merge } from '../index';
+import { at, doc30, expectMergeError, expectSuccess, op, ok, schema, schemaKeys } from './_helpers/documents';
+import { OpenApiDocument } from '../oas31';
+
+/**
+ * Cross-document `$ref` resolution (issues #104 and #10).
+ *
+ * `merge()` never does file I/O -- everything here calls it directly with
+ * hand-built `externalDocuments`, exactly as a caller (`openapi-merge-cli`)
+ * would after resolving paths/URLs and loading files itself. No CLI, no disk,
+ * no network: the subtle logic (dedup, disambiguation, recursion, cycles) all
+ * lives here and is fully testable without any of that.
+ */
+
+describe('#104 -- refs into another declared input', () => {
+  it('resolves a forward reference (input 0 refs input 2, not yet processed)', () => {
+    const output = expectSuccess(merge([
+      { oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'common#/components/schemas/ServerError' }) } } }) },
+      { oas: doc30({ paths: { '/b': { get: op('getB') } } }) },
+      { oas: doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } }), sourceIdentity: 'common' },
+    ]));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+    expect(schemaKeys(output)).toEqual(['ServerError', 'Widget']);
+  });
+
+  it('resolves a backward reference (input 2 refs input 0, already processed)', () => {
+    const output = expectSuccess(merge([
+      { oas: doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } }), sourceIdentity: 'common' },
+      { oas: doc30({ paths: { '/b': { get: op('getB') } } }) },
+      { oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'common#/components/schemas/ServerError' }) } } }) },
+    ]));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+  });
+
+  it('resolves a ref to a component that was renamed for a clash in the target input', () => {
+    const output = expectSuccess(merge([
+      { oas: doc30({ components: { schemas: { ServerError: schema({ type: 'object', properties: { a: schema({ type: 'string' }) } }) } } }) },
+      {
+        oas: doc30({ components: { schemas: { ServerError: schema({ type: 'object', properties: { b: schema({ type: 'string' }) } }) } } }),
+        sourceIdentity: 'common',
+      },
+      { oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'common#/components/schemas/ServerError' }) } } }) },
+    ]));
+
+    // input 1's ServerError clashed with input 0's (different content) and was
+    // renamed ServerError1 -- the ref into it must follow the rename.
+    expect(schemaKeys(output)).toEqual(['ServerError', 'ServerError1', 'Widget']);
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/ServerError1' });
+  });
+
+  it('leaves a ref unresolved when its identity is claimed by more than one input', () => {
+    // The config can legitimately list the same file twice; there is no
+    // principled way to tell which copy a cross-document ref meant.
+    const output = expectSuccess(merge([
+      { oas: doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } }), sourceIdentity: 'common' },
+      { oas: doc30({ components: { schemas: { OtherError: schema({ type: 'object' }) } } }), sourceIdentity: 'common' },
+      { oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'common#/components/schemas/ServerError' }) } } }) },
+    ]));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: 'common#/components/schemas/ServerError' });
+  });
+});
+
+describe('#10 -- pulling components from externalDocuments', () => {
+  it('pulls in a component the first time it is referenced', () => {
+    const externalDoc = doc30({
+      components: { schemas: { ServerError: schema({ type: 'object', properties: { message: schema({ type: 'string' }) } }) } },
+    });
+
+    const output = expectSuccess(merge(
+      [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'errors.yaml#/components/schemas/ServerError' }) } } }) }],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+    expect(output.components?.schemas?.ServerError).toEqual({ type: 'object', properties: { message: { type: 'string' } } });
+  });
+
+  it('collapses a pulled-in component against an equivalent one already in the output', () => {
+    const serverError = schema({ type: 'object', properties: { message: schema({ type: 'string' }) } });
+    const externalDoc = doc30({ components: { schemas: { ServerError: _.cloneDeep(serverError) } } });
+
+    const output = expectSuccess(merge(
+      [
+        { oas: doc30({ components: { schemas: { ServerError: serverError } } }) },
+        { oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'errors.yaml#/components/schemas/ServerError' }) } } }) },
+      ],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    expect(schemaKeys(output)).toEqual(['ServerError', 'Widget']);
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+  });
+
+  it('disambiguates with a numeric suffix when a pulled-in component clashes with a different one', () => {
+    const externalDoc = doc30({
+      components: { schemas: { ServerError: schema({ type: 'object', properties: { code: schema({ type: 'integer' }) } }) } },
+    });
+
+    const output = expectSuccess(merge(
+      [
+        { oas: doc30({ components: { schemas: { ServerError: schema({ type: 'object', properties: { message: schema({ type: 'string' }) } }) } } }) },
+        { oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'errors.yaml#/components/schemas/ServerError' }) } } }) },
+      ],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    // No dispute config applies to a pulled-in component (it was never a
+    // declared input); the fallback is the same numeric-suffix disambiguation
+    // `processComponents` already uses when no dispute is configured.
+    expect(schemaKeys(output)).toEqual(['ServerError', 'ServerError1', 'Widget']);
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/ServerError1' });
+  });
+
+  it('recursively pulls in components across a chain of external documents', () => {
+    const docC = doc30({ components: { schemas: { Inner: schema({ type: 'string' }) } } });
+    const docB = doc30({ components: { schemas: { Wrapper: schema({ $ref: 'c.yaml#/components/schemas/Inner' }) } } });
+
+    const output = expectSuccess(merge(
+      [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'b.yaml#/components/schemas/Wrapper' }) } } }) }],
+      { externalDocuments: { 'b.yaml': docB, 'c.yaml': docC } },
+    ));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: '#/components/schemas/Wrapper' });
+    expect(output.components?.schemas?.Wrapper).toEqual({ $ref: '#/components/schemas/Inner' });
+    expect(output.components?.schemas?.Inner).toEqual({ type: 'string' });
+  });
+
+  it('resolves a declared-input ref and an external-document ref from the same input', () => {
+    const externalDoc = doc30({ components: { schemas: { FromExternal: schema({ type: 'string' }) } } });
+
+    const output = expectSuccess(merge(
+      [
+        {
+          oas: doc30({
+            components: {
+              schemas: {
+                Widget: schema({
+                  type: 'object',
+                  properties: {
+                    a: schema({ $ref: 'common#/components/schemas/FromInput' }),
+                    b: schema({ $ref: 'external.yaml#/components/schemas/FromExternal' }),
+                  },
+                }),
+              },
+            },
+          }),
+        },
+        { oas: doc30({ components: { schemas: { FromInput: schema({ type: 'number' }) } } }), sourceIdentity: 'common' },
+      ],
+      { externalDocuments: { 'external.yaml': externalDoc } },
+    ));
+
+    expect(at(output, 'components', 'schemas', 'Widget', 'properties', 'a')).toEqual({ $ref: '#/components/schemas/FromInput' });
+    expect(at(output, 'components', 'schemas', 'Widget', 'properties', 'b')).toEqual({ $ref: '#/components/schemas/FromExternal' });
+  });
+
+  it('reports a clean error for a cyclic external reference instead of overflowing the stack', () => {
+    const docX = doc30({
+      components: {
+        schemas: {
+          A: schema({ $ref: '#/components/schemas/B' }),
+          B: schema({ $ref: '#/components/schemas/A' }),
+        },
+      },
+    });
+
+    const message = expectMergeError(
+      merge(
+        [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'x.yaml#/components/schemas/A' }) } } }) }],
+        { externalDocuments: { 'x.yaml': docX } },
+      ),
+      'cyclic-external-reference',
+    );
+
+    expect(message).toContain('x.yaml');
+  });
+
+  it('leaves an unsupported fragment shape (a nested path) unresolved rather than guessing', () => {
+    const externalDoc = doc30({
+      components: { schemas: { ServerError: schema({ type: 'object', properties: { message: schema({ type: 'string' }) } }) } },
+    });
+    const nestedRef = 'errors.yaml#/components/schemas/ServerError/properties/message';
+
+    const output = expectSuccess(merge(
+      [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: nestedRef }) } } }) }],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: nestedRef });
+  });
+
+  it('leaves a securitySchemes fragment unresolved -- addressed by name, never by $ref', () => {
+    const externalDoc = {
+      ...doc30({}),
+      components: { securitySchemes: { apiKey: { type: 'apiKey', name: 'X-Api-Key', in: 'header' } } },
+    } as unknown as OpenApiDocument;
+    const securitySchemeRef = 'auth.yaml#/components/securitySchemes/apiKey';
+
+    const output = expectSuccess(merge(
+      [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: securitySchemeRef }) } } }) }],
+      { externalDocuments: { 'auth.yaml': externalDoc } },
+    ));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: securitySchemeRef });
+  });
+
+  it('leaves a whole-document ref (no fragment) untouched, even with a matching externalDocuments entry', () => {
+    const externalDoc = doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } });
+    const wholeDocRef = 'errors.yaml';
+
+    const output = expectSuccess(merge(
+      [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: wholeDocRef }) } } }) }],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: wholeDocRef });
+  });
+
+  it('reuses the same pulled-in component (and identity+fragment cache) when referenced twice', () => {
+    const externalDoc = doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } });
+
+    const output = expectSuccess(merge(
+      [{
+        oas: doc30({
+          components: {
+            schemas: {
+              WidgetA: schema({ $ref: 'errors.yaml#/components/schemas/ServerError' }),
+              WidgetB: schema({ $ref: 'errors.yaml#/components/schemas/ServerError' }),
+            },
+          },
+        }),
+      }],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    expect(schemaKeys(output)).toEqual(['ServerError', 'WidgetA', 'WidgetB']);
+    expect(output.components?.schemas?.WidgetA).toEqual({ $ref: '#/components/schemas/ServerError' });
+    expect(output.components?.schemas?.WidgetB).toEqual({ $ref: '#/components/schemas/ServerError' });
+  });
+
+  it('leaves a ref unresolved when the external document exists but the named component does not', () => {
+    const externalDoc = doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } });
+    const typoRef = 'errors.yaml#/components/schemas/ServerErro';
+
+    const output = expectSuccess(merge(
+      [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: typoRef }) } } }) }],
+      { externalDocuments: { 'errors.yaml': externalDoc } },
+    ));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: typoRef });
+  });
+
+  it('stops processing a pulled-in component\'s remaining refs once one of them errors', () => {
+    // Two refs in the same component: the first is cyclic (errors), the
+    // second is perfectly resolvable. The second must not also be resolved
+    // and silently placed -- once a component has failed, nothing further
+    // from it should be inserted.
+    const docX = doc30({
+      components: {
+        schemas: {
+          A: schema({ $ref: '#/components/schemas/B' }),
+          B: schema({ $ref: '#/components/schemas/A' }),
+          Combined: schema({
+            type: 'object',
+            properties: {
+              cyclic: schema({ $ref: '#/components/schemas/A' }),
+              fine: schema({ $ref: '#/components/schemas/Fine' }),
+            },
+          }),
+          Fine: schema({ type: 'string' }),
+        },
+      },
+    });
+
+    const message = expectMergeError(
+      merge(
+        [{ oas: doc30({ components: { schemas: { Widget: schema({ $ref: 'x.yaml#/components/schemas/Combined' }) } } }) }],
+        { externalDocuments: { 'x.yaml': docX } },
+      ),
+      'cyclic-external-reference',
+    );
+
+    expect(message).toContain('x.yaml');
+  });
+
+  it('leaves a cross-document ref untouched when externalDocuments is not provided at all', () => {
+    // Regression guard: this option must be fully opt-in by omission, with no
+    // behaviour change for a caller that never passes it (e.g. today's CLI
+    // with `resolveExternalReferences` off).
+    const untouchedRef = 'errors.yaml#/components/schemas/ServerError';
+
+    const output = expectSuccess(merge([
+      { oas: doc30({ components: { schemas: { Widget: schema({ $ref: untouchedRef }) } } }) },
+    ]));
+
+    expect(output.components?.schemas?.Widget).toEqual({ $ref: untouchedRef });
+  });
+
+  it('a pulled-in component survives pruneUnusedComponents, since it really is referenced', () => {
+    const externalDoc = doc30({ components: { schemas: { ServerError: schema({ type: 'object' }) } } });
+
+    const output = expectSuccess(merge(
+      [{
+        oas: doc30({
+          paths: {
+            '/a': {
+              get: {
+                ...op('getA'),
+                responses: {
+                  ...ok,
+                  default: {
+                    description: 'error',
+                    content: { 'application/json': { schema: schema({ $ref: 'errors.yaml#/components/schemas/ServerError' }) } },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }],
+      { externalDocuments: { 'errors.yaml': externalDoc }, pruneUnusedComponents: true },
+    ));
+
+    expect(schemaKeys(output)).toEqual(['ServerError']);
+  });
+});

--- a/packages/openapi-merge/src/data.ts
+++ b/packages/openapi-merge/src/data.ts
@@ -89,6 +89,27 @@ export type TagInjection = {
 export interface SingleMergeInputBase {
   oas: OpenApiDocument;
 
+  /**
+   * An opaque identity for this input -- typically the resolved absolute path
+   * or URL it was loaded from (issue #104).
+   *
+   * The library never parses or resolves this string; it only compares it for
+   * exact equality against the non-fragment portion of a `$ref` elsewhere in
+   * the merge (in another input's document, or in {@link MergeOptions.externalDocuments}).
+   * A `$ref` shaped `<this input's sourceIdentity>#/components/schemas/X`
+   * found anywhere in the merge is treated as if it were the bare, in-document
+   * ref `#/components/schemas/X` *as seen from this input* -- rewritten to
+   * wherever this input's `X` ended up after deduplication/renaming, exactly
+   * like any other reference into this input.
+   *
+   * Resolving the file-path or URL portion of a cross-document `$ref` against
+   * this identity (e.g. deciding that `../common/Errors.yml` in one input
+   * refers to the same file as another input's own path) is the caller's job
+   * -- normally `openapi-merge-cli`, which is the layer that knows about file
+   * paths and can do the async I/O this library deliberately does not do.
+   */
+  sourceIdentity?: string;
+
   pathModification?: PathModification;
 
   /**
@@ -246,6 +267,26 @@ export interface MergeOptions {
    * one serves.
    */
   securitySchemesStrategy?: SecuritySchemesStrategy;
+
+  /**
+   * Documents this merge may need to pull individual components out of, keyed
+   * by the same opaque identity described on {@link SingleMergeInputBase.sourceIdentity}
+   * (issue #10).
+   *
+   * Unlike an input, a document here never contributes `paths`, `webhooks`,
+   * `info`, `security`, `tags` or anything else to the output on its own --
+   * only the specific components a `$ref` elsewhere in the merge actually asks
+   * for are pulled in (and, transitively, whatever those components' own
+   * references need), deduplicated against the rest of the output exactly like
+   * any other component. A document listed here that nothing ends up
+   * referencing contributes nothing at all.
+   *
+   * Loading these (from disk, or over the network) is entirely the caller's
+   * job -- by the time this reaches `merge()`, every document is already an
+   * in-memory `OpenApiDocument` and merging proceeds synchronously, same as
+   * always.
+   */
+  externalDocuments?: Record<string, OpenApiDocument>;
 }
 
 export type SuccessfulMergeResult = {
@@ -262,7 +303,14 @@ export type ErrorType =
   /** The inputs did not all declare the same OpenAPI major.minor version. */
   | 'mixed-openapi-versions'
   /** Two inputs declared the same webhook name (3.1). */
-  | 'duplicate-webhooks';
+  | 'duplicate-webhooks'
+  /**
+   * A component reachable from `externalDocuments` (issue #10) transitively
+   * references itself -- A's schema needs B's, which needs A's again. Reported
+   * rather than silently broken or stack-overflowing, since there is no
+   * sensible finite document to produce for a genuinely circular definition.
+   */
+  | 'cyclic-external-reference';
 
 export type ErrorMergeResult = {
   type: ErrorType;

--- a/packages/openapi-merge/src/external-references.ts
+++ b/packages/openapi-merge/src/external-references.ts
@@ -1,0 +1,281 @@
+import _ from 'lodash';
+import { SwaggerLookup } from '@atlassian/atlassian-openapi';
+import { ErrorMergeResult } from './data';
+import { Components31, OpenApiDocument } from './oas31';
+import { walkComponentReferences } from './reference-walker';
+import { deepEquality } from './component-equivalence';
+import { Components, DEDUPLICATED_COMPONENT_TYPES, processComponents } from './paths-and-components';
+
+/**
+ * Cross-document `$ref` resolution (issues #104 and #10).
+ *
+ * A `$ref` that does not start with `#` names another document -- either one
+ * of this merge's own inputs (`#/components/schemas/X` as seen from a
+ * *different* input than the one containing the ref, qualified with that
+ * input's `sourceIdentity`), or a document this merge never received as an
+ * input at all, only as {@link import('./data').MergeOptions.externalDocuments}.
+ * Both are resolved through the same entry point, {@link createCrossDocumentResolver},
+ * because from the referencing side they look identical: a `$ref` shaped
+ * `<identity>#<fragment>`.
+ *
+ * What differs is what "resolving" means once the identity is known:
+ * - **A declared input**: the component is already being merged in as part
+ *   of that whole input. Resolving means looking up what it was renamed to
+ *   (if anything) in that input's own `referenceModification` map -- the
+ *   exact map its own bare in-document refs are rewritten with.
+ * - **An external document**: nothing about it is being merged in
+ *   automatically. Resolving means reaching into that document, cloning out
+ *   *just* the referenced component, deduplicating it into the output like
+ *   any other component, and -- since that component may itself `$ref`
+ *   something, either locally within the same external document or another
+ *   external document entirely -- resolving those the same way, recursively.
+ */
+
+type ComponentBucket = typeof DEDUPLICATED_COMPONENT_TYPES[number];
+
+export type ParsedComponentFragment = {
+  bucket: ComponentBucket;
+  name: string;
+};
+
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+/**
+ * Parses a `#`-prefixed fragment like `#/components/schemas/ServerError` into
+ * its bucket and name -- matching exactly the shape
+ * {@link DEDUPLICATED_COMPONENT_TYPES} already deduplicates.
+ *
+ * Anything else is unsupported and returns `undefined`, left for the caller
+ * to leave unresolved rather than guessed at:
+ * - A nested path (`#/components/schemas/Foo/properties/bar`): this library
+ *   only ever tracks whole-component renames, never partial ones.
+ * - `#/components/securitySchemes/X`: security schemes are addressed by name
+ *   in a security requirement object, never by `$ref`, so this shape is not
+ *   a reference-target OpenAPI itself defines (issue #33/#94's existing
+ *   carve-out for the same reason).
+ * - Anything not shaped `#/components/<bucket>/<name>` at all.
+ */
+export function parseComponentFragment(fragment: string): ParsedComponentFragment | undefined {
+  if (!fragment.startsWith('#/')) {
+    return undefined;
+  }
+
+  // `fragment.slice(2)` drops both the `#` and the `/` that follows it, so
+  // splitting `#/components/schemas/X` yields exactly `['components',
+  // 'schemas', 'X']` -- not a leading empty string from the delimiter still
+  // being present.
+  const segments = fragment.slice(2).split('/').map(decodeJsonPointerSegment);
+
+  if (segments.length !== 3 || segments[0] !== 'components') {
+    return undefined;
+  }
+
+  const [, bucket, name] = segments;
+
+  if (!(DEDUPLICATED_COMPONENT_TYPES as ReadonlyArray<string>).includes(bucket)) {
+    return undefined;
+  }
+
+  return { bucket: bucket as ComponentBucket, name };
+}
+
+/** Splits a cross-document `$ref` into its identity and (`#`-prefixed) fragment, or `undefined` for a bare same-document ref. */
+export function splitCrossDocumentRef(ref: string): { identity: string; fragment: string | undefined } | undefined {
+  if (ref.startsWith('#')) {
+    return undefined;
+  }
+
+  const hashIndex = ref.indexOf('#');
+  if (hashIndex === -1) {
+    // A whole-document reference (`./common/Errors.yml`, no fragment). Legal
+    // OpenAPI, but there is no single local pointer in the merged output that
+    // means "that whole document" -- left unresolved rather than guessed at.
+    return { identity: ref, fragment: undefined };
+  }
+
+  return { identity: ref.slice(0, hashIndex), fragment: `#${ref.slice(hashIndex + 1)}` };
+}
+
+export type ReferenceModificationByIdentity = Record<string, { [original: string]: string }>;
+
+export type ExternalReferenceResolution =
+  | { kind: 'resolved'; ref: string }
+  | { kind: 'error'; error: ErrorMergeResult }
+  | { kind: 'unresolved' };
+
+/**
+ * Builds the resolver used by {@link import('./paths-and-components').mergePathsAndComponents}'s
+ * cross-document pass. One resolver per merge call: it caches every
+ * identity+fragment it has already placed, and grows `resultComponents` in
+ * place as external components are pulled in.
+ *
+ * @param referenceModificationByIdentity Each declared input's own rename map
+ *   (built during that input's normal per-input processing), keyed by its
+ *   `sourceIdentity`.
+ * @param ambiguousIdentities Identities claimed by more than one declared
+ *   input (issue #104 §5.2) -- treated as unmatched rather than guessed at,
+ *   since there is no principled way to pick which input a ref meant.
+ * @param externalDocuments Documents that are not inputs, only a source of
+ *   components to pull in on demand (issue #10).
+ * @param resultComponents The merge's own `components`, mutated in place as
+ *   external components are placed into it.
+ */
+export function createCrossDocumentResolver(
+  referenceModificationByIdentity: ReferenceModificationByIdentity,
+  ambiguousIdentities: ReadonlySet<string>,
+  externalDocuments: Record<string, OpenApiDocument>,
+  resultComponents: Components31,
+): (identity: string, fragment: string) => ExternalReferenceResolution {
+  // Keyed by `${identity}#${fragment}`, both memoizing completed placements
+  // and detecting cycles: an identity+fragment re-entered while still being
+  // resolved means a component transitively references itself.
+  const resolvedCache = new Map<string, string>();
+  const inProgress = new Set<string>();
+
+  function resolveIdentityFragment(identity: string, fragment: string): ExternalReferenceResolution {
+    if (ambiguousIdentities.has(identity)) {
+      return { kind: 'unresolved' };
+    }
+
+    const inputMap = referenceModificationByIdentity[identity];
+    if (inputMap !== undefined) {
+      return resolveAgainstInputMap(inputMap, fragment);
+    }
+
+    const doc = externalDocuments[identity];
+    if (doc !== undefined) {
+      return pullInComponent(identity, doc, fragment);
+    }
+
+    // Not a declared input and never discovered/loaded -- out of scope
+    // (issue #104 §8 / issue #37), left exactly as found.
+    return { kind: 'unresolved' };
+  }
+
+  function resolveAgainstInputMap(inputMap: { [original: string]: string }, fragment: string): ExternalReferenceResolution {
+    if (inputMap[fragment] !== undefined) {
+      return { kind: 'resolved', ref: inputMap[fragment] };
+    }
+
+    const modifiedKeys = Object.keys(inputMap);
+    const matchingKeys = modifiedKeys.filter(key => key.startsWith(`${fragment}/`));
+
+    if (matchingKeys.length > 1) {
+      throw new Error(`Found more than one matching key for reference '${fragment}': ${JSON.stringify(matchingKeys)}`);
+    } else if (matchingKeys.length === 1) {
+      return { kind: 'resolved', ref: inputMap[matchingKeys[0]] };
+    }
+
+    // No rename recorded for this exact fragment: it survives into the
+    // output unchanged, exactly as a same-input bare ref would.
+    return { kind: 'resolved', ref: fragment };
+  }
+
+  function pullInComponent(identity: string, doc: OpenApiDocument, fragment: string): ExternalReferenceResolution {
+    const cacheKey = `${identity}${fragment}`;
+
+    const cached = resolvedCache.get(cacheKey);
+    if (cached !== undefined) {
+      return { kind: 'resolved', ref: cached };
+    }
+
+    if (inProgress.has(cacheKey)) {
+      return {
+        kind: 'error',
+        error: {
+          type: 'cyclic-external-reference',
+          message: `'${identity}${fragment}' is part of a cycle of external references and cannot be resolved.`,
+        },
+      };
+    }
+
+    const parsed = parseComponentFragment(fragment);
+    if (parsed === undefined) {
+      return { kind: 'unresolved' };
+    }
+
+    const sourceBucket = (doc.components as Components31 | undefined)?.[parsed.bucket] as Components<unknown> | undefined;
+    const raw = sourceBucket?.[parsed.name];
+    if (raw === undefined) {
+      return { kind: 'unresolved' };
+    }
+
+    // Marked in-progress (and only unmarked on the way out) *before* any
+    // cloning or placement, so a cycle is caught before anything is inserted
+    // -- an insert later orphaned by a cycle error would be worse than no
+    // insert at all.
+    inProgress.add(cacheKey);
+    try {
+      const cloned = _.cloneDeep(raw);
+      const wrapped = { [parsed.bucket]: { [parsed.name]: cloned } } as unknown as Components31;
+
+      let innerError: ErrorMergeResult | undefined;
+      walkComponentReferences(wrapped, ref => {
+        if (innerError !== undefined) {
+          return ref;
+        }
+
+        const split = splitCrossDocumentRef(ref);
+        // A bare ref (`split === undefined`) is local to *this* external
+        // document -- resolved against the same identity, recursively.
+        const resolution = split === undefined
+          ? resolveIdentityFragment(identity, ref)
+          : split.fragment === undefined
+            ? { kind: 'unresolved' as const }
+            : resolveIdentityFragment(split.identity, split.fragment);
+
+        if (resolution.kind === 'error') {
+          innerError = resolution.error;
+          return ref;
+        }
+
+        return resolution.kind === 'resolved' ? resolution.ref : ref;
+      });
+
+      if (innerError !== undefined) {
+        return { kind: 'error', error: innerError };
+      }
+
+      // Fresh on every call, not memoized across pulls: `resultComponents`
+      // grows as earlier pulls in the same pass are placed, and a later
+      // dedup check must see them. Mirrors how `mergePathsAndComponents`
+      // rebuilds the equivalent lookups on every input, for the same reason.
+      const resultLookup = new SwaggerLookup.InternalLookup({
+        openapi: '3.0.1', info: { title: 'dummy', version: '0' }, paths: {}, components: resultComponents,
+      });
+      const currentLookup = new SwaggerLookup.InternalLookup({
+        openapi: '3.0.1', info: { title: 'dummy', version: '0' }, paths: {}, components: doc.components ?? {},
+      });
+
+      const targetBucket = ((resultComponents as unknown as Record<string, Components<unknown> | undefined>)[parsed.bucket]) ?? {};
+      (resultComponents as unknown as Record<string, Components<unknown>>)[parsed.bucket] = targetBucket;
+
+      let finalName = parsed.name;
+      // `dispute: undefined` -- a discovered document was never declared as
+      // an input, so there is no per-input dispute config to consult. A name
+      // clash falls back to the same numeric-suffix disambiguation
+      // `processComponents` already uses when no dispute is configured.
+      const placementError = processComponents(
+        targetBucket,
+        { [parsed.name]: cloned },
+        deepEquality(resultLookup, currentLookup),
+        undefined,
+        (_from, to) => { finalName = to; },
+      );
+
+      if (placementError !== undefined) {
+        return { kind: 'error', error: placementError };
+      }
+
+      const finalRef = `#/components/${parsed.bucket}/${finalName}`;
+      resolvedCache.set(cacheKey, finalRef);
+      return { kind: 'resolved', ref: finalRef };
+    } finally {
+      inProgress.delete(cacheKey);
+    }
+  }
+
+  return resolveIdentityFragment;
+}

--- a/packages/openapi-merge/src/index.ts
+++ b/packages/openapi-merge/src/index.ts
@@ -54,7 +54,7 @@ export function merge(inputs: MergeInput, options?: MergeOptions): MergeResult {
     return versionError;
   }
 
-  const pathAndComponentResult = mergePathsAndComponents(inputs, options?.securitySchemesStrategy);
+  const pathAndComponentResult = mergePathsAndComponents(inputs, options?.securitySchemesStrategy, options?.externalDocuments);
 
   if (isErrorResult(pathAndComponentResult)) {
     return pathAndComponentResult;

--- a/packages/openapi-merge/src/paths-and-components.ts
+++ b/packages/openapi-merge/src/paths-and-components.ts
@@ -9,6 +9,7 @@ import { deepEquality } from "./component-equivalence";
 import { applyDispute, getDispute } from './dispute';
 import { DEFAULT_SECURITY_SCHEMES_STRATEGY, SecuritySchemesStrategy } from './security-schemes';
 import { Components31, getPathItemOperations, getPaths, getWebhooks, OpenApiDocument, PathItem32, PathItemMap } from './oas31';
+import { createCrossDocumentResolver, ReferenceModificationByIdentity, splitCrossDocumentRef } from './external-references';
 
 export type PathAndComponents = {
   paths: Swagger.Paths;
@@ -35,11 +36,27 @@ function removeFromStart(input: string, trim: string): string {
   return input;
 }
 
-type Components<A> = { [key: string]: A };
-type Equal<A> = (x: A, y: A) => boolean;
-type AddModRef = (from: string, to: string) => void;
+export type Components<A> = { [key: string]: A };
+export type Equal<A> = (x: A, y: A) => boolean;
+export type AddModRef = (from: string, to: string) => void;
 
-function processComponents<A>(results: Components<A>, components: Components<A>, areEqual: Equal<A>, dispute: Dispute | undefined, addModifiedReference: AddModRef): ErrorMergeResult | undefined {
+/**
+ * Every deduplicated component type goes through the same machinery. Kept as
+ * one list rather than nine near-identical blocks: the duplication is how
+ * `pathItems` came to be missing when 3.1 support landed, and how the error
+ * return in {@link processComponents} came to be dropped in all nine places.
+ *
+ * Exported (rather than local to {@link mergePathsAndComponents}) so
+ * `external-references.ts` validates a pulled-in `$ref`'s fragment against
+ * exactly the same set of bucket names this function already deduplicates --
+ * one list, not two that can drift apart.
+ */
+export const DEDUPLICATED_COMPONENT_TYPES = [
+  'schemas', 'responses', 'parameters', 'examples', 'requestBodies',
+  'headers', 'links', 'pathItems', 'callbacks',
+] as const;
+
+export function processComponents<A>(results: Components<A>, components: Components<A>, areEqual: Equal<A>, dispute: Dispute | undefined, addModifiedReference: AddModRef): ErrorMergeResult | undefined {
   for (const key in components) {
     /* eslint-disable-next-line no-prototype-builtins */
     if (components.hasOwnProperty(key)) {
@@ -323,6 +340,7 @@ function ensureUniqueCallbackOperationIds(
 export function mergePathsAndComponents(
   inputs: MergeInput,
   securitySchemesStrategy: SecuritySchemesStrategy = DEFAULT_SECURITY_SCHEMES_STRATEGY,
+  externalDocuments: Record<string, OpenApiDocument> = {},
 ): PathAndComponents | ErrorMergeResult {
   const seenOperationIds = new Set<string>();
 
@@ -331,6 +349,31 @@ export function mergePathsAndComponents(
     paths: {},
     components: {},
   };
+
+  // Every declared input's own `referenceModification` map, kept past the end
+  // of its loop iteration (unlike before #104/#10) so a *different* input's
+  // `$ref` into this one -- forward or backward, since this is only read once
+  // every input has had its turn -- can be resolved against it in the
+  // cross-document pass below.
+  const referenceModificationByIdentity: ReferenceModificationByIdentity = {};
+
+  // An identity claimed by more than one input (the config can legitimately
+  // list the same file twice, e.g. with different `pathModification`) has no
+  // principled resolution -- which copy would a cross-document `$ref` have
+  // meant? Treated as unmatched rather than guessed at (issue #104 §5.2).
+  const ambiguousIdentities = new Set<string>();
+  {
+    const seenIdentities = new Set<string>();
+    for (const input of inputs) {
+      if (input.sourceIdentity === undefined) {
+        continue;
+      }
+      if (seenIdentities.has(input.sourceIdentity)) {
+        ambiguousIdentities.add(input.sourceIdentity);
+      }
+      seenIdentities.add(input.sourceIdentity);
+    }
+  }
 
   for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
     const input = inputs[inputIndex];
@@ -349,6 +392,9 @@ export function mergePathsAndComponents(
 
     // Original references will be transformed to new non-conflicting references
     const referenceModification: { [originalReference: string]: string } = {};
+    if (input.sourceIdentity !== undefined && !ambiguousIdentities.has(input.sourceIdentity)) {
+      referenceModificationByIdentity[input.sourceIdentity] = referenceModification;
+    }
 
     // Security schemes are addressed by name rather than by `$ref`, so their
     // renames are tracked separately from `referenceModification` (issue #33).
@@ -361,14 +407,6 @@ export function mergePathsAndComponents(
       // document may legitimately have none, and the lookup only resolves
       // component `$ref`s, so an empty object is equivalent for its purposes.
       const currentLookup = new SwaggerLookup.InternalLookup({ ...oas, paths: getPaths(oas) });
-      // Every deduplicated component type goes through the same machinery. Kept
-      // as one list rather than nine near-identical blocks: the duplication is
-      // how `pathItems` came to be missing when 3.1 support landed, and how the
-      // error return below came to be dropped in all nine places.
-      const DEDUPLICATED_COMPONENT_TYPES = [
-        'schemas', 'responses', 'parameters', 'examples', 'requestBodies',
-        'headers', 'links', 'pathItems', 'callbacks',
-      ] as const;
 
       // Indexing a heterogeneous record by a dynamic key: every value here is a
       // `{ [name: string]: A }`, but TypeScript cannot prove the A matches
@@ -613,6 +651,52 @@ export function mergePathsAndComponents(
 
       return ref;
     });
+  }
+
+  // Cross-document `$ref`s (issues #104 and #10) -- deliberately a second
+  // pass over the *finished* `result`, not folded into the loop above. A
+  // `$ref` in input A may name input C, processed later in the loop above;
+  // C's own `referenceModification` map (and, for issue #10, anything
+  // `externalDocuments` needs pulled in) is only complete once every input
+  // has had its turn, so resolving cross-document refs any earlier would get
+  // a forward reference wrong.
+  const resolveCrossDocumentReference = createCrossDocumentResolver(
+    referenceModificationByIdentity,
+    ambiguousIdentities,
+    externalDocuments,
+    result.components,
+  );
+
+  let crossDocumentError: ErrorMergeResult | undefined;
+  // `walkAllReferences` wants a full `OpenApiDocument`; `result` only carries
+  // the subset it actually reads (`paths`/`webhooks`/`components`), the same
+  // gap `SwaggerLookup.InternalLookup` papers over elsewhere in this file.
+  walkAllReferences({ openapi: '3.0.1', info: { title: 'dummy', version: '0' }, ...result }, ref => {
+    if (crossDocumentError !== undefined || ref.startsWith('#')) {
+      // Bare same-document refs were already handled correctly by the
+      // per-input pass above; nothing further to do for them here.
+      return ref;
+    }
+
+    const split = splitCrossDocumentRef(ref);
+    if (split === undefined || split.fragment === undefined) {
+      // No fragment: a whole-document reference, left untouched (see
+      // `splitCrossDocumentRef`'s own note on why there is no single local
+      // pointer that could stand in for it).
+      return ref;
+    }
+
+    const resolution = resolveCrossDocumentReference(split.identity, split.fragment);
+    if (resolution.kind === 'error') {
+      crossDocumentError = resolution.error;
+      return ref;
+    }
+
+    return resolution.kind === 'resolved' ? resolution.ref : ref;
+  });
+
+  if (crossDocumentError !== undefined) {
+    return crossDocumentError;
   }
 
   return result;


### PR DESCRIPTION
## Summary

Implements "Option 2, refined" from [proposal 37](ai-planning/issues/37-proposal-10-external-ref-bundling.md): `merge()` stays fully synchronous and consults a pre-loaded `externalDocuments` map, while the CLI does all async I/O (file reads, HTTP fetches) up front.

Two independent behaviors land together in the one change, per [proposal 36](ai-planning/issues/36-proposal-104-external-ref-rewriting.md) and proposal 37 — building them jointly avoided having to design the cross-document reference machinery twice:

- **#104** — Refs into already-declared merge inputs now resolve correctly regardless of declaration order (forward or backward references between inputs), unconditionally, with no config flag.
- **#10** — Discovery and pulling-in of undeclared external files/URLs is opt-in via a new `resolveExternalReferences` config flag, since it widens the CLI's read surface transitively (documented in the README's Security section).

Closes #104, closes #10.

### Known gap (documented, not fixed)

There is no containment/allow-list mechanism yet for the read side when `resolveExternalReferences: true` is set — a relative ref can walk anywhere the process can read, analogous to the write-side risk `outputRoot` protects against. This is called out explicitly in proposal 37 §9.3 and the README. A follow-up proposal for an `inputRoot` restriction is in progress on a branch off this one.

## Test plan

- [x] `bun test` — full workspace suite passes (625 tests, 863 assertions)
- [x] Lint and typecheck clean in both packages
- [x] Manual smoke test: original #104 repro fixed with no flag needed
- [x] Manual smoke test: #10 discovery pulls in an undeclared file's component when the flag is on, and leaves the ref unresolved (normalized to an absolute path) when the flag is off — confirming the flag genuinely gates the behavior
- [x] New unit tests for the resolver (`external-references.test.ts`, 18 cases) covering forward/backward refs, renames, ambiguous identities, external pull-in, recursion, dedup, cycles, and unsupported fragment shapes
- [x] New CLI end-to-end tests (`cli-external-references.test.ts`, 9 cases) covering the #104 repro, multi-file discovery chains, file-level cycles, genuine cyclic component references, missing files, and URL discovery via a real in-process HTTP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)