### PR TITLE
feat(cli): add inputRoot, a read-side containment boundary (proposal 38)

### DIFF
--- a/ai-planning/38-proposal-input-root-containment.md
+++ b/ai-planning/38-proposal-input-root-containment.md
@@ -62,15 +62,12 @@ than inventing new vocabulary.
  * whether a declared `inputFile` or a file discovered via
  * `resolveExternalReferences` — from anywhere outside this directory.
  *
- * Declared inputs outside `inputRoot` are a config error: the merge never
- * starts, and every offending input is reported at once (the same
+ * Any local file load that would reach outside `inputRoot` is a hard
+ * error: the merge does not proceed and no output is written, whether the
+ * offending path came from a declared `inputFile` or was reached
+ * transitively by following a `$ref` out of some other document. Every
+ * violation found is reported together, not just the first (the same
  * report-everything-then-exit shape `ErrorLoadingInputs` already uses).
- * Discovered files outside `inputRoot` are treated the same way a discovery
- * load failure already is: a warning, the referencing `$ref` left
- * unresolved, the merge proceeds. The distinction matters because a
- * declared input is something the config author wrote and is responsible
- * for; a discovered file is named by a `$ref` inside a document the config
- * author may not have authored themselves.
  *
  * Applies to local files only. `inputURL` and URLs discovered via
  * `resolveExternalReferences` are a different trust boundary (network
@@ -106,28 +103,42 @@ compare" shape, unchanged.
 
 ### 2.4 Where the check runs
 
+Both call sites are hard errors, and both are resolved *before* `merge()`
+is ever invoked — the "Option 2, refined" architecture already puts all I/O
+in the CLI ahead of the synchronous merge (proposal 37), so there is no
+point after discovery has run where a violation could sneak past
+undetected.
+
 **Declared inputs — eager, before any merge work starts.** Resolve every
 `inputFile`'s full path up front (this already happens once per input) and
 check containment before `loadOasForInput` reads anything. Collect *every*
 violating input, not just the first — matching `ErrorLoadingInputs`'s
 existing "all inputs are attempted before exiting" philosophy
 (`exit-codes.ts:62-63`), so a config with three bad `inputFile` entries
-doesn't require three separate fix-and-rerun cycles. On any violation, exit
-before the merge is attempted at all.
+doesn't require three separate fix-and-rerun cycles.
 
-**Discovered files — soft, per-file, during the breadth-first walk.** Inside
-`discoverExternalDocuments`'s worklist loop (`external-reference-discovery.ts:171-194`),
-check containment immediately before `loadDocument` for a `kind: 'file'`
-reference. A violation becomes a `DiscoveryWarning` with a message that
-names the file and the configured root — reusing the exact shape
-already used for "file does not exist" and "file fails to parse" — and the
-referencing `$ref` is left unresolved, exactly as it would be for a missing
-file. This is a deliberate asymmetry from the declared-input case: one
-adversarial or careless `$ref` inside a *discovered* document — which the
-config author did not necessarily write — should not abort an otherwise
-successful merge of everything else. The security property that matters is
-that the file is never read, not that the whole run dies; both the warning
-path and the hard-fail path satisfy that.
+**Discovered files — checked per-file during the breadth-first walk, but
+still fatal.** Inside `discoverExternalDocuments`'s worklist loop
+(`external-reference-discovery.ts:171-194`), check containment immediately
+before `loadDocument` for a `kind: 'file'` reference. A violation is never
+read — that is the property that actually matters — but instead of being
+downgraded to a `DiscoveryWarning` (as a missing or unparseable file already
+is), it is collected into a distinct `containmentViolations` list alongside
+the existing `warnings`. The worklist continues draining (so every
+reachable, non-violating branch still gets a chance to surface its own
+violations or its own ordinary warnings in the same pass — one bad `$ref`
+should not hide a second one three files over), but a violating identity's
+*own* refs are never discovered, since the file was never read. Once the
+worklist is empty, if `containmentViolations` is non-empty, `main()` skips
+calling `merge()` entirely: no output is written, and every violation found
+— declared and discovered together — is reported in one pass.
+
+The result is symmetric with the declared-input case in outcome (hard
+failure, nothing written, everything found is reported at once) even though
+*where* the check runs differs (eagerly for declared inputs, which are
+known up front; interleaved with discovery for transitive references,
+which by definition are not known until something else has already been
+read).
 
 ### 2.5 New exit code
 
@@ -135,9 +146,10 @@ Append `ErrorUnsafeInputPath = 10` (do not reuse `ErrorUnsafePath` — that
 code's TSDoc is specifically about the *output* escaping its root, and CI
 scripts branching on exit codes need the two directions to stay
 distinguishable, same reasoning that kept the three `ErrorInputUrl*Status`
-codes separate from each other). Fires only for the declared-input case
-(§2.4); discovered-file violations exit `0` with a warning already printed,
-same as any other discovery failure.
+codes separate from each other). Fires for both cases in §2.4 — declared
+input outside the root, or a reference discovered from inside an input
+resolving outside the root — since from a caller's perspective both are the
+same failure: "this config would have read something outside `inputRoot`."
 
 ### 2.6 Resolution semantics
 
@@ -180,9 +192,19 @@ Following the pattern already established for `outputRoot`
   `--restrict-input-to` overriding a config `inputRoot` (mirroring the
   existing `--restrict-output-to` precedence test).
 - CLI end-to-end test: `resolveExternalReferences: true` with `inputRoot`
-  set, a discovered file outside the root — merge succeeds, a warning names
-  the file, the `$ref` is left unresolved (reusing the existing missing-file
-  test's assertion shape).
+  set, a discovered file outside the root — merge does not run, no output
+  file is written, exit code is `ErrorUnsafeInputPath`, and the error names
+  the offending file and the referencing document.
+- CLI end-to-end test: two separate containment violations in one run — one
+  declared `inputFile` outside the root and one discovered file outside the
+  root (reached via a *different*, in-bounds input) — both are named in the
+  single error report, confirming the worklist keeps draining after the
+  first violation instead of stopping short.
+- CLI end-to-end test: a discovered file outside the root sits alongside an
+  ordinary discovery failure (a genuinely missing file, reached via another
+  ref) in the same run — the missing file still produces its existing
+  non-fatal warning shape, while the containment violation still aborts the
+  merge; the two failure modes don't get conflated.
 - Regression guard: `inputRoot` unset behaves identically to today (every
   existing `cli-*.test.ts` file already exercises this by omission).
 

--- a/ai-planning/38-proposal-input-root-containment.md
+++ b/ai-planning/38-proposal-input-root-containment.md
@@ -1,0 +1,200 @@
+# Proposal 38: `inputRoot` — a read-side containment boundary for local files
+
+**Status:** Proposal (not yet implemented)
+
+**Not tied to a filed GitHub issue.** This is the follow-up Robert asked for
+directly, off the back of a gap [proposal 37](issues/37-proposal-10-external-ref-bundling.md)
+§5 and §9.3 flagged but explicitly did not build: `resolveExternalReferences`
+(issue #10, shipped in [PR #143](https://github.com/robertmassaioli/openapi-merge/pull/143))
+follows `$ref`s to files nobody named in `inputs`, with nothing bounding how
+far outside the config's own directory that following can reach. If this
+should be tracked as its own GitHub issue before merging, that's a one-line
+follow-up — flagging it here rather than assuming.
+
+## 1. The asymmetry this closes
+
+`outputRoot` ([issue #93](issues/03-proposal-93-absolute-paths.md), shipped)
+is a defence-in-depth knob on the *write* side: when set, the CLI refuses to
+write the merged output anywhere outside a configured directory, defeats
+symlink-out-of-jail tricks by re-anchoring on the realpath of the nearest
+existing ancestor, and exits with a dedicated code (`ExitCode.ErrorUnsafePath`,
+5) rather than silently writing wherever the config says.
+
+There has never been a *read*-side equivalent. Two independent code paths
+read arbitrary local files today, and both grew directly out of this
+conversation's own work:
+
+- **Declared inputs.** `loadOasForInput` (`packages/openapi-merge-cli/src/index.ts:218-232`)
+  resolves each `inputFile` against the config's directory
+  (`resolveConfigPath`) and reads it with no containment check. This has
+  been true since the CLI existed — `inputFile` was always as unrestricted
+  as `output` was before #93.
+- **Discovered files (new, issue #10).** `loadDocument`
+  (`packages/openapi-merge-cli/src/external-reference-discovery.ts:104-113`)
+  reads whatever file identity `resolveCrossDocumentIdentity` computes by
+  resolving a `$ref`'s relative path against the *referencing document's own
+  directory* — not the config's `basePath`. When `resolveExternalReferences:
+  true`, this repeats breadth-first over every newly discovered document
+  until the worklist is empty.
+
+The second path is what makes this urgent rather than theoretical. Before
+#10, the reachable file set was exactly what `inputs` listed — visible in the
+config, one line per file. With `resolveExternalReferences: true`, the
+reachable set becomes transitive: anything any input, or anything *that*
+input pulls in, cares to `$ref`. A relative path shaped like
+`../../../../../etc/passwd` inside a spec the config author did not author
+themselves (a vendor-supplied spec pulled from a registry, say) is followed
+exactly as readily as `../common/Errors.yml`. Proposal 37 §9.3 named this and
+left it open on the grounds that the flag is opt-in and the README says so —
+that is a documentation mitigation, not a technical one.
+
+## 2. Proposed design
+
+Mirror `outputRoot` as closely as the read/write asymmetry allows, rather
+than inventing new vocabulary.
+
+### 2.1 Configuration
+
+```typescript
+/**
+ * Optional defence-in-depth restriction, the read-side counterpart to
+ * `outputRoot`: when set, the CLI will refuse to read a local file —
+ * whether a declared `inputFile` or a file discovered via
+ * `resolveExternalReferences` — from anywhere outside this directory.
+ *
+ * Declared inputs outside `inputRoot` are a config error: the merge never
+ * starts, and every offending input is reported at once (the same
+ * report-everything-then-exit shape `ErrorLoadingInputs` already uses).
+ * Discovered files outside `inputRoot` are treated the same way a discovery
+ * load failure already is: a warning, the referencing `$ref` left
+ * unresolved, the merge proceeds. The distinction matters because a
+ * declared input is something the config author wrote and is responsible
+ * for; a discovered file is named by a `$ref` inside a document the config
+ * author may not have authored themselves.
+ *
+ * Applies to local files only. `inputURL` and URLs discovered via
+ * `resolveExternalReferences` are a different trust boundary (network
+ * egress, not filesystem containment) and are not affected by this option
+ * -- see §5 of proposal 38 for why that is out of scope here.
+ *
+ * Leave unset to keep the historical permissive default.
+ *
+ * @minLength 1
+ */
+inputRoot?: string;
+```
+
+### 2.2 CLI flag
+
+`--restrict-input-to <dir>`, overriding `inputRoot` from the config file,
+exactly mirroring `--restrict-output-to`'s relationship to `outputRoot`
+(`packages/openapi-merge-cli/src/index.ts:36,51`).
+
+### 2.3 The containment check itself
+
+`assertOutputContained` (`packages/openapi-merge-cli/src/path-resolution.ts:66-100`)
+is not input/output-specific in its logic — it takes a resolved path and a
+root and does a realpath-based ancestor walk. Generalise it into a shared
+`assertPathContained(resolved, root, kind, realpathSync?, exists?)` that
+both `assertOutputContained` and a new `assertInputContained` call, each
+throwing their own named error subclass (`OutputOutsideRootError` already
+exists; add `InputOutsideRootError` alongside it) so call sites keep
+distinguishable error types without duplicating the symlink-defeating walk.
+This is a refactor of existing code, not new algorithmic work — same
+"walk up to the nearest existing ancestor, realpath that, re-anchor,
+compare" shape, unchanged.
+
+### 2.4 Where the check runs
+
+**Declared inputs — eager, before any merge work starts.** Resolve every
+`inputFile`'s full path up front (this already happens once per input) and
+check containment before `loadOasForInput` reads anything. Collect *every*
+violating input, not just the first — matching `ErrorLoadingInputs`'s
+existing "all inputs are attempted before exiting" philosophy
+(`exit-codes.ts:62-63`), so a config with three bad `inputFile` entries
+doesn't require three separate fix-and-rerun cycles. On any violation, exit
+before the merge is attempted at all.
+
+**Discovered files — soft, per-file, during the breadth-first walk.** Inside
+`discoverExternalDocuments`'s worklist loop (`external-reference-discovery.ts:171-194`),
+check containment immediately before `loadDocument` for a `kind: 'file'`
+reference. A violation becomes a `DiscoveryWarning` with a message that
+names the file and the configured root — reusing the exact shape
+already used for "file does not exist" and "file fails to parse" — and the
+referencing `$ref` is left unresolved, exactly as it would be for a missing
+file. This is a deliberate asymmetry from the declared-input case: one
+adversarial or careless `$ref` inside a *discovered* document — which the
+config author did not necessarily write — should not abort an otherwise
+successful merge of everything else. The security property that matters is
+that the file is never read, not that the whole run dies; both the warning
+path and the hard-fail path satisfy that.
+
+### 2.5 New exit code
+
+Append `ErrorUnsafeInputPath = 10` (do not reuse `ErrorUnsafePath` — that
+code's TSDoc is specifically about the *output* escaping its root, and CI
+scripts branching on exit codes need the two directions to stay
+distinguishable, same reasoning that kept the three `ErrorInputUrl*Status`
+codes separate from each other). Fires only for the declared-input case
+(§2.4); discovered-file violations exit `0` with a warning already printed,
+same as any other discovery failure.
+
+### 2.6 Resolution semantics
+
+Same as `outputRoot`: `inputRoot` (or `--restrict-input-to`) is resolved via
+`resolveConfigPath(basePath, ...)` — relative values are anchored to the
+config file's directory, absolute values pass through unchanged.
+
+## 3. Non-goals
+
+- **URL containment / SSRF.** `inputURL` and discovery-following of absolute
+  URLs are untouched by this proposal. Bounding *those* is a genuinely
+  different problem — allow-listing hosts or schemes, not directory
+  containment — and deserves its own design rather than being bolted onto
+  a filesystem-shaped mechanism. Worth its own proposal if
+  `resolveExternalReferences` sees use against configs that also discover
+  URLs from untrusted content.
+- **Retroactively restricting `inputFile` by default.** `inputRoot` is
+  opt-in, like `outputRoot`. Existing configs that read from anywhere keep
+  doing so unless the user asks for the restriction.
+- **Sandboxing the YAML/JSON parse itself.** `readYamlOrJSON` already uses
+  js-yaml's `load` (not `loadAll`/unsafe constructors), so arbitrary-type
+  instantiation is out of scope for both this proposal and the problem it
+  addresses — this is purely about *which paths may be read*, not what
+  happens to their contents once read.
+
+## 4. Testing plan
+
+Following the pattern already established for `outputRoot`
+(`cli-output-safety.test.ts`) and for #10 discovery
+(`cli-external-references.test.ts`):
+
+- Unit tests for the generalised `assertPathContained` / `assertInputContained`,
+  covering the same cases `path-resolution.test.ts` already covers for
+  output: plain containment, escape via `..`, escape via an absolute path,
+  symlink-out-of-jail via a planted symlink in an existing ancestor, and a
+  root that does not yet exist.
+- CLI end-to-end test: a declared `inputFile` outside `inputRoot` exits
+  `ErrorUnsafeInputPath` and names the offending file, with a second bad
+  input in the same config also reported (not just the first).
+  `--restrict-input-to` overriding a config `inputRoot` (mirroring the
+  existing `--restrict-output-to` precedence test).
+- CLI end-to-end test: `resolveExternalReferences: true` with `inputRoot`
+  set, a discovered file outside the root — merge succeeds, a warning names
+  the file, the `$ref` is left unresolved (reusing the existing missing-file
+  test's assertion shape).
+- Regression guard: `inputRoot` unset behaves identically to today (every
+  existing `cli-*.test.ts` file already exercises this by omission).
+
+## 5. Relationship to prior work
+
+- Directly closes the gap [proposal 37 §9.3](issues/37-proposal-10-external-ref-bundling.md#93-the-containmentallow-list-gap--still-open-flagged-rather-than-fixed)
+  named and explicitly left open.
+- Reuses, rather than reinvents, the containment mechanism [issue #93](issues/03-proposal-93-absolute-paths.md)
+  built for `outputRoot` — same realpath/symlink defence, same
+  resolve-relative-to-`basePath` semantics, same optional/backward-compatible
+  posture.
+- Sits entirely in the CLI package, consistent with proposal 36 §3's
+  reasoning for why all file-path and network awareness stays out of the
+  `openapi-merge` library itself: `inputRoot` is a CLI-only concept, and
+  `merge()`'s signature does not change.

--- a/ai-planning/38-proposal-input-root-containment.md
+++ b/ai-planning/38-proposal-input-root-containment.md
@@ -1,6 +1,6 @@
 # Proposal 38: `inputRoot` — a read-side containment boundary for local files
 
-**Status:** Proposal (not yet implemented)
+**Status:** ✅ Implemented on branch `issue/input-root-containment`, at Robert's explicit direction, with the strictness of §2.4 revised before implementation began (see §6).
 
 **Not tied to a filed GitHub issue.** This is the follow-up Robert asked for
 directly, off the back of a gap [proposal 37](issues/37-proposal-10-external-ref-bundling.md)
@@ -220,3 +220,106 @@ Following the pattern already established for `outputRoot`
   reasoning for why all file-path and network awareness stays out of the
   `openapi-merge` library itself: `inputRoot` is a CLI-only concept, and
   `merge()`'s signature does not change.
+
+## 6. What was actually built
+
+### 6.1 §2.4 was revised before implementation, not after
+
+The original draft of §2.4 made discovered-file violations a soft warning
+(ref left unresolved, merge proceeds), on the theory that a `$ref` inside a
+*discovered* document is content the config author may not have written
+themselves. Before any code was written, Robert was asked directly whether
+that asymmetry was intended and said no: a containment violation should be
+fatal whichever side it comes from. §2.1, §2.4, §2.5 and the §4 testing plan
+above already reflect that decision — this section records the outcome, not
+a second change. The distinction that survives is not *hard-fail vs. warn*
+but *where the check runs*: eagerly, before any input is read, for declared
+inputs; interleaved with the breadth-first discovery walk for transitive
+references, since those identities are not known any earlier.
+
+### 6.2 The design landed exactly as specified
+
+- `assertPathContained`'s generalisation (§2.3) is real: `path-resolution.ts`
+  now has one `resolveContainment` helper, and `assertOutputContained` /
+  `assertInputContained` are both thin wrappers throwing their own error
+  type. No behavioural change to the existing `outputRoot` check — same
+  tests (`path-resolution.test.ts`'s `assertOutputContained` suite) still
+  pass unmodified.
+- `ErrorUnsafeInputPath = 10` (§2.5) is used for both the eager declared-input
+  case and the interleaved discovered-file case, exactly as specified.
+- The worklist-keeps-draining behaviour (§2.4) works as designed: two
+  declared inputs, each pulling in a different out-of-root file via
+  `resolveExternalReferences`, produce one exit with both files named on
+  stderr, not two separate runs' worth of trial and error.
+
+### 6.3 One thing the proposal did not fully anticipate: declared-input checks are all-or-nothing before discovery even starts
+
+§2.4's "both are reported in one pass" language is only exactly true within
+each of the two categories (declared vs. discovered), not *across* them.
+`convertInputs` loads every declared input concurrently via `Promise.all`
+and only proceeds to cross-document discovery once *all* of them succeed —
+that was already the existing behaviour for ordinary load failures
+(`ErrorLoadingInputs`), before this proposal touched anything. A declared
+`inputFile` outside `inputRoot` therefore short-circuits before discovery
+ever runs, so a containment violation on a declared input and a containment
+violation on a file that same run *would have* discovered cannot both
+appear in one error report — the discovered-file violation is simply never
+reached. This is not a gap in the security property (nothing outside
+`inputRoot` is ever read either way), just a correction to an implicit claim
+in §2.4's phrasing. The §4 testing plan's "two separate containment
+violations in one run" test was adjusted accordingly, to combine two
+discovered-file violations reached via two different (individually valid)
+declared inputs, which does hit the "both reported together" path.
+
+### 6.4 Two gaps found in review, fixed before landing
+
+An advisor review of the first implementation pass caught two real defects,
+both fixed before this branch was considered done:
+
+- **The leaf itself wasn't realpath'd.** §2.3's shared `resolveContainment`
+  walks up to the nearest *existing ancestor* and realpaths that -- correct
+  for `outputRoot`, where the output file usually doesn't exist yet, so only
+  a symlinked ancestor *directory* is a real risk. For `inputRoot` the leaf
+  is the thing being read and normally already exists, so a symlink planted
+  as the file itself (`inputRoot/evil.yml -> /etc/passwd`) sailed through
+  the original check untouched. The existing symlink unit test only covered
+  a symlinked *directory* (copied case-for-case from the `outputRoot` suite),
+  which is exactly why the leaf gap didn't show up sooner. Fixed in
+  `assertInputContained` only (not the shared helper, and not
+  `assertOutputContained`): when the resolved input exists, it is realpathed
+  before being handed to `resolveContainment`, which then walks an
+  already-canonical path -- a no-op for it, but closes the gap. Covered by a
+  new real-filesystem test (a stub can't demonstrate this; it would just
+  assert the mock was written correctly).
+- **A fatal containment violation silently swallowed ordinary discovery
+  warnings from the same run.** In `main()`, the `containmentViolations`
+  check and `process.exit` originally sat *above* the `discovery.warnings`
+  reporting loop, so a run with both a missing discovered file and an
+  out-of-root one only ever showed the containment error -- exactly the
+  fix-and-rerun cycle the "report everything, then exit" philosophy (§2.1,
+  §2.4) exists to avoid, and a direct contradiction of the corresponding §4
+  test's own name. The test passed anyway because it never asserted the
+  warning was present. Fixed by moving the warnings loop above the
+  containment check, and the test now asserts both the stdout warning and
+  the stderr violation are present in the same run.
+
+### 6.5 Verification
+
+- `bun test`: 646 tests pass (up from 625 before this proposal), including
+  5 new declared-input containment tests (`cli-input-safety.test.ts`), 5 new
+  discovered-file containment tests (added to `cli-external-references.test.ts`),
+  1 new `inputRoot`-does-not-affect-`inputURL` test (added to
+  `cli-remote-inputs.test.ts`), and 9 new unit tests for `assertInputContained`
+  (added to `path-resolution.test.ts`, mirroring the existing
+  `assertOutputContained` suite case-for-case, plus the real-filesystem
+  leaf-symlink test from §6.4).
+- Lint and typecheck clean in both packages.
+- Coverage: `path-resolution.ts` and `index.ts` both 100% functions/lines;
+  `external-reference-discovery.ts` 100% functions / 97.98% lines, the one
+  uncovered line (a URL-fetch-non-ok-status branch in `loadDocument`)
+  pre-dating this proposal and unrelated to it.
+- Manual end-to-end smoke tests against the real CLI binary (not the test
+  harness) confirmed: a discovered file outside `inputRoot` exits `10` with
+  no output written; widening `inputRoot` to cover it succeeds; a declared
+  `inputFile` outside `inputRoot` exits `10` before the merge starts, also
+  with no output written.

--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -64,6 +64,7 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`29-proposal-node-runtime-verification.md`](29-proposal-node-runtime-verification.md) | ✅ Building with Bun while proving the artifacts run on Node |
 | [`30-proposal-bundle-the-cli.md`](30-proposal-bundle-the-cli.md) | ✅ Bundling the CLI so it runs under both Node and Bun; reduces 29 |
 | [`33-proposal-cli-init-command.md`](33-proposal-cli-init-command.md) | ✅ An `init` command that writes a starter configuration, scanning for inputs |
+| [`38-proposal-input-root-containment.md`](38-proposal-input-root-containment.md) | `inputRoot` — a read-side containment boundary mirroring `outputRoot`, closing the gap proposal 37 left open |
 | [`issue-triage-value-vs-effort.md`](issue-triage-value-vs-effort.md) | Value/effort scoring of every open issue; the index into `issues/` |
 | [`spec-edge-case-findings.md`](spec-edge-case-findings.md) | Divergences between the merge and the spec, found by edge-case testing |
 | [`bun-tsgo-migration-build-timings.md`](bun-tsgo-migration-build-timings.md) | Measured build timings for the Bun + tsgo migration |

--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -64,7 +64,7 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`29-proposal-node-runtime-verification.md`](29-proposal-node-runtime-verification.md) | ✅ Building with Bun while proving the artifacts run on Node |
 | [`30-proposal-bundle-the-cli.md`](30-proposal-bundle-the-cli.md) | ✅ Bundling the CLI so it runs under both Node and Bun; reduces 29 |
 | [`33-proposal-cli-init-command.md`](33-proposal-cli-init-command.md) | ✅ An `init` command that writes a starter configuration, scanning for inputs |
-| [`38-proposal-input-root-containment.md`](38-proposal-input-root-containment.md) | `inputRoot` — a read-side containment boundary mirroring `outputRoot`, closing the gap proposal 37 left open |
+| [`38-proposal-input-root-containment.md`](38-proposal-input-root-containment.md) | ✅ `inputRoot` — a read-side containment boundary mirroring `outputRoot`, closing the gap proposal 37 left open |
 | [`issue-triage-value-vs-effort.md`](issue-triage-value-vs-effort.md) | Value/effort scoring of every open issue; the index into `issues/` |
 | [`spec-edge-case-findings.md`](spec-edge-case-findings.md) | Divergences between the merge and the spec, found by edge-case testing |
 | [`bun-tsgo-migration-build-timings.md`](bun-tsgo-migration-build-timings.md) | Measured build timings for the Bun + tsgo migration |

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -230,7 +230,7 @@ in your `openapi-merge.json` (or via `--config`). The tool assumes that this
 configuration file is **trusted**, the same way you trust a `Makefile`,
 `package.json`, or `webpack.config.js` in your repository. Do not run the CLI
 against a configuration file from an untrusted source without restricting the
-output location.
+input and output locations.
 
 `resolveExternalReferences` widens what gets *read*, not just written: with
 it on, the files and URLs the CLI loads are no longer limited to what
@@ -254,6 +254,34 @@ are defeated by realpath-ing the closest existing ancestor of the output.
 When unset, the CLI keeps its historical permissive default and writes
 wherever you tell it to.
 
+You can restrict where the CLI will *read* local files from the same way --
+the read-side counterpart, and the one that matters most once
+`resolveExternalReferences` is on, since that setting is what makes the
+reachable file set transitive rather than confined to what `inputs` lists:
+
+* Add `"inputRoot": "/path/to/safe/dir"` to your `openapi-merge.json`, **or**
+* Pass `--restrict-input-to /path/to/safe/dir` on the command line (the flag
+  takes precedence over the config field).
+
+When set, any local file the CLI would read -- a declared `inputFile` or a
+file `resolveExternalReferences` discovers -- that does not lie under the
+configured root is refused, and the CLI exits with code `10`
+(`ExitCode.ErrorUnsafeInputPath`). The offending file is never opened: the
+check runs before the read is attempted, using the same realpath-based
+containment check as `outputRoot`, extended to also realpath the file itself
+(not just its parent directory) before comparing -- an input, unlike an
+output, normally already exists, so a symlink planted as the file itself,
+not just an ancestor directory, has to be defeated too. A declared
+`inputFile` outside the root is reported before the merge starts at all; a
+discovered file outside the root
+aborts the merge the same way, rather than being left as an unresolved `$ref`
+the way an ordinary missing or unparseable discovered file is. `inputURL` and
+URLs discovered via `resolveExternalReferences` are unaffected -- `inputRoot`
+bounds the filesystem, not the network.
+
+When unset, the CLI keeps its historical permissive default and reads
+whatever the inputs point to.
+
 ## Exit codes
 
 The CLI's exit codes are part of its contract; scripts and CI pipelines can
@@ -271,6 +299,7 @@ branch on them.
 | `7` | An `inputURL` responded with a **5xx** status |
 | `8` | An `inputURL` responded with some other non-2xx status |
 | `9` | An input declared an unsupported OpenAPI version, or the inputs disagreed |
+| `10` | A local file read escaped `inputRoot` / `--restrict-input-to` |
 
 Codes `6`–`8` are separate from `2` on purpose. `2` means an input could not be
 obtained at all — a missing file, an unreachable host, content that parses as

--- a/packages/openapi-merge-cli/src/__tests__/cli-external-references.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-external-references.test.ts
@@ -268,6 +268,166 @@ describe('#10 -- discovering files nobody declared as an input (resolveExternalR
   });
 });
 
+describe('inputRoot -- containing discovered files (proposal 38)', () => {
+  it('aborts the merge when a discovered file resolves outside inputRoot', async () => {
+    // '../common/ServerError.yml' escapes 'specs/a', the directory inputRoot
+    // is set to -- discovery must never read it.
+    cli.write('specs/common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "../common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a/Api.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+      inputRoot: './specs/a',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafeInputPath);
+    expect(cli.exists('bundle.json')).toBe(false);
+    const stderr = cli.stderr().join('\n');
+    expect(stderr).toContain('ServerError.yml');
+    expect(stderr).toContain('inputRoot');
+  });
+
+  it('succeeds when the discovered file stays inside inputRoot', async () => {
+    cli.write('specs/a/common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "./common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a/Api.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+      inputRoot: './specs/a',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    const output = JSON.parse(cli.read('bundle.json'));
+    expect(output.components.schemas.ServerError).toEqual({ type: 'object' });
+  });
+
+  it('reports every discovered-file violation in a run, not just the first', async () => {
+    // Both declared inputs load fine (containment for those is checked
+    // eagerly, before discovery ever starts), but each pulls in a different
+    // out-of-root file -- the worklist must keep draining past the first
+    // violation so both surface together.
+    cli.write('specs/common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('specs/common/NotFound.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    NotFound:\n      type: object\n');
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "../common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    cli.write('specs/a/Api2.yml', [
+      'openapi: "3.0.0"',
+      'components:',
+      '  schemas:',
+      '    Gadget:',
+      '      $ref: "../common/NotFound.yml#/components/schemas/NotFound"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a/Api.yml' }, { inputFile: './specs/a/Api2.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+      inputRoot: './specs/a',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafeInputPath);
+    const stderr = cli.stderr().join('\n');
+    expect(stderr).toContain('ServerError.yml');
+    expect(stderr).toContain('NotFound.yml');
+  });
+
+  it('keeps an ordinary discovery warning and a containment violation distinct in the same run', async () => {
+    // A missing file, reached via one ref, and an out-of-root file, reached
+    // via another -- the two failure modes must not get conflated: a
+    // containment violation is fatal, a missing file is not.
+    cli.write('specs/common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('specs/a/Api.yml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "./does-not-exist.yml#/components/schemas/ServerError"',
+      '    Gadget:',
+      '      $ref: "../common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './specs/a/Api.yml' }],
+      output: './bundle.json',
+      resolveExternalReferences: true,
+      inputRoot: './specs/a',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafeInputPath);
+    expect(cli.exists('bundle.json')).toBe(false);
+    // The missing-file warning must still be reported, not hidden behind the
+    // fatal containment violation -- otherwise fixing inputRoot and re-running
+    // would be the only way to learn about it.
+    expect(cli.stdout().join('\n')).toContain('does-not-exist.yml');
+    expect(cli.stderr().join('\n')).toContain('ServerError.yml');
+  });
+
+  it('does not restrict a discovered URL, only discovered local files', async () => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/errors.yaml') {
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end('openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+      } else {
+        res.writeHead(404);
+        res.end('not found');
+      }
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : 0;
+
+      cli.write('specs/a/Api.yml', [
+        'openapi: "3.0.0"',
+        'info: { title: A, version: "1.0" }',
+        'components:',
+        '  schemas:',
+        '    Widget:',
+        `      $ref: "http://127.0.0.1:${port}/errors.yaml#/components/schemas/ServerError"`,
+        '',
+      ].join('\n'));
+      const config = cli.writeJson('openapi-merge.json', {
+        inputs: [{ inputFile: './specs/a/Api.yml' }],
+        output: './bundle.json',
+        resolveExternalReferences: true,
+        inputRoot: './specs/a',
+      });
+
+      expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+      const output = JSON.parse(cli.read('bundle.json'));
+      expect(output.components.schemas.ServerError).toEqual({ type: 'object' });
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+});
+
 describe('resolveExternalReferences schema validation', () => {
   it('rejects a non-boolean value', async () => {
     cli.write('a.json', JSON.stringify({ openapi: '3.0.3', info: { title: 'T', version: '1' }, paths: {} }));

--- a/packages/openapi-merge-cli/src/__tests__/cli-input-safety.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-input-safety.test.ts
@@ -1,0 +1,83 @@
+import path from 'path';
+import fs from 'fs';
+import { ExitCode } from '../index';
+import { getPath, installCliHarness, oas } from './_helpers/cli-harness';
+
+/**
+ * Restricting where the CLI is allowed to read local files from (proposal
+ * 38, the read-side counterpart to `cli-output-safety.test.ts`).
+ *
+ * `inputRoot` in the config and `--restrict-input-to` on the command line
+ * both confine declared `inputFile`s; the flag wins. Discovered-file
+ * containment (`resolveExternalReferences`) is covered separately in
+ * `cli-external-references.test.ts`, since it needs the discovery machinery
+ * set up.
+ */
+
+const cli = installCliHarness();
+
+describe('main - input path safety', () => {
+  it('exits ErrorUnsafeInputPath when a declared inputFile escapes inputRoot', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    fs.mkdirSync(path.join(cli.dir(), 'allowed'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: '../a.json' }],
+      output: './allowed/output.json',
+      inputRoot: './allowed',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafeInputPath);
+    expect(cli.exists('allowed/output.json')).toBe(false);
+  });
+
+  it('succeeds when the declared input stays inside inputRoot', async () => {
+    fs.mkdirSync(path.join(cli.dir(), 'allowed'));
+    cli.writeJson('allowed/a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './allowed/a.json' }],
+      output: './output.json',
+      inputRoot: './allowed',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(cli.exists('output.json')).toBe(true);
+  });
+
+  it('reports every offending declared input, not just the first', async () => {
+    fs.mkdirSync(path.join(cli.dir(), 'allowed'));
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    cli.writeJson('b.json', oas({ '/b': getPath('getB') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: '../a.json' }, { inputFile: '../b.json' }],
+      output: './allowed/output.json',
+      inputRoot: './allowed',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafeInputPath);
+    const stderr = cli.stderr().join('\n');
+    expect(stderr).toContain('a.json');
+    expect(stderr).toContain('b.json');
+  });
+
+  it('lets --restrict-input-to reject an input the config would have allowed', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    fs.mkdirSync(path.join(cli.dir(), 'allowed'));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './allowed/output.json',
+    });
+
+    expect(await cli.run('-c', config, '--restrict-input-to', './allowed')).toBe(ExitCode.ErrorUnsafeInputPath);
+  });
+
+  it('lets --restrict-input-to allow an input inside the named directory', async () => {
+    fs.mkdirSync(path.join(cli.dir(), 'allowed'));
+    cli.writeJson('allowed/a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './allowed/a.json' }],
+      output: './output.json',
+    });
+
+    expect(await cli.run('-c', config, '--restrict-input-to', './allowed')).toBe(ExitCode.Success);
+  });
+});

--- a/packages/openapi-merge-cli/src/__tests__/cli-remote-inputs.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-remote-inputs.test.ts
@@ -168,6 +168,19 @@ describe('main - inputURL', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorLoadingInputs);
   });
 
+  it('is unaffected by inputRoot, which bounds local files only (proposal 38)', async () => {
+    // A narrow inputRoot that would reject every local file still lets an
+    // inputURL through -- inputRoot is a filesystem-containment mechanism,
+    // not a network allow-list.
+    const config = cli.writeJson('sub/openapi-merge.json', {
+      inputs: [{ inputURL: `${baseUrl}/spec.json` }],
+      output: '../output.json',
+      inputRoot: '.',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+  });
+
   it('reports the first failing input when inputs fail for different reasons', async () => {
     // Input 0 is a missing file (ErrorLoadingInputs), input 1 is a 404
     // (ErrorInputUrlStatus). The first failure decides the exit code.

--- a/packages/openapi-merge-cli/src/__tests__/exit-codes.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/exit-codes.test.ts
@@ -19,6 +19,7 @@ const documented: { [member: string]: number } = {
   ErrorInputUrlServerStatus: 7,
   ErrorInputUrlUnexpectedStatus: 8,
   ErrorOpenApiVersion: 9,
+  ErrorUnsafeInputPath: 10,
 };
 
 describe('ExitCode contract', () => {

--- a/packages/openapi-merge-cli/src/__tests__/path-resolution.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/path-resolution.test.ts
@@ -2,7 +2,9 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 import {
+  assertInputContained,
   assertOutputContained,
+  InputOutsideRootError,
   OutputOutsideRootError,
   resolveConfigPath,
 } from '../path-resolution';
@@ -117,6 +119,110 @@ describe('assertOutputContained', () => {
       expect((e as OutputOutsideRootError).message).toContain(path.resolve('/root'));
       expect((e as OutputOutsideRootError).resolved).toBe(path.resolve('/etc/passwd'));
       expect((e as OutputOutsideRootError).root).toBe(path.resolve('/root'));
+    }
+  });
+});
+
+describe('assertInputContained', () => {
+  it('is a no-op when inputRoot is undefined', () => {
+    const input = path.resolve('/anywhere/at/all.json');
+    expect(assertInputContained(input, undefined)).toBe(input);
+  });
+
+  it('accepts an input exactly at the root', () => {
+    const root = path.resolve('/root');
+    const input = path.resolve('/root');
+    const realpath = (p: string): string => p;
+    const exists = (): boolean => true;
+    expect(assertInputContained(input, root, realpath, exists)).toBe(input);
+  });
+
+  it('accepts an input beneath the root', () => {
+    const root = path.resolve('/root');
+    const input = path.resolve('/root/sub/dir/file.json');
+    const realpath = (p: string): string => p;
+    const exists = (): boolean => true;
+    expect(assertInputContained(input, root, realpath, exists)).toBe(input);
+  });
+
+  it('rejects an input above the root with InputOutsideRootError', () => {
+    const root = path.resolve('/root/inner');
+    const input = path.resolve('/root/escape.json');
+    const realpath = (p: string): string => p;
+    const exists = (): boolean => true;
+    expect(() => assertInputContained(input, root, realpath, exists))
+      .toThrow(InputOutsideRootError);
+  });
+
+  it('rejects an input on a completely different branch', () => {
+    const root = path.resolve('/root');
+    const input = path.resolve('/etc/passwd');
+    const realpath = (p: string): string => p;
+    const exists = (): boolean => true;
+    expect(() => assertInputContained(input, root, realpath, exists))
+      .toThrow(InputOutsideRootError);
+  });
+
+  it('defeats a symlink-out-of-jail by realpath-ing the existing ancestor', () => {
+    const root = path.resolve('/safe');
+    const input = path.resolve('/safe/link/file.json');
+
+    // Stubbed realpath: `/safe/link` is a symlink to `/elsewhere`.
+    const realpath = (p: string): string => {
+      if (p === path.resolve('/safe/link')) return path.resolve('/elsewhere');
+      return p;
+    };
+    const exists = (): boolean => true;
+
+    expect(() => assertInputContained(input, root, realpath, exists))
+      .toThrow(InputOutsideRootError);
+  });
+
+  it('defeats a symlink planted as the leaf itself, not just a symlinked ancestor directory', () => {
+    // The read/write asymmetry that matters here: an output usually doesn't
+    // exist yet, so only its parent chain can carry a planted symlink. An
+    // input is the thing being read and normally *does* exist, so the leaf
+    // itself has to be checked too -- real filesystem, since a stub would
+    // just assert the mock was written correctly rather than the behaviour.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openapi-merge-38-leaf-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openapi-merge-38-outside-'));
+    try {
+      const outsideFile = path.join(outsideDir, 'secret.yml');
+      fs.writeFileSync(outsideFile, 'openapi: "3.0.0"\n');
+      const link = path.join(root, 'link.yml');
+      fs.symlinkSync(outsideFile, link);
+
+      expect(() => assertInputContained(link, root)).toThrow(InputOutsideRootError);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('walks up to the closest existing ancestor when the input does not exist yet', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openapi-merge-38-'));
+    try {
+      const input = path.join(tmpRoot, 'not', 'yet', 'created', 'file.json');
+      expect(assertInputContained(input, tmpRoot)).toBe(input);
+    } finally {
+      fs.rmdirSync(tmpRoot);
+    }
+  });
+
+  it('includes both paths in the thrown error message', () => {
+    const root = path.resolve('/root');
+    const input = path.resolve('/etc/passwd');
+    const realpath = (p: string): string => p;
+    const exists = (): boolean => true;
+    try {
+      assertInputContained(input, root, realpath, exists);
+      throw new Error('expected InputOutsideRootError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(InputOutsideRootError);
+      expect((e as InputOutsideRootError).message).toContain(path.resolve('/etc/passwd'));
+      expect((e as InputOutsideRootError).message).toContain(path.resolve('/root'));
+      expect((e as InputOutsideRootError).resolved).toBe(path.resolve('/etc/passwd'));
+      expect((e as InputOutsideRootError).root).toBe(path.resolve('/root'));
     }
   });
 });

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -275,6 +275,32 @@ export type Configuration = {
   outputRoot?: string;
 
   /**
+   * Optional defence-in-depth restriction, the read-side counterpart to
+   * `outputRoot` (proposal 38): when set, the CLI will refuse to read a
+   * local file -- whether a declared `inputFile` or a file discovered via
+   * `resolveExternalReferences` -- from anywhere outside this directory.
+   *
+   * Any local file load that would reach outside `inputRoot` is a hard
+   * error: the merge does not proceed and no output is written, whether the
+   * offending path came from a declared `inputFile` or was reached
+   * transitively by following a `$ref` out of some other document. Every
+   * violation found is reported together, not just the first. The check
+   * compares the realpath of the resolved input's nearest existing ancestor
+   * against the realpath of this root, so symlinks cannot be used to escape.
+   *
+   * Applies to local files only. `inputURL` and URLs discovered via
+   * `resolveExternalReferences` are a different trust boundary (network
+   * egress, not filesystem containment) and are not affected by this option.
+   *
+   * Leave unset to keep the historical permissive default; this option is
+   * intended for embedded / multi-tenant uses of the CLI, or for configs
+   * whose `resolveExternalReferences` inputs are not fully trusted.
+   *
+   * @minLength 1
+   */
+  inputRoot?: string;
+
+  /**
    * Optional output-formatting controls (issue #114). When omitted, the
    * output is formatted with 2 spaces of indentation (the historical
    * default).

--- a/packages/openapi-merge-cli/src/exit-codes.ts
+++ b/packages/openapi-merge-cli/src/exit-codes.ts
@@ -21,6 +21,7 @@
  * | 7         | ExitCode.ErrorInputUrlServerStatus     | An `inputURL` returned 5xx               |
  * | 8         | ExitCode.ErrorInputUrlUnexpectedStatus | `inputURL` non-2xx, neither 4xx nor 5xx  |
  * | 9         | ExitCode.ErrorOpenApiVersion           | Input version unsupported or inconsistent |
+ * | 10        | ExitCode.ErrorUnsafeInputPath          | A local file read escaped `inputRoot`    |
  */
 export enum ExitCode {
   /**
@@ -168,4 +169,26 @@ export enum ExitCode {
    * 0. A loud failure here is the entire point.
    */
   ErrorOpenApiVersion = 9,
+
+  /**
+   * A local file the CLI would read lies outside the configured `inputRoot`.
+   *
+   * Fires when `inputRoot` (config) or `--restrict-input-to` (flag, which
+   * takes precedence) is set and either a declared `inputFile` or a file
+   * discovered via `resolveExternalReferences` resolves to somewhere outside
+   * it. The read-side counterpart to {@link ExitCode.ErrorUnsafePath}: kept
+   * as its own code rather than reused, since a script branching on exit
+   * codes needs "output escaped its root" and "input escaped its root" to
+   * stay distinguishable.
+   *
+   * Every violation found -- declared and discovered alike -- is reported
+   * together before exiting, matching {@link ExitCode.ErrorLoadingInputs}'s
+   * report-everything-then-exit shape. The offending file is never read: the
+   * check runs before the attempt, not after a failed one.
+   *
+   * Same realpath-based symlink defence as `ErrorUnsafePath`: the check
+   * re-anchors on the realpath of the closest existing ancestor before
+   * comparing, so a symlink pointing out of the jail does not defeat it.
+   */
+  ErrorUnsafeInputPath = 10,
 }

--- a/packages/openapi-merge-cli/src/external-reference-discovery.ts
+++ b/packages/openapi-merge-cli/src/external-reference-discovery.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { OpenApiDocument } from 'openapi-merge/dist/oas31';
 import { walkAllReferences } from 'openapi-merge/dist/reference-walker';
 import { readFileAsString, readYamlOrJSON } from './file-loading';
-import { resolveConfigPath } from './path-resolution';
+import { assertInputContained, InputOutsideRootError, resolveConfigPath } from './path-resolution';
 
 /**
  * Discovering and loading `$ref`-only documents (issue #10) -- files or URLs
@@ -117,9 +117,16 @@ export type DiscoveryWarning = {
   message: string;
 };
 
+/** A discovered local file that would have been read from outside `inputRoot` (proposal 38). Never read. */
+export type ContainmentViolation = {
+  reference: DocumentReference;
+  message: string;
+};
+
 export type DiscoveryResult = {
   externalDocuments: Record<string, OpenApiDocument>;
   warnings: DiscoveryWarning[];
+  containmentViolations: ContainmentViolation[];
 };
 
 /**
@@ -146,14 +153,26 @@ export function urlInputIdentity(inputURL: string): DocumentReference {
  * `externalDocuments` -- any `$ref` naming it is then simply unresolved by
  * the library, exactly as a `$ref` to a declared input that does not exist
  * would be.
+ *
+ * `inputRoot`, when set, bounds every discovered *file* identity (proposal
+ * 38): before a discovered file is loaded, it must resolve inside
+ * `inputRoot` or it is never read at all, only recorded as a
+ * `ContainmentViolation`. Unlike an ordinary load failure this is not a
+ * warning -- the worklist keeps draining so every reachable violation (and
+ * every ordinary warning) in the same run still surfaces, but the caller is
+ * expected to treat any non-empty `containmentViolations` as fatal and skip
+ * the merge entirely. URL identities are untouched: `inputRoot` is a
+ * filesystem-containment mechanism, not a network allow-list.
  */
 export async function discoverExternalDocuments(
   declaredInputs: ReadonlyArray<{ document: OpenApiDocument; reference: DocumentReference }>,
   enableDiscovery: boolean,
+  inputRoot?: string,
 ): Promise<DiscoveryResult> {
   const known = new Set(declaredInputs.map(input => input.reference.identity));
   const externalDocuments: Record<string, OpenApiDocument> = {};
   const warnings: DiscoveryWarning[] = [];
+  const containmentViolations: ContainmentViolation[] = [];
 
   const worklist: DocumentReference[] = [];
   for (const input of declaredInputs) {
@@ -177,6 +196,21 @@ export async function discoverExternalDocuments(
       break;
     }
 
+    if (next.kind === 'file' && inputRoot !== undefined) {
+      try {
+        assertInputContained(next.identity, inputRoot);
+      } catch (e) {
+        if (e instanceof InputOutsideRootError) {
+          // Never read: the file's own refs are therefore never discovered
+          // either, but the rest of the worklist keeps going so every
+          // violation reachable via an in-bounds path still surfaces.
+          containmentViolations.push({ reference: next, message: e.message });
+          continue;
+        }
+        throw e;
+      }
+    }
+
     try {
       const document = await loadDocument(next);
       externalDocuments[next.identity] = document;
@@ -193,5 +227,5 @@ export async function discoverExternalDocuments(
     }
   }
 
-  return { externalDocuments, warnings };
+  return { externalDocuments, warnings, containmentViolations };
 }

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -17,7 +17,7 @@ import { Swagger } from "@atlassian/atlassian-openapi";
 import { dump as dumpYaml } from 'js-yaml';
 import { readFileAsString, readYamlOrJSON } from "./file-loading";
 import { ExitCode } from "./exit-codes";
-import { assertOutputContained, OutputOutsideRootError, resolveConfigPath } from "./path-resolution";
+import { assertInputContained, assertOutputContained, InputOutsideRootError, OutputOutsideRootError, resolveConfigPath } from "./path-resolution";
 import { discoverExternalDocuments, DocumentReference, fileInputIdentity, urlInputIdentity } from "./external-reference-discovery";
 import { indentToJsonStringifyArg, indentToYamlArg } from "./formatting";
 import { DEFAULT_INDENT, Indent } from "./data";
@@ -34,6 +34,7 @@ export { ExitCode } from "./exit-codes";
 type CliOptions = {
   config?: string;
   restrictOutputTo?: string;
+  restrictInputTo?: string;
 };
 
 // Built per invocation rather than once at module scope. A Command retains the
@@ -48,7 +49,8 @@ function buildProgram(): Command {
 
   program
     .option('-c, --config <config_file>', 'The path to the configuration file for the merge tool.')
-    .option('--restrict-output-to <dir>', 'Refuse to write output anywhere outside this directory (overrides outputRoot in the config).');
+    .option('--restrict-output-to <dir>', 'Refuse to write output anywhere outside this directory (overrides outputRoot in the config).')
+    .option('--restrict-input-to <dir>', 'Refuse to read any local input file from outside this directory (overrides inputRoot in the config).');
 
   // `init` is deliberately NOT registered with `.command()`.
   //
@@ -215,9 +217,10 @@ function exitCodeForMergeError(type: ErrorMergeResult['type']): ExitCode {
   }
 }
 
-async function loadOasForInput(basePath: string, input: ConfigurationInput, inputIndex: number, logger: LogWithMillisDiff): Promise<Swagger.SwaggerV3> {
+async function loadOasForInput(basePath: string, input: ConfigurationInput, inputIndex: number, logger: LogWithMillisDiff, inputRoot: string | undefined): Promise<Swagger.SwaggerV3> {
   if (isConfigurationInputFromFile(input)) {
     const fullPath = resolveConfigPath(basePath, input.inputFile);
+    assertInputContained(fullPath, inputRoot);
     logger.log(`## Loading input ${inputIndex}: ${fullPath}`);
     return (await readYamlOrJSON(await readFileAsString(fullPath))) as Swagger.SwaggerV3;
   } else {
@@ -262,10 +265,10 @@ type ConvertedInputs = {
   references: DocumentReference[];
 };
 
-async function convertInputs(basePath: string, configInputs: ConfigurationInput[], logger: LogWithMillisDiff): Promise<ConvertedInputs | InputConversionErrors> {
+async function convertInputs(basePath: string, configInputs: ConfigurationInput[], logger: LogWithMillisDiff, inputRoot: string | undefined): Promise<ConvertedInputs | InputConversionErrors> {
   const results = await Promise.all(configInputs.map<Promise<SingleMergeInput | InputConversionError>>(async (input, inputIndex) => {
     try {
-      const oas = await loadOasForInput(basePath, input, inputIndex, logger);
+      const oas = await loadOasForInput(basePath, input, inputIndex, logger, inputRoot);
 
       const output: SingleMergeInput = {
         oas,
@@ -291,6 +294,12 @@ async function convertInputs(basePath: string, configInputs: ConfigurationInput[
 
       return output;
     } catch (e) {
+      if (e instanceof InputOutsideRootError) {
+        return {
+          message: `Input ${inputIndex}: ${e.message}`,
+          exitCode: ExitCode.ErrorUnsafeInputPath,
+        };
+      }
       return {
         message: `Input ${inputIndex}: could not load configuration file. ${e}`,
         exitCode: e instanceof InputUrlStatusError
@@ -363,7 +372,14 @@ export async function main(): Promise<void> {
 
   const basePath = path.dirname(options.config || './');
 
-  const converted = await convertInputs(basePath, config.inputs, logger);
+  // The CLI flag overrides whatever is in the config file. Both are resolved
+  // against the config's directory so that relative `inputRoot` values mean
+  // what a config author would expect. Computed before any input is read, so
+  // it can bound the very first file load (proposal 38).
+  const inputRootRaw: string | undefined = options.restrictInputTo || config.inputRoot;
+  const inputRoot = inputRootRaw === undefined ? undefined : resolveConfigPath(basePath, inputRootRaw);
+
+  const converted = await convertInputs(basePath, config.inputs, logger, inputRoot);
 
   if ('errors' in converted) {
     converted.errors.forEach(error => console.error(error));
@@ -378,15 +394,29 @@ export async function main(): Promise<void> {
   // input runs unconditionally -- that fix is always safe, since it only
   // ever affects a `$ref` that would otherwise be silently broken.
   // `resolveExternalReferences` controls only whether a `$ref` naming a file
-  // or URL nobody declared as an input gets followed and loaded.
+  // or URL nobody declared as an input gets followed and loaded. `inputRoot`
+  // bounds where a discovered *file* may come from (proposal 38); a
+  // discovered URL is untouched by it.
   const discovery = await discoverExternalDocuments(
     inputs.map((input, i) => ({ document: input.oas, reference: references[i] })),
     config.resolveExternalReferences === true,
+    inputRoot,
   );
 
+  // Reported before the containment check below exits, so an ordinary
+  // discovery failure elsewhere in the same run is not hidden behind a
+  // containment violation -- both are worth knowing about in one pass.
   discovery.warnings.forEach(warning => {
     logger.log(`## WARNING: could not load '${warning.reference.identity}', referenced via $ref -- left unresolved. (${warning.message})`);
   });
+
+  if (discovery.containmentViolations.length > 0) {
+    discovery.containmentViolations.forEach(violation => {
+      console.error(`${violation.message} (referenced via $ref, not a declared input)`);
+    });
+    process.exit(ExitCode.ErrorUnsafeInputPath);
+    return;
+  }
 
   logger.log(`## Loaded the inputs into memory, merging the results.`);
 

--- a/packages/openapi-merge-cli/src/path-resolution.ts
+++ b/packages/openapi-merge-cli/src/path-resolution.ts
@@ -46,6 +46,68 @@ export class OutputOutsideRootError extends Error {
 }
 
 /**
+ * Error thrown when the (defence-in-depth) `inputRoot` safety knob is set
+ * (proposal 38) and a local file the CLI would read -- a declared
+ * `inputFile` or one discovered via `resolveExternalReferences` -- escapes
+ * that root.
+ *
+ * Carries the `resolved` and `root` paths separately, mirroring
+ * {@link OutputOutsideRootError}, so callers can render a helpful
+ * diagnostic without having to parse `.message`.
+ */
+export class InputOutsideRootError extends Error {
+  public readonly resolved: string;
+
+  public readonly root: string;
+
+  constructor(resolved: string, root: string) {
+    super(
+      `Refusing to read input from '${resolved}': it is outside the configured inputRoot '${root}'. ` +
+      `Remove the 'inputRoot' option or move the input inside it.`
+    );
+    this.name = 'InputOutsideRootError';
+    this.resolved = resolved;
+    this.root = root;
+  }
+}
+
+/**
+ * The realpath-based containment algorithm shared by {@link assertOutputContained}
+ * and {@link assertInputContained} (proposal 38 §2.3): given a resolved path
+ * and a root, determine whether the path lies inside the root, defeating
+ * symlink-out-of-jail tricks by re-anchoring on the realpath of the nearest
+ * *existing* ancestor rather than trusting the lexical path.
+ *
+ * Neither the path nor the root need exist yet -- the walk climbs to
+ * whatever part of the chain does exist before calling `realpathSync`, since
+ * that is the only part an attacker could have planted a symlink in.
+ */
+function resolveContainment(
+  resolvedPath: string,
+  root: string,
+  realpathSync: (p: string) => string,
+  exists: (p: string) => boolean
+): { realResolved: string; realRoot: string; escapes: boolean } {
+  const rootAbsolute = path.resolve(root);
+  const rootReal = exists(rootAbsolute) ? realpathSync(rootAbsolute) : rootAbsolute;
+
+  const parent = path.dirname(resolvedPath);
+  let existingAncestor = parent;
+  while (!exists(existingAncestor) && existingAncestor !== path.dirname(existingAncestor)) {
+    existingAncestor = path.dirname(existingAncestor);
+  }
+  const ancestorReal = exists(existingAncestor) ? realpathSync(existingAncestor) : existingAncestor;
+
+  const suffix = path.relative(existingAncestor, resolvedPath);
+  const realResolved = path.resolve(ancestorReal, suffix);
+
+  const rel = path.relative(rootReal, realResolved);
+  const escapes = rel.startsWith('..') || path.isAbsolute(rel);
+
+  return { realResolved, realRoot: rootReal, escapes };
+}
+
+/**
  * Defence-in-depth check (issue #93 Security Considerations): when the user
  * has set `outputRoot` (or the `--restrict-output-to` CLI flag), reject any
  * resolved output path that lies outside that directory.
@@ -73,28 +135,53 @@ export function assertOutputContained(
     return resolvedOutput;
   }
 
-  const rootAbsolute = path.resolve(outputRoot);
-  const rootReal = exists(rootAbsolute) ? realpathSync(rootAbsolute) : rootAbsolute;
-
-  // Walk up from the output's parent to the first existing ancestor; that is
-  // the deepest path the attacker can have influenced via a symlink.
-  const outputParent = path.dirname(resolvedOutput);
-  let existingAncestor = outputParent;
-  while (!exists(existingAncestor) && existingAncestor !== path.dirname(existingAncestor)) {
-    existingAncestor = path.dirname(existingAncestor);
-  }
-  const ancestorReal = exists(existingAncestor) ? realpathSync(existingAncestor) : existingAncestor;
-
-  // Re-anchor the resolved output onto the realpath'd ancestor.
-  const suffix = path.relative(existingAncestor, resolvedOutput);
-  const realResolved = path.resolve(ancestorReal, suffix);
-
-  // Containment: realResolved must equal rootReal or live underneath it.
-  const rel = path.relative(rootReal, realResolved);
-  const escapes = rel.startsWith('..') || path.isAbsolute(rel);
+  const { realResolved, realRoot, escapes } = resolveContainment(resolvedOutput, outputRoot, realpathSync, exists);
   if (escapes) {
-    throw new OutputOutsideRootError(realResolved, rootReal);
+    throw new OutputOutsideRootError(realResolved, realRoot);
   }
 
   return resolvedOutput;
+}
+
+/**
+ * Defence-in-depth check (proposal 38, the read-side counterpart to
+ * {@link assertOutputContained}): when the user has set `inputRoot` (or the
+ * `--restrict-input-to` CLI flag), reject any resolved local-file path the
+ * CLI would read that lies outside that directory -- whether a declared
+ * `inputFile` or a file discovered via `resolveExternalReferences`.
+ *
+ * Same realpath-based ancestor-walk as `assertOutputContained`, but with one
+ * difference the read/write asymmetry actually requires: an output usually
+ * does not exist yet, so `assertOutputContained` only needs to realpath its
+ * *parent* to defeat a directory-level symlink. An input, by contrast, is
+ * the thing about to be read and normally does exist -- so a symlink planted
+ * as the leaf itself (`inputRoot/evil.yml -> /etc/passwd`) has to be
+ * defeated too, not just a symlinked ancestor directory. When the resolved
+ * input exists, it is realpathed *before* the ancestor walk runs; the walk
+ * then operates on an already-canonical path, which is a no-op for it but
+ * closes the leaf-symlink gap the output-side check doesn't need to close.
+ *
+ * If `inputRoot` is `undefined`, this function is a no-op. Existing users
+ * see no change.
+ *
+ * Throws `InputOutsideRootError` on violation. Returns the resolved input
+ * path unchanged on success.
+ */
+export function assertInputContained(
+  resolvedInput: string,
+  inputRoot: string | undefined,
+  realpathSync: (p: string) => string = fs.realpathSync,
+  exists: (p: string) => boolean = fs.existsSync
+): string {
+  if (inputRoot === undefined) {
+    return resolvedInput;
+  }
+
+  const target = exists(resolvedInput) ? realpathSync(resolvedInput) : resolvedInput;
+  const { realResolved, realRoot, escapes } = resolveContainment(target, inputRoot, realpathSync, exists);
+  if (escapes) {
+    throw new InputOutsideRootError(realResolved, realRoot);
+  }
+
+  return resolvedInput;
 }


### PR DESCRIPTION
## Summary

Implements [proposal 38](ai-planning/38-proposal-input-root-containment.md): `inputRoot`, the read-side counterpart to `outputRoot` (#93). Closes the trust-boundary gap [proposal 37 §9.3](ai-planning/issues/37-proposal-10-external-ref-bundling.md#93-the-containmentallow-list-gap--still-open-flagged-rather-than-fixed) flagged but didn't build: with `resolveExternalReferences: true` (#143), a `$ref`'s relative path was followed and read with nothing bounding how far outside the input's own directory it could reach.

- New `inputRoot` config field + `--restrict-input-to` CLI flag, mirroring `outputRoot`/`--restrict-output-to`.
- Both a declared `inputFile` and a file discovered via `resolveExternalReferences` are checked for containment. Either kind of violation is a **hard failure** — new exit code `10` (`ExitCode.ErrorUnsafeInputPath`) — not a soft warning, per explicit direction: a containment violation should abort the merge whichever side it comes from.
- Declared inputs are checked eagerly, before any merge work starts; discovered files are checked during the breadth-first discovery walk, which keeps draining past a violation so every reachable violation *and* every ordinary discovery warning in the same run still surfaces together, rather than a fix-and-rerun cycle.
- `inputURL` and discovered URLs are unaffected — `inputRoot` bounds the filesystem, not the network.
- The realpath-based containment check is shared with `assertOutputContained` via a new `resolveContainment` helper, but `assertInputContained` additionally realpaths the *leaf* itself before walking ancestors: unlike an output (which usually doesn't exist yet), an input normally already exists, so a symlink planted as the file itself — not just a symlinked ancestor directory — has to be defeated too.

Two real defects were found and fixed during an internal review pass before this was considered done (see proposal §6.4 for the full writeup): the leaf-symlink gap above, and an ordering bug where a fatal containment violation was silently swallowing ordinary discovery warnings from the same run.

## Test plan

- [x] `bun test` — full workspace suite passes (646 tests, up from 625 before this branch)
- [x] Lint and typecheck clean in both packages
- [x] New unit tests for `assertInputContained` (`path-resolution.test.ts`), including a real-filesystem leaf-symlink test
- [x] New CLI end-to-end tests: declared-input containment (`cli-input-safety.test.ts`), discovered-file containment (`cli-external-references.test.ts`), `inputRoot`-doesn't-affect-`inputURL` (`cli-remote-inputs.test.ts`)
- [x] Manual smoke tests against the real CLI binary: discovered-file violation exits 10 with no output written; widening `inputRoot` succeeds; declared-input violation exits 10 before the merge starts; leaf-symlink escape is defeated

🤖 Generated with [Claude Code](https://claude.com/claude-code)