### PR TITLE
feat(cli): turn on resolveExternalReferences + inputRoot by default in init (proposal 39)

### DIFF
--- a/ai-planning/39-proposal-init-convenience-defaults.md
+++ b/ai-planning/39-proposal-init-convenience-defaults.md
@@ -1,0 +1,238 @@
+# Proposal 39: Which `init` defaults should be turned *on*, not just shown
+
+**Status:** Proposal (not yet implemented)
+
+**Not tied to a filed GitHub issue.** Robert's ask directly: turn on some
+`Configuration` fields by default in the file `openapi-merge-cli init`
+writes, `resolveExternalReferences` given as the example, "for maximum
+convenience." Written on a fresh branch off `main` (which already has both
+[proposal 34/35](34-proposal-init-yaml-commented-options.md) — every
+optional field shown commented out — and #104/#10's `resolveExternalReferences`
+merged; [proposal 38](38-proposal-input-root-containment.md)'s `inputRoot` is
+in review as [PR #144](https://github.com/robertmassaioli/openapi-merge/pull/144)
+but not yet merged).
+
+## 1. This ask runs directly against a design invariant that was just shipped
+
+[Proposal 34](34-proposal-init-yaml-commented-options.md) §2 states a design
+goal in so many words: *"The active (uncommented) part of the file is still
+just `inputs` and `output` — nothing behavioural changes for someone who
+ignores the comments and runs the tool as before."* That was the right call
+at the time (§1 of that document: `pruneUnusedComponents`,
+`securitySchemesStrategy` and friends were all newly discoverable, none of
+them obviously wanted by everyone), and it is still correct for most of
+`Configuration`'s optional fields — see §3 below.
+
+But it is not a law of nature, and Robert is the one person who gets to
+revise it. The honest framing for this proposal is: **for the small number
+of fields where turning a feature on is genuinely what most first-time users
+would want, and where doing so costs nothing for users who don't need it,
+deliberately break that invariant for those fields specifically** — not
+silently, and not for everything, but as a named, scoped exception.
+
+This only matters going forward. `init` already refuses to overwrite an
+existing config without `--force` (proposal 33 §4), so nothing about an
+already-generated file changes; this only affects configs generated *after*
+whatever change lands here.
+
+## 2. A gap this proposal has to fix regardless of what it recommends
+
+While reading `init-command.ts` to answer the actual question, two fields
+that already exist on `Configuration` turned out to be completely absent
+from `TOP_LEVEL_OPTIONAL_BLOCKS` — not commented out, not shown at all:
+
+- `resolveExternalReferences` (issue #10, merged to `main` before proposal
+  34/35's branch was cut, so its author didn't know about it yet).
+- `inputRoot` (proposal 38, PR #144, not merged as of this writing — will
+  make the gap worse the moment it lands, for the same reason).
+
+This is a real, present-tense defect independent of anything this proposal
+recommends: proposal 34's own stated promise (§2, "every optional field on
+`Configuration`... appears somewhere in the file") is **not currently true**
+on `main`. It slipped past `init-command.test.ts`'s
+`'every optional top-level Configuration field is represented'` test because
+that test compares `TOP_LEVEL_OPTIONAL_BLOCKS` against a **hand-copied
+`expected` array in the test file itself** (`init-command.test.ts:270-272`),
+not against `Configuration`'s actual keys — so the test enforces "the two
+hand-maintained lists agree with each other," and both were written (or, for
+`inputRoot`, will be written) without knowing about the new field. It cannot
+catch this class of drift by construction.
+
+Two things worth doing regardless of §3's outcome:
+
+1. Add `resolveExternalReferences` (now) and `inputRoot` (once #144 lands)
+   to `TOP_LEVEL_OPTIONAL_BLOCKS`, whether shown on or off (§4 decides
+   which).
+2. Make the coverage test resistant to this happening again: derive
+   `expected` from `Configuration`'s actual keys via a `keyof` /
+   `Object.keys` check at the type level, or at minimum add a code comment
+   at the *top of `Configuration` in `data.ts`* pointing back at
+   `TOP_LEVEL_OPTIONAL_BLOCKS`, so adding a field there prompts a look at
+   `init-command.ts` rather than relying on someone remembering. A `keyof`
+   comparison is stronger and worth attempting first — TypeScript's
+   `Record<keyof Configuration, unknown>` shape means a genuinely missing
+   key is a compile error, not just an untested one, which is a much better
+   guarantee than a runtime test that can drift silently.
+
+## 3. Field-by-field: what actually belongs on this list
+
+Every optional field on `Configuration`, assessed against the bar "would
+turning this on by default, for a config nobody has customised yet, help
+more than it surprises":
+
+| Field | Recommend on by default? | Why |
+| --- | --- | --- |
+| `resolveExternalReferences` | **Yes** | See §5 — this is the field Robert named, and it is the one place `init`'s own reason for existing (a directory of specs that plausibly `$ref` each other) directly benefits from the feature working without the user ever finding the flag. |
+| `inputRoot` | **Yes, paired with the above** | Not a "convenience" field on its own — it only ever *restricts*. Recommended because turning `resolveExternalReferences` on by default without it would widen the read surface with no compensating containment, which is exactly the gap proposal 38 exists to close. See §5. |
+| `outputRoot` | **No, but flagged as a free option worth a separate decision** | Same shape as `inputRoot` — a pure restriction, zero convenience — but nothing this proposal turns on newly threatens the *write* side the way `resolveExternalReferences` threatens the *read* side, so there's no forcing reason to bundle it in here. It costs nothing to also default it to `.` (init's own suggested `output` is always inside the scanned directory, so it can never reject what `init` itself produces), but that is an independent defense-in-depth call, not a consequence of this proposal's reasoning. Worth a one-line decision from Robert (§8), not a default recommendation from this proposal. |
+| `pruneUnusedComponents` | **No** | Its own doc comment (`data.ts`) calls it destructive by nature: *"a document may carry definitions referenced only from outside it."* It also does nothing without `operationSelection`, which `init` never sets — defaulting it on would be a silent, occasionally-destructive behaviour change with zero compensating benefit for the common case (no filtering configured at all). |
+| `securitySchemesStrategy` | **No** | `merge` is already the library default when the field is omitted. Writing it explicitly changes nothing behaviourally — it would only add a line that looks like a decision was made when none was. |
+| `serversStrategy` | **No** | Same reasoning: `first` is already the default. No behavioural difference between omitting it and writing it. |
+| `formatting` | **No** | 2-space indentation is already the default. Same reasoning again. |
+| `info` | **No** | Has no sensible universal default — it needs an actual title/version the generator cannot invent. Stays commented, as a template to fill in. |
+| Per-input fields (`pathModification`, `operationSelection`, `description`, `duplicatePathHandling`, `tag`, `dispute`) | **No** | None of these have a value that is correct for an arbitrary directory of specs — they encode decisions specific to the inputs found (which prefix to strip, which tags to keep, what a clashing schema should be renamed to). There is nothing to "turn on"; the value itself has to come from the user. |
+
+The pattern across every "no": either the field already matches the
+library's own default (writing it is inert), or the field's correct value
+is inherently input-specific and the generator has no basis for guessing
+it, or turning it on is actively destructive with no offsetting benefit for
+the common case. `resolveExternalReferences` is the one field that is none
+of those three things — it has a real default-off reason (§4 of `data.ts`'s
+own doc comment: "it changes what this tool reads"), but that reason is a
+*trust* argument, not a *behavioural-inertness* argument, and for a config
+`init` just generated from files it just read off local disk, the trust
+question has already been answered by the act of running `init` in that
+directory in the first place.
+
+## 4. How "on by default" should look in the generated file
+
+Everything in `TOP_LEVEL_OPTIONAL_BLOCKS` today renders the same way: a
+commented explanation line, then the field commented out. `resolveExternalReferences`
+(and `inputRoot`, per §5) need a visually distinct third rendering — active,
+not commented, but still explained, so a user does not mistake "we turned
+this on for you" for "this is just another suggestion like everything
+below it." Sketch:
+
+```yaml
+inputs:
+  - inputFile: ./users.yaml
+  - inputFile: ./orders.yaml
+output: ./openapi.json
+
+# Follows $refs into files these inputs don't declare, and files those pull
+# in, however many deep -- so a $ref like '../common/Errors.yml#/...' just
+# works without listing every file it touches in 'inputs'. Enabled here
+# because everything discovered has to live inside inputRoot, below, which
+# is set to the same directory init just scanned. Set to false to turn this
+# off, or see the README for what it means to widen inputRoot.
+resolveExternalReferences: true
+
+# Defence in depth, paired with the setting above: refuses to read any local
+# file -- declared or discovered -- from outside this directory. Already
+# covers everything init found here; only needs widening if you add an
+# inputFile, or a discovered $ref, that reaches outside '.'.
+inputRoot: .
+
+# Defence in depth: refuse to write the merged output anywhere outside this directory.
+# outputRoot: .
+```
+
+This needs a new `OptionalFieldBlock`-like shape (or a boolean flag added to
+the existing one, `active: boolean`) distinguishing "commented suggestion"
+from "active default, explained" — `renderCommentedBlock` stays as-is for
+the commented case; a new `renderActiveBlock` (or a branch inside a shared
+renderer) handles the other case. Keep both fields adjacent in the file (as
+sketched above), since they are one decision, not two independent ones —
+seeing them apart would make the pairing in §5 much harder to notice by
+reading the generated file alone.
+
+## 5. Why `resolveExternalReferences` and `inputRoot` are a package, not two separate calls
+
+Turning `resolveExternalReferences` on by default without also bounding it
+would reintroduce exactly the risk proposal 37 §9.3 and proposal 38 exist to
+close: an unbounded, transitive local-file read surface, now opt-*out*
+instead of opt-*in* for anyone who runs `init` and does not read the
+generated comments. That is a strictly worse security posture than today's
+status quo (field commented out, off), and defaulting it on without
+`inputRoot` would not be "convenience" so much as "convenience purchased
+with a containment gap this repository just spent two proposals closing."
+
+The fix is available for free, though, precisely because of what `init`
+already knows: every input it found came from scanning **the current
+directory only** (proposal 33 §3, Option E — recursion was deliberately
+rejected). So `inputRoot: .` costs nothing for the case `init` generated —
+every declared input and every plausible same-directory discovered file is
+already inside `.` — while closing the gap that would otherwise open. This
+is the concrete reason §3 recommends `inputRoot` as a default despite it
+being a pure restriction with no convenience value on its own: it is not an
+independent default decision, it is the specific mitigation this specific
+convenience default requires.
+
+**Residual gap this pairing does not close.** `inputRoot` only bounds local
+files (proposal 38 §2.1: *"Applies to local files only... a different trust
+boundary"*). If a user later adds an `inputURL` entry to a config that
+still has `resolveExternalReferences: true`, any `$ref` that document
+contains gets followed across the network with no equivalent restriction —
+`inputRoot` does not, and per proposal 38's own explicit non-goal (§3), was
+never meant to. This is not new risk introduced by defaulting the flag on
+(a hand-written config with `resolveExternalReferences: true` and an
+`inputURL` input has exactly the same exposure today), but defaulting the
+flag on does mean more configs will carry it un-examined. Worth a sentence
+in the generated comment (see the §4 sketch — "if you add `inputURL`
+entries" is deliberately called out) rather than a technical fix; an actual
+network-side containment mechanism is out of scope here the same way it was
+out of scope for proposal 38 (§3: *"Worth its own proposal"*).
+
+## 6. What this proposal explicitly does not do
+
+- Does not add interactive prompts asking which defaults to enable —
+  proposal 33 §3 Option D already rejected interactivity for `init`, and
+  nothing here changes that reasoning (no prompt dependency, still needs to
+  work unattended).
+- Does not add a flag (`--convenient`, `--minimal`, etc.) to choose between
+  default sets. One behaviour, chosen well, beats a second mode nobody
+  remembers exists. If usage shows people frequently want the other
+  behaviour, that is a proposal of its own.
+- Does not change `resolveExternalReferences`'s or `inputRoot`'s default
+  *when the field is omitted from a config* — that stays `false` /
+  `undefined` at the schema and library level, exactly as issue #10 and
+  proposal 38 specified. Only what `init` chooses to *write explicitly*
+  changes. This is the distinction that keeps this proposal from being a
+  breaking change to anything: no existing config's behaviour moves, because
+  no existing config goes through `init` again.
+- Does not touch `outputRoot` (§3's table entry) — flagged for a separate
+  yes/no from Robert, not decided here.
+
+## 7. Testing plan
+
+- Update `init-command.test.ts`'s two `'field coverage matches data.ts'`
+  tests (§2) to include `resolveExternalReferences` and `inputRoot`, and
+  attempt the stronger `keyof Configuration`-based check described in §2.2
+  so this class of drift cannot recur silently.
+- New tests for the "active, not commented" rendering: `resolveExternalReferences: true`
+  and `inputRoot: .` both appear uncommented in freshly generated output;
+  every other currently-commented field stays commented (regression guard
+  against accidentally widening the "on" set).
+- Extend the existing init-then-merge round-trip test (proposal 33 §6.2) to
+  cover the new defaults specifically: scan a directory containing two specs
+  where one `$ref`s into the other via a relative path outside both
+  declared `inputs` (the exact shape issue #10 targets), run `init`, then
+  run the merge against `init`'s own output with zero edits, and confirm the
+  `$ref` actually resolves — proving the default is not just present in the
+  file but functionally does something useful out of the box.
+- A CLI test confirming `inputRoot: .` from a freshly-generated config does
+  not reject any file `init` itself would have scanned (the "costs nothing"
+  claim in §5, made concrete rather than asserted).
+
+## 8. Open questions for Robert
+
+1. `outputRoot: .` as a third default (§3, §6) — bundle it into this
+   proposal's scope, or leave it as a separate ask?
+2. Is the `keyof Configuration`-based exhaustiveness check (§2.2) worth the
+   type-level complexity, or is a code comment pointing at
+   `TOP_LEVEL_OPTIONAL_BLOCKS` from `data.ts` enough given how rarely
+   `Configuration` gains a field?
+3. Should the generated comment's residual-gap note (§5) actually name
+   `inputURL` specifically, or keep it more general ("if any input is
+   remote...") so it doesn't need updating if URL discovery containment
+   (proposal 38 §3's stated non-goal) is ever built?

--- a/ai-planning/39-proposal-init-convenience-defaults.md
+++ b/ai-planning/39-proposal-init-convenience-defaults.md
@@ -1,6 +1,6 @@
 # Proposal 39: Which `init` defaults should be turned *on*, not just shown
 
-**Status:** Proposal (not yet implemented)
+**Status:** ✅ Implemented on branch `feature/init-convenience-defaults`, at Robert's explicit direction, exactly as §3/§4/§5 recommend. See §9 for what was actually built and the calls made on the three §8 open questions.
 
 **Not tied to a filed GitHub issue.** Robert's ask directly: turn on some
 `Configuration` fields by default in the file `openapi-merge-cli init`
@@ -236,3 +236,128 @@ out of scope for proposal 38 (§3: *"Worth its own proposal"*).
    `inputURL` specifically, or keep it more general ("if any input is
    remote...") so it doesn't need updating if URL discovery containment
    (proposal 38 §3's stated non-goal) is ever built?
+
+## 9. What was actually built
+
+### 9.1 §3/§4/§5 landed as specified
+
+`ACTIVE_TOP_LEVEL_DEFAULTS` (`init-command.ts`) holds exactly the two
+entries §3 recommends -- `resolveExternalReferences: true` and
+`inputRoot: .`, in that order, adjacent in the generated file, each with a
+commented explanation above the active line -- rendered by a new
+`renderActiveBlock`, kept structurally separate from `TOP_LEVEL_OPTIONAL_BLOCKS`'s
+`renderCommentedBlock` rather than adding a branch/flag to one shared
+function, since the two need visibly different treatment (the whole point)
+and conflating them risked a bug where a flag gets flipped wrong on one
+entry and nobody notices.
+
+### 9.2 §8's three open questions, resolved during implementation
+
+1. **`outputRoot: .` (§8.1): not bundled in.** Left exactly as proposed --
+   a pure restriction with no forcing reason tied to this proposal's actual
+   ask, so it stays a separate decision rather than being smuggled in
+   alongside `resolveExternalReferences`/`inputRoot`. `outputRoot` remains
+   commented, unchanged, in `TOP_LEVEL_OPTIONAL_BLOCKS`.
+2. **The `keyof Configuration` exhaustiveness check (§8.2): built, and it
+   works.** Implemented via `[...] as const satisfies ReadonlyArray<OptionalFieldBlock>`
+   on both `TOP_LEVEL_OPTIONAL_BLOCKS` and `ACTIVE_TOP_LEVEL_DEFAULTS` (to
+   keep each entry's literal `name` type rather than widening it to `string`),
+   plus a `type _MissingTopLevelInitBlocks = Exclude<TopLevelOptionalConfigurationKey, DeclaredTopLevelBlockName>`
+   check that fails to typecheck -- not silently, a real `tsc`/`tsgo` error
+   naming the missing field -- if either list ever drifts from `Configuration`
+   again. Verified directly, not just written and hoped: temporarily
+   renaming `inputRoot`'s entry to `inputRoot_TYPO` and running `bun run
+   typecheck` produced `Type 'boolean' is not assignable to type ["...", "inputRoot"]`,
+   naming the exact missing field. This is the mechanism that would have
+   caught the `resolveExternalReferences`/`inputRoot` gap §2 found, had it
+   existed before those fields were added -- which is the whole reason for
+   building it now rather than leaving the comment-only fallback. `PER_INPUT_OPTIONAL_BLOCKS`
+   was deliberately left with the plain hand-copied-list test only (no
+   `satisfies`/exhaustiveness check) -- out of this proposal's scope, and
+   its own coverage test already exists.
+3. **The residual-gap comment (§8.3): kept general.** The generated comment
+   says *"a $ref inside a remote (URL) input isn't restricted the same
+   way"* rather than naming `inputURL` as a config field -- concrete enough
+   to be useful, general enough that it does not need editing if URL
+   containment is ever designed.
+
+### 9.3 One thing worth flagging that the proposal didn't anticipate
+
+§2's fix for the pre-existing coverage gap changed the *shape* of the
+existing `'every optional top-level Configuration field is represented'`
+test, not just its `expected` list: since `resolveExternalReferences` and
+`inputRoot` moved to a wholly separate list (`ACTIVE_TOP_LEVEL_DEFAULTS`)
+rather than just being added to `TOP_LEVEL_OPTIONAL_BLOCKS`'s existing
+`expected` array, that test now asserts two lists instead of one. This
+wasn't a design decision proposal 39 called out explicitly, but follows
+directly from §4's own recommendation to keep active and commented
+rendering structurally distinct -- worth noting only because a reader
+diffing the test file against §7's testing plan might otherwise wonder why
+the test changed shape and not just content.
+
+Separately, the three existing `'the active part is inert'` tests
+(`init-command.test.ts`) needed their assertions widened from
+`.toEqual(buildConfiguration(inputs))` to a new `withActiveDefaults(inputs)`
+helper that adds the two active fields -- an expected, mechanical
+consequence of §1's point that the active part of the file is no longer
+*just* `inputs`/`output`, but worth recording since it is the most direct,
+concrete evidence that §1's named invariant genuinely changed, not just in
+prose but in what the test suite itself asserts.
+
+### 9.4 Verification
+
+- `bun test`: 682 tests pass (up from 677 before this proposal's
+  implementation commit), including 3 new rendering tests confirming the
+  active/commented distinction, 1 new coverage test, 1 new CLI end-to-end
+  test proving the `resolveExternalReferences`/`inputRoot` pairing resolves
+  a real `$ref` into an undeclared subdirectory file with zero edits to
+  `init`'s own output, and 1 new CLI test pinning the behaviour change
+  recorded in §9.5.
+- Lint and typecheck clean in both packages; `init-command.ts` and
+  `index.ts` both at 100% function/line coverage.
+- Manual verification: ran `openapi-merge-cli init` against a real temp
+  directory and eyeballed the generated file (matches the §4 sketch
+  exactly), then ran the merge against that file unmodified to confirm
+  `ExitCode.Success` and a written output.
+
+### 9.5 A behaviour change worth Robert's attention specifically, not a footnote
+
+§5's "costs nothing" claim is true of what `init` itself generates in a
+single scan, and only that. The first edit a user makes changes the
+calculus, and one very ordinary edit makes it worse, not better:
+
+**A `$ref` to a file one directory up (a common "shared components live in
+`../common/`" layout) used to fail silently; now it fails loudly, and it is
+the *default*, not an opt-in, that changed this.** Traced and verified with
+a real CLI run, not just reasoned about:
+
+- **Before this proposal** (`resolveExternalReferences` unset/`false`):
+  discovery never runs at all. The `$ref` is normalised to an absolute path
+  and left exactly as unresolved as it always was. The merge succeeds,
+  output is written, exit `0`. Silent, but not destructive.
+- **After** (`resolveExternalReferences: true` + `inputRoot: .`, both
+  defaults from this proposal): discovery reaches the file, finds it
+  outside `.`, and -- correctly, per proposal 38's design -- refuses to
+  read it. The merge does not run. No output is written. Exit `10`.
+
+This is not a bug -- `inputRoot`'s hard-fail-on-violation behaviour is
+exactly what proposal 38 was built to do, deliberately, at Robert's own
+prior direction (that conversation's confirmation: *"Both should error,
+[...] Yes, hard error both cases"*). And arguably loud-and-wrong beats
+quiet-and-wrong: a merge that silently drops a `$ref` unresolved was never
+actually correct either, it just failed in a way nobody noticed until
+later. But it is a genuine behaviour change specifically caused by turning
+`resolveExternalReferences` on by *default*, for the single most common way
+someone extends a freshly `init`-generated project (adding a second
+directory of shared specs next to the first) -- and it converts a
+previously non-fatal surprise into a merge that produces *no output at
+all*, which is a bigger blast radius than "the `$ref` didn't resolve."
+
+Recorded here explicitly, with a regression test pinning the exact exit
+code (`ExitCode.ErrorUnsafeInputPath`, `cli-invocation.test.ts`), rather
+than left as something only discoverable by reading the generated file's
+comments. Worth Robert's explicit sign-off before this ships as the
+default rather than an opt-in the way #10 originally was: the remedy is
+simple and already documented in the generated comment (widen `inputRoot`,
+or set it to `false`), but the first time someone hits it will be a build
+failure, not a warning.

--- a/ai-planning/39-proposal-init-convenience-defaults.md
+++ b/ai-planning/39-proposal-init-convenience-defaults.md
@@ -361,3 +361,40 @@ default rather than an opt-in the way #10 originally was: the remedy is
 simple and already documented in the generated comment (widen `inputRoot`,
 or set it to `false`), but the first time someone hits it will be a build
 failure, not a warning.
+
+## 10. Follow-up in the same PR: every commented field's alternatives, not just its default
+
+Requested directly after §9's implementation landed, and folded into the
+same branch/PR rather than a new proposal number: for a commented-out field
+with more than one possible value -- an enum (`serversStrategy`,
+`securitySchemesStrategy`, `duplicatePathHandling`, `formatting.indent.style`)
+or a discriminated choice (`dispute`'s prefix vs. suffix) -- show *every*
+value as its own commented example line, not just the default with the
+alternatives named in a trailing inline comment. Picking one becomes
+"uncomment this line instead of that one," not "look up the other spellings
+and edit a value by hand."
+
+Implementation: `OptionalFieldBlock` gained an optional `alternatives?:
+ReadonlyArray<string>` -- each entry a complete, standalone, independently
+schema-valid replacement for `yaml`, rendered by `renderCommentedBlock`
+directly after `yaml`'s own lines, same indent, same `# ` comment prefix.
+`ACTIVE_TOP_LEVEL_DEFAULTS` (§9.1) is untouched -- neither of its two
+entries is an enum, and `alternatives` being optional means nothing there
+had to change.
+
+Every `alternatives` entry gets exactly the same per-block validity test
+`yaml` already had (`init-command.test.ts`'s
+`'every commented block, and every one of its alternatives, is independently
+valid once uncommented'`), not a weaker or separate check -- an alternative
+that fails ajv would be worse than not offering it at all. One existing
+test needed adjusting rather than just extending: `'shows the full
+per-input block exactly once'` used to count occurrences by field name
+(`# ${block.name}:`), which broke the moment a block's own alternatives
+legitimately repeat that same field name within one occurrence of the
+block (`duplicatePathHandling` alone produced 4 matches, one per
+alternative, from a single correctly-rendered block). Fixed by counting on
+`block.explanation` instead, which appears exactly once per block
+regardless of how many alternatives it has -- verified end-to-end against
+the real CLI binary, including uncommenting a non-default alternative
+(`serversStrategy: concat`) by hand and confirming the merge accepts it
+unmodified.

--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -67,7 +67,7 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`34-proposal-init-yaml-commented-options.md`](34-proposal-init-yaml-commented-options.md) | ✅ `init` writes YAML with every optional field present, commented out |
 | [`35-proposal-commented-yaml-section-type.md`](35-proposal-commented-yaml-section-type.md) | Evaluates a typed `Section`/`CommentedYaml` refactor of how 34's generator builds that file |
 | [`38-proposal-input-root-containment.md`](38-proposal-input-root-containment.md) | ✅ `inputRoot` — a read-side containment boundary mirroring `outputRoot`, closing the gap proposal 37 left open |
-| [`39-proposal-init-convenience-defaults.md`](39-proposal-init-convenience-defaults.md) | Which `Configuration` fields `init` should turn on by default, not just show commented out |
+| [`39-proposal-init-convenience-defaults.md`](39-proposal-init-convenience-defaults.md) | ✅ `resolveExternalReferences` + `inputRoot` turned on by default in `init`'s output |
 | [`issue-triage-value-vs-effort.md`](issue-triage-value-vs-effort.md) | Value/effort scoring of every open issue; the index into `issues/` |
 | [`spec-edge-case-findings.md`](spec-edge-case-findings.md) | Divergences between the merge and the spec, found by edge-case testing |
 | [`bun-tsgo-migration-build-timings.md`](bun-tsgo-migration-build-timings.md) | Measured build timings for the Bun + tsgo migration |

--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -66,6 +66,7 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`33-proposal-cli-init-command.md`](33-proposal-cli-init-command.md) | ✅ An `init` command that writes a starter configuration, scanning for inputs |
 | [`34-proposal-init-yaml-commented-options.md`](34-proposal-init-yaml-commented-options.md) | ✅ `init` writes YAML with every optional field present, commented out |
 | [`35-proposal-commented-yaml-section-type.md`](35-proposal-commented-yaml-section-type.md) | Evaluates a typed `Section`/`CommentedYaml` refactor of how 34's generator builds that file |
+| [`39-proposal-init-convenience-defaults.md`](39-proposal-init-convenience-defaults.md) | Which `Configuration` fields `init` should turn on by default, not just show commented out |
 | [`issue-triage-value-vs-effort.md`](issue-triage-value-vs-effort.md) | Value/effort scoring of every open issue; the index into `issues/` |
 | [`spec-edge-case-findings.md`](spec-edge-case-findings.md) | Divergences between the merge and the spec, found by edge-case testing |
 | [`bun-tsgo-migration-build-timings.md`](bun-tsgo-migration-build-timings.md) | Measured build timings for the Bun + tsgo migration |

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -11,8 +11,8 @@ used for most use cases, some of the feature decisions are tailored for that spe
 
 In order to use this merging cli tool you need to have one or more OpenAPI 3.0 files that you wish to merge. Then you need to create a configuration file,
 called `openapi-merge.yaml` by default (`openapi-merge.json` is also read, for configurations written before this tool wrote YAML), in your current directory.
-The [`init`](#getting-started-init) command below writes a starting point for you, with every setting documented and commented out. Written by hand, it
-should look something like this:
+The [`init`](#getting-started-init) command below writes a starting point for you, with every setting documented (most commented out, a couple turned on by
+default -- see below). Written by hand, it should look something like this:
 
 ``` json
 {
@@ -111,17 +111,23 @@ OpenAPI 3.x files it finds alongside it:
 ## Wrote openapi-merge.yaml with 2 inputs:
 ##   ./service-a.yaml
 ##   ./service-b.yaml
-##   Every other setting is included, commented out -- uncomment what you need.
+##   resolveExternalReferences and inputRoot are turned on by default -- see the
+##   comments above them. Every other setting is included, commented out -- uncomment what you need.
 ## Edit openapi-merge.yaml, then run openapi-merge-cli to produce './openapi.yaml'.
 ```
 
-The generated file is not just `inputs` and `output` -- every optional setting
-this tool supports, both per-input (`dispute`, `pathModification`,
-`operationSelection`, `description`, `duplicatePathHandling`, `tag`) and
-top-level (`outputRoot`, `formatting`, `serversStrategy`,
-`securitySchemesStrategy`, `pruneUnusedComponents`, `info`), is written out
-commented, with a one-line explanation and a working example. Uncomment a
-block and it is immediately valid -- nothing else to fill in:
+The generated file is not just `inputs` and `output`. Two settings,
+`resolveExternalReferences` and `inputRoot`, are turned **on** by default --
+see [Cross-document `$ref`s](#cross-document-refs) below for what the first
+one does; the second bounds it to the directory `init` just scanned, which
+costs nothing since everything `init` found already lives there. Every other
+optional setting this tool supports, both per-input (`dispute`,
+`pathModification`, `operationSelection`, `description`,
+`duplicatePathHandling`, `tag`) and top-level (`outputRoot`, `formatting`,
+`serversStrategy`, `securitySchemesStrategy`, `pruneUnusedComponents`,
+`info`), is written out commented, with a one-line explanation and a working
+example. Uncomment a block and it is immediately valid -- nothing else to
+fill in:
 
 ```yaml
 inputs:
@@ -136,11 +142,26 @@ inputs:
     # Per-input options: see the commented block under the first input above -- the same fields apply here.
 output: ./openapi.yaml
 
+# Follows $refs into files these inputs don't declare, and files those pull in,
+# however many deep -- so a $ref into an undeclared file just works. Paired
+# with inputRoot, below, which bounds every local file this can reach to '.'.
+# Set to false to turn this off.
+resolveExternalReferences: true
+
+# Defence in depth for the setting above: refuses to read any local file --
+# declared or discovered -- from outside this directory.
+inputRoot: .
+
 # Defence in depth: refuse to write the merged output anywhere outside this directory.
 # outputRoot: .
 
 # ... formatting, serversStrategy, securitySchemesStrategy, pruneUnusedComponents, info ...
 ```
+
+If you would rather start from the historical permissive defaults (both
+settings unset, matching every version of `init` before this), delete or
+comment out the two active lines -- deleting an active line is exactly as
+valid as leaving a commented one uncommented.
 
 Details worth knowing:
 

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -127,7 +127,11 @@ optional setting this tool supports, both per-input (`dispute`,
 `serversStrategy`, `securitySchemesStrategy`, `pruneUnusedComponents`,
 `info`), is written out commented, with a one-line explanation and a working
 example. Uncomment a block and it is immediately valid -- nothing else to
-fill in:
+fill in. **A field with more than one possible value -- an enum like
+`serversStrategy`, or a choice like `dispute`'s prefix-vs-suffix -- shows
+every value as its own commented example line**, so picking one is
+"uncomment this line instead of that one," not "look up the other spellings
+and edit a value by hand":
 
 ```yaml
 inputs:
@@ -137,7 +141,12 @@ inputs:
     # pathModification:
     #   stripStart: /v1
     #   prepend: /service-a
-    # ... operationSelection, description, duplicatePathHandling, tag, dispute ...
+    # What to do when this input declares a path another input already contributed.
+    # duplicatePathHandling: error            # (default) fail the merge
+    # duplicatePathHandling: skip-later       # keep the definition already present, drop this one
+    # duplicatePathHandling: prefer-later     # replace the definition already present with this one
+    # duplicatePathHandling: merge-operations # combine when methods don't overlap and path-level fields agree
+    # ... operationSelection, description, tag, dispute ...
   - inputFile: ./service-b.yaml
     # Per-input options: see the commented block under the first input above -- the same fields apply here.
 output: ./openapi.yaml
@@ -155,7 +164,11 @@ inputRoot: .
 # Defence in depth: refuse to write the merged output anywhere outside this directory.
 # outputRoot: .
 
-# ... formatting, serversStrategy, securitySchemesStrategy, pruneUnusedComponents, info ...
+# How to combine the top-level 'servers' array across inputs.
+# serversStrategy: first  # (default) keep only the first input's servers, discard the rest
+# serversStrategy: concat # keep every input's servers, deduplicated by URL
+
+# ... formatting, securitySchemesStrategy, pruneUnusedComponents, info ...
 ```
 
 If you would rather start from the historical permissive defaults (both

--- a/packages/openapi-merge-cli/src/__tests__/cli-invocation.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-invocation.test.ts
@@ -141,6 +141,68 @@ describe('init command', () => {
     expect(Object.keys(merged.paths).sort()).toEqual(['/a', '/b']);
   });
 
+  it('the resolveExternalReferences/inputRoot defaults (proposal 39) actually resolve a $ref, unmodified', async () => {
+    // A shared-components subdirectory `init`'s (non-recursive) scan never
+    // declares as an input, referenced from a file it does scan -- exactly
+    // the case resolveExternalReferences exists for. Proves the default is
+    // not just present in the generated file but functionally does
+    // something useful with zero edits, and that inputRoot: '.' doesn't
+    // reject a file that legitimately lives inside '.', just not at its
+    // top level.
+    cli.write('common/ServerError.yml', 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    cli.write('a.yaml', [
+      'openapi: "3.0.0"',
+      'info: { title: A, version: "1.0" }',
+      'components:',
+      '  schemas:',
+      '    Widget:',
+      '      $ref: "./common/ServerError.yml#/components/schemas/ServerError"',
+      '',
+    ].join('\n'));
+
+    expect(await runInDir('init')).toBe(ExitCode.Success);
+    expect(generated().inputs).toEqual([{ inputFile: './a.yaml' }]);
+
+    expect(await runInDir()).toBe(ExitCode.Success);
+
+    const merged = loadYaml(fs.readFileSync(path.join(cli.dir(), generated().output), 'utf8')) as {
+      components: { schemas: Record<string, unknown> };
+    };
+    expect(merged.components.schemas.Widget).toEqual({ $ref: '#/components/schemas/ServerError' });
+    expect(merged.components.schemas.ServerError).toEqual({ type: 'object' });
+  });
+
+  it('turns a shared-components-one-directory-up layout into a hard failure, not the old silent success (proposal 39 §9.5)', async () => {
+    // Before resolveExternalReferences/inputRoot were on by default, this
+    // exact layout produced ExitCode.Success with the $ref left unresolved
+    // -- discovery never ran, so nothing was ever attempted, let alone
+    // rejected. With the default on, discovery reaches the file and
+    // inputRoot correctly refuses to read it, so the merge now hard-fails
+    // instead. "Shared components live one directory up" is a common
+    // layout, and this is the one behaviour change worth a second look
+    // before relying on the new defaults for an existing directory -- not
+    // a silent footnote, see proposal 39 §9.5.
+    const outsidePath = path.join(cli.dir(), '..', 'shared-common.yaml');
+    fs.writeFileSync(outsidePath, 'openapi: "3.0.0"\ncomponents:\n  schemas:\n    ServerError:\n      type: object\n');
+    try {
+      cli.write('a.yaml', [
+        'openapi: "3.0.0"',
+        'info: { title: A, version: "1.0" }',
+        'components:',
+        '  schemas:',
+        '    Widget:',
+        '      $ref: "../shared-common.yaml#/components/schemas/ServerError"',
+        '',
+      ].join('\n'));
+
+      expect(await runInDir('init')).toBe(ExitCode.Success);
+      expect(await runInDir()).toBe(ExitCode.ErrorUnsafeInputPath);
+      expect(cli.exists('openapi.yaml')).toBe(false);
+    } finally {
+      fs.rmSync(outsidePath, { force: true });
+    }
+  });
+
   it('refuses to overwrite an existing openapi-merge.yaml', async () => {
     cli.write('openapi-merge.yaml', 'inputs:\n  - inputFile: ./hand-written.yaml\noutput: ./out.json\n');
 

--- a/packages/openapi-merge-cli/src/__tests__/init-command.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/init-command.test.ts
@@ -1,6 +1,6 @@
 import {
-  buildConfiguration, CandidateFile, chosenInputs, classify, isScannable, OptionalFieldBlock, PER_INPUT_OPTIONAL_BLOCKS,
-  PLACEHOLDER_INPUT, renderInitYaml, selectInputs, suggestedOutput, TOP_LEVEL_OPTIONAL_BLOCKS,
+  ACTIVE_TOP_LEVEL_DEFAULTS, buildConfiguration, CandidateFile, chosenInputs, classify, isScannable, OptionalFieldBlock,
+  PER_INPUT_OPTIONAL_BLOCKS, PLACEHOLDER_INPUT, renderInitYaml, selectInputs, suggestedOutput, TOP_LEVEL_OPTIONAL_BLOCKS,
 } from '../init-command';
 import { load as loadYaml } from 'js-yaml';
 import Ajv from 'ajv';
@@ -207,24 +207,60 @@ describe('init YAML rendering (renderInitYaml)', () => {
     return renderInitYaml(chosenInputs(inputs), buildConfiguration(inputs).output);
   }
 
-  describe('the active part is inert -- comments add nothing to what is parsed', () => {
+  /** {@link buildConfiguration}'s output, plus the two fields proposal 39 turns on by default. */
+  function withActiveDefaults(inputs: ReadonlyArray<string>): Configuration {
+    return { ...buildConfiguration(inputs), resolveExternalReferences: true, inputRoot: '.' };
+  }
+
+  describe('the active part is inert -- comments add nothing beyond inputs/output/the active defaults', () => {
     it('with several inputs', () => {
       const inputs = ['./service-a.yaml', './service-b.yaml'];
-      expect(parseActive(render(inputs))).toEqual(buildConfiguration(inputs));
+      expect(parseActive(render(inputs))).toEqual(withActiveDefaults(inputs));
     });
 
     it('with a single input', () => {
       const inputs = ['./only.yaml'];
-      expect(parseActive(render(inputs))).toEqual(buildConfiguration(inputs));
+      expect(parseActive(render(inputs))).toEqual(withActiveDefaults(inputs));
     });
 
     it('with no inputs -- the placeholder case', () => {
-      expect(parseActive(render([]))).toEqual(buildConfiguration([]));
+      expect(parseActive(render([]))).toEqual(withActiveDefaults([]));
     });
   });
 
   it('the active document validates against the real configuration schema', () => {
     expect(validate(parseActive(render(['./a.yaml', './b.yaml', './c.yaml'])))).toBe(true);
+  });
+
+  describe('proposal 39 -- resolveExternalReferences and inputRoot are active defaults, not commented suggestions', () => {
+    it('renders both uncommented, not as "# resolveExternalReferences:" / "# inputRoot:"', () => {
+      const rendered = render(['./a.yaml', './b.yaml']);
+
+      expect(rendered).toContain('\nresolveExternalReferences: true\n');
+      expect(rendered).toContain('\ninputRoot: .\n');
+      expect(rendered).not.toContain('# resolveExternalReferences:');
+      expect(rendered).not.toContain('# inputRoot:');
+    });
+
+    it('every other top-level optional field stays commented (regression guard against widening the active set)', () => {
+      const rendered = render(['./a.yaml', './b.yaml']);
+
+      for (const block of TOP_LEVEL_OPTIONAL_BLOCKS) {
+        const firstLine = block.yaml.split('\n')[0];
+        expect(rendered).toContain(`# ${firstLine}`);
+        expect(rendered).not.toContain(`\n${firstLine}\n`);
+      }
+    });
+
+    it('explains each active default with a commented line above it', () => {
+      const rendered = render(['./a.yaml']);
+
+      for (const block of ACTIVE_TOP_LEVEL_DEFAULTS) {
+        for (const explanationLine of block.explanation.split('\n')) {
+          expect(rendered).toContain(`# ${explanationLine}`);
+        }
+      }
+    });
   });
 
   it('is deterministic -- the same inputs render the same bytes twice', () => {
@@ -264,13 +300,16 @@ describe('init YAML rendering (renderInitYaml)', () => {
   });
 
   describe('field coverage matches data.ts', () => {
-    it('every optional top-level Configuration field is represented', () => {
-      // Cross-checked by hand against Configuration in data.ts. Update this list
-      // (and TOP_LEVEL_OPTIONAL_BLOCKS) if a field is added, renamed or removed.
-      const expected = [
-        'outputRoot', 'formatting', 'serversStrategy', 'securitySchemesStrategy', 'pruneUnusedComponents', 'info',
-      ];
-      expect(TOP_LEVEL_OPTIONAL_BLOCKS.map(block => block.name).sort()).toEqual([...expected].sort());
+    it('every optional top-level Configuration field is represented, as either a commented suggestion or an active default', () => {
+      // Cross-checked by hand against Configuration in data.ts. Update these
+      // lists (and TOP_LEVEL_OPTIONAL_BLOCKS / ACTIVE_TOP_LEVEL_DEFAULTS) if a
+      // field is added, renamed or removed. init-command.ts also enforces this
+      // at compile time (proposal 39 §2.2) -- this test is a readable,
+      // explicit cross-check, not the only guard against drift.
+      const expectedCommented = ['outputRoot', 'formatting', 'serversStrategy', 'securitySchemesStrategy', 'pruneUnusedComponents', 'info'];
+      const expectedActive = ['resolveExternalReferences', 'inputRoot'];
+      expect(TOP_LEVEL_OPTIONAL_BLOCKS.map(block => block.name).sort()).toEqual([...expectedCommented].sort());
+      expect(ACTIVE_TOP_LEVEL_DEFAULTS.map(block => block.name).sort()).toEqual([...expectedActive].sort());
     });
 
     it('every optional per-input field (ConfigurationInputBase + DisputeV2) is represented', () => {

--- a/packages/openapi-merge-cli/src/__tests__/init-command.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/init-command.test.ts
@@ -283,7 +283,12 @@ describe('init YAML rendering (renderInitYaml)', () => {
     const rendered = render(['./a.yaml', './b.yaml', './c.yaml']);
 
     for (const block of PER_INPUT_OPTIONAL_BLOCKS) {
-      const occurrences = rendered.split(`# ${block.name}:`).length - 1;
+      // Counted by `explanation`, not by field name: a block with
+      // `alternatives` (e.g. `dispute`, `duplicatePathHandling`) legitimately
+      // repeats its own field name once per alternative within its ONE
+      // occurrence of the block -- `explanation` is the part that only ever
+      // appears once per block, regardless of how many alternatives it has.
+      const occurrences = rendered.split(`# ${block.explanation}`).length - 1;
       expect(occurrences).toBe(1);
     }
     // Every input after the first points back at it instead of repeating it.
@@ -322,35 +327,50 @@ describe('init YAML rendering (renderInitYaml)', () => {
     });
   });
 
-  describe('every commented block is independently valid once uncommented', () => {
+  describe('every commented block, and every one of its alternatives, is independently valid once uncommented', () => {
     // Not "uncomment everything at once": `dispute` is prefix XOR suffix, and
     // an input is inputFile XOR inputURL, so an all-uncommented document would
     // fail ajv for reasons that have nothing to do with whether any individual
-    // block is correct. Each block is tested in isolation instead, merged into
-    // an otherwise-minimal, otherwise-valid base document.
+    // block is correct. Each candidate (a block's `yaml`, and separately each
+    // of its `alternatives`) is tested in isolation instead, merged into an
+    // otherwise-minimal, otherwise-valid base document -- an `alternatives`
+    // entry is supposed to be exactly as valid a standalone replacement for
+    // `yaml` as `yaml` itself, so it gets exactly the same test `yaml` does.
 
     const baseInputs = ['./a.yaml', './b.yaml'];
     const baseConfig = buildConfiguration(baseInputs) as Configuration;
 
-    for (const block of TOP_LEVEL_OPTIONAL_BLOCKS) {
-      it(`top-level: ${block.name}`, () => {
-        const fragment = loadYaml(block.yaml) as Partial<Configuration>;
-        const doc = { ...baseConfig, ...fragment };
+    /** `yaml` plus every entry in `alternatives`, labelled for the test name. */
+    function candidates(block: OptionalFieldBlock): ReadonlyArray<{ label: string; yaml: string }> {
+      return [
+        { label: block.name, yaml: block.yaml },
+        ...(block.alternatives ?? []).map((yaml, i) => ({ label: `${block.name} (alternative ${i + 1})`, yaml })),
+      ];
+    }
 
-        expect(validate(doc)).toBe(true);
-      });
+    for (const block of TOP_LEVEL_OPTIONAL_BLOCKS) {
+      for (const candidate of candidates(block)) {
+        it(`top-level: ${candidate.label}`, () => {
+          const fragment = loadYaml(candidate.yaml) as Partial<Configuration>;
+          const doc = { ...baseConfig, ...fragment };
+
+          expect(validate(doc)).toBe(true);
+        });
+      }
     }
 
     for (const block of PER_INPUT_OPTIONAL_BLOCKS) {
-      it(`per-input: ${block.name}`, () => {
-        const fragment = loadYaml(block.yaml) as Record<string, unknown>;
-        const doc: Configuration = {
-          ...baseConfig,
-          inputs: [{ ...baseConfig.inputs[0], ...fragment }, ...baseConfig.inputs.slice(1)],
-        };
+      for (const candidate of candidates(block)) {
+        it(`per-input: ${candidate.label}`, () => {
+          const fragment = loadYaml(candidate.yaml) as Record<string, unknown>;
+          const doc: Configuration = {
+            ...baseConfig,
+            inputs: [{ ...baseConfig.inputs[0], ...fragment }, ...baseConfig.inputs.slice(1)],
+          };
 
-        expect(validate(doc)).toBe(true);
-      });
+          expect(validate(doc)).toBe(true);
+        });
+      }
     }
   });
 

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -65,9 +65,10 @@ function buildProgram(): Command {
 Commands:
   init [--force]             Write a starter openapi-merge.yaml in the current
                              directory, filled in with any OpenAPI 3.x files
-                             found alongside it, and every optional setting
-                             shown commented out. Refuses to overwrite an
-                             existing configuration (openapi-merge.yaml or
+                             found alongside it, with resolveExternalReferences
+                             and inputRoot turned on and every other optional
+                             setting shown commented out. Refuses to overwrite
+                             an existing configuration (openapi-merge.yaml or
                              openapi-merge.json) unless --force is given.
 
 Run with no arguments to perform the merge described by openapi-merge.yaml
@@ -138,7 +139,8 @@ async function runInit(force: boolean, logger: LogWithMillisDiff): Promise<ExitC
     logger.log(`##   placeholder input -- replace '${PLACEHOLDER_INPUT}' before running the merge.`);
   }
 
-  logger.log(`##   Every other setting is included, commented out -- uncomment what you need.`);
+  logger.log(`##   resolveExternalReferences and inputRoot are turned on by default -- see the`);
+  logger.log(`##   comments above them. Every other setting is included, commented out -- uncomment what you need.`);
 
   if (swagger2.length > 0) {
     // Named rather than ignored: people do try to merge 2.0 documents (issue

--- a/packages/openapi-merge-cli/src/init-command.ts
+++ b/packages/openapi-merge-cli/src/init-command.ts
@@ -179,7 +179,7 @@ export type OptionalFieldBlock = {
  * there. Deliberately excludes the deprecated `disputePrefix` -- only the
  * current `dispute` shape (`DisputeV2`) is worth showing to a new user.
  */
-export const TOP_LEVEL_OPTIONAL_BLOCKS: ReadonlyArray<OptionalFieldBlock> = [
+export const TOP_LEVEL_OPTIONAL_BLOCKS = [
   {
     name: 'outputRoot',
     explanation: 'Defence in depth: refuse to write the merged output anywhere outside this directory.',
@@ -220,7 +220,68 @@ export const TOP_LEVEL_OPTIONAL_BLOCKS: ReadonlyArray<OptionalFieldBlock> = [
       '  description: A description for the merged document.',
     ].join('\n'),
   },
-];
+] as const satisfies ReadonlyArray<OptionalFieldBlock>;
+
+/**
+ * Top-level `Configuration` fields written ACTIVE (uncommented) rather than
+ * as a suggestion (proposal 39), because for these two specifically, on is
+ * what a first-time user scanning a directory of specs almost always wants,
+ * and it costs nothing for the config `init` itself just generated: every
+ * input `init` found came from scanning `.` only (no recursion -- see
+ * `isScannable`), so `inputRoot: .` can never reject anything `init` itself
+ * produced. They are paired deliberately, not two independent defaults:
+ * turning `resolveExternalReferences` on alone would widen the local-file
+ * read surface with nothing bounding it, exactly the gap proposal 38's
+ * `inputRoot` exists to close.
+ *
+ * Rendered via {@link renderActiveBlock}, not {@link renderCommentedBlock} --
+ * same shape as {@link OptionalFieldBlock}, but `yaml` is written out as-is,
+ * not commented, with `explanation` still commented above it as a `# ` block.
+ */
+export const ACTIVE_TOP_LEVEL_DEFAULTS = [
+  {
+    name: 'resolveExternalReferences',
+    explanation: [
+      "Follows $refs into files these inputs don't declare, and files those pull",
+      "in, however many deep -- so a $ref like '../common/Errors.yml#/...' just",
+      "works without listing every file it touches in 'inputs'. Paired below",
+      'with inputRoot, which bounds every local file this can reach to \'.\' --',
+      "note that bound is local files only, so a $ref inside a remote (URL) input",
+      "isn't restricted the same way. Set to false to turn this off.",
+    ].join('\n'),
+    yaml: 'resolveExternalReferences: true',
+  },
+  {
+    name: 'inputRoot',
+    explanation: [
+      'Defence in depth for the setting above: refuses to read any local file --',
+      'declared or discovered -- from outside this directory. Already covers',
+      "everything init found here; only needs widening if you add an inputFile,",
+      "or a discovered $ref, that reaches outside '.'.",
+    ].join('\n'),
+    yaml: 'inputRoot: .',
+  },
+] as const satisfies ReadonlyArray<OptionalFieldBlock>;
+
+/**
+ * Compile-time guard (proposal 39 §2.2): if `Configuration` gains a new
+ * optional top-level field that nobody adds to either
+ * {@link TOP_LEVEL_OPTIONAL_BLOCKS} or {@link ACTIVE_TOP_LEVEL_DEFAULTS}
+ * above, this fails to typecheck instead of `init`'s output silently falling
+ * behind `Configuration` again the way it did for `resolveExternalReferences`
+ * and `inputRoot` themselves before this guard existed. `'inputs'` and
+ * `'output'` are excluded: they are required, not optional, and are always
+ * rendered directly rather than through either block list.
+ */
+type TopLevelOptionalConfigurationKey = Exclude<keyof Configuration, 'inputs' | 'output'>;
+type DeclaredTopLevelBlockName =
+  | (typeof TOP_LEVEL_OPTIONAL_BLOCKS)[number]['name']
+  | (typeof ACTIVE_TOP_LEVEL_DEFAULTS)[number]['name'];
+type _MissingTopLevelInitBlocks = Exclude<TopLevelOptionalConfigurationKey, DeclaredTopLevelBlockName>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- exists for its type error, not its value
+const _assertNoMissingTopLevelInitBlocks: _MissingTopLevelInitBlocks extends never
+  ? true
+  : ['Add a TOP_LEVEL_OPTIONAL_BLOCKS or ACTIVE_TOP_LEVEL_DEFAULTS entry in init-command.ts for:', _MissingTopLevelInitBlocks] = true;
 
 /**
  * `ConfigurationInputBase` and `DisputeV2`'s optional fields (data.ts), in
@@ -288,6 +349,18 @@ function renderCommentedBlock(block: OptionalFieldBlock, indent: string): string
   return lines.join('\n');
 }
 
+/**
+ * Renders one {@link ACTIVE_TOP_LEVEL_DEFAULTS} entry as an ACTIVE
+ * (uncommented) top-level setting -- `explanation` is still commented above
+ * it, `yaml` is not. Always top-level: unlike {@link renderCommentedBlock},
+ * takes no indent, since nothing currently in {@link ACTIVE_TOP_LEVEL_DEFAULTS}
+ * is per-input.
+ */
+function renderActiveBlock(block: OptionalFieldBlock): string {
+  const explanationLines = block.explanation.split('\n').map(line => `# ${line}`);
+  return [...explanationLines, block.yaml].join('\n');
+}
+
 /** Indent of a second-or-later key inside an `inputs` list item, matching js-yaml's own 2-space nesting. */
 const PER_INPUT_BLOCK_INDENT = '    ';
 
@@ -298,9 +371,9 @@ function yamlScalar(value: string): string {
 
 /**
  * Renders the full file `init` writes: real `inputs`/`output`, computed
- * exactly as {@link buildConfiguration} does, interleaved with every
- * optional field from `Configuration` and `ConfigurationInputBase`,
- * commented out.
+ * exactly as {@link buildConfiguration} does, {@link ACTIVE_TOP_LEVEL_DEFAULTS}
+ * turned on (proposal 39), and every other optional field from
+ * `Configuration` and `ConfigurationInputBase` commented out.
  *
  * Not built by serialising a `Configuration` object -- js-yaml's `dump()`
  * has no notion of a comment attached to a key, so comments cannot survive
@@ -324,18 +397,22 @@ export function renderInitYaml(chosenInputs: ReadonlyArray<string>, output: stri
     return [line, `${PER_INPUT_BLOCK_INDENT}# Per-input options: see the commented block under the first input above -- the same fields apply here.`];
   });
 
+  const activeLines = ACTIVE_TOP_LEVEL_DEFAULTS.flatMap(block => ['', renderActiveBlock(block)]);
   const topLevelLines = TOP_LEVEL_OPTIONAL_BLOCKS.flatMap(block => ['', renderCommentedBlock(block, '')]);
 
   return [
     '# openapi-merge-cli configuration.',
     '#',
-    "# Everything from here down to 'output:' is required; everything after it",
-    '# is optional and commented out. Uncomment a block to turn it on.',
+    "# Everything from here down to 'output:' is required. A couple of settings",
+    '# right after it are turned on by default -- see their own comments below --',
+    '# and everything after that is optional and commented out. Uncomment a block',
+    '# to turn it on.',
     '# Full documentation: https://github.com/robertmassaioli/openapi-merge/wiki/README',
     '',
     'inputs:',
     ...inputLines,
     `output: ${yamlScalar(output)}`,
+    ...activeLines,
     ...topLevelLines,
     '',
   ].join('\n');

--- a/packages/openapi-merge-cli/src/init-command.ts
+++ b/packages/openapi-merge-cli/src/init-command.ts
@@ -170,8 +170,19 @@ export type OptionalFieldBlock = {
   name: string;
   /** One-line (or one-line-per-sub-field) explanation, condensed from the TSDoc in data.ts. */
   explanation: string;
-  /** The field's YAML, uncommented, at zero indentation. */
+  /** The field's default/primary example, uncommented, at zero indentation. */
   yaml: string;
+  /**
+   * Other mutually-exclusive values for this same field (an enum, or a
+   * discriminated union like `dispute`'s prefix/suffix), each shown as its
+   * own additional commented example line right after `yaml` -- so every
+   * choice is visible without checking the README, and picking one means
+   * uncommenting the line you want rather than editing a value by hand.
+   * Each entry, alone, must be exactly as valid a standalone replacement
+   * for `yaml` as `yaml` itself -- covered by the same per-block validity
+   * test `yaml` gets (`init-command.test.ts`).
+   */
+  alternatives?: ReadonlyArray<string>;
 };
 
 /**
@@ -191,19 +202,33 @@ export const TOP_LEVEL_OPTIONAL_BLOCKS = [
     yaml: [
       'formatting:',
       '  indent:',
-      '    style: spaces # spaces | tabs (tabs are JSON-output only -- YAML forbids tab indentation)',
+      '    style: spaces # (default) width below sets how many spaces per level',
       '    width: 2',
     ].join('\n'),
+    alternatives: [
+      [
+        'formatting:',
+        '  indent:',
+        '    style: tabs # JSON output only -- YAML forbids tab indentation',
+      ].join('\n'),
+    ],
   },
   {
     name: 'serversStrategy',
     explanation: "How to combine the top-level 'servers' array across inputs.",
-    yaml: 'serversStrategy: first # first (default, keep only the first input\'s servers) | concat (keep every input\'s, deduplicated)',
+    yaml: "serversStrategy: first  # (default) keep only the first input's servers, discard the rest",
+    alternatives: [
+      'serversStrategy: concat # keep every input\'s servers, deduplicated by URL',
+    ],
   },
   {
     name: 'securitySchemesStrategy',
     explanation: 'How to combine components.securitySchemes across inputs.',
-    yaml: 'securitySchemesStrategy: merge # merge (default, rename clashes) | first (drop the rest) | error (fail on a clash)',
+    yaml: 'securitySchemesStrategy: merge # (default) combine, renaming clashing definitions',
+    alternatives: [
+      "securitySchemesStrategy: first # take the first input's schemes, drop the rest",
+      'securitySchemesStrategy: error # fail if two inputs define the same scheme name differently',
+    ],
   },
   {
     name: 'pruneUnusedComponents',
@@ -321,7 +346,12 @@ export const PER_INPUT_OPTIONAL_BLOCKS: ReadonlyArray<OptionalFieldBlock> = [
   {
     name: 'duplicatePathHandling',
     explanation: 'What to do when this input declares a path another input already contributed.',
-    yaml: 'duplicatePathHandling: error # error (default) | skip-later | prefer-later | merge-operations',
+    yaml: 'duplicatePathHandling: error            # (default) fail the merge',
+    alternatives: [
+      'duplicatePathHandling: skip-later       # keep the definition already present, drop this one',
+      'duplicatePathHandling: prefer-later     # replace the definition already present with this one',
+      "duplicatePathHandling: merge-operations # combine when methods don't overlap and path-level fields agree",
+    ],
   },
   {
     name: 'tag',
@@ -334,18 +364,35 @@ export const PER_INPUT_OPTIONAL_BLOCKS: ReadonlyArray<OptionalFieldBlock> = [
   },
   {
     name: 'dispute',
-    explanation: "If a component name clashes with another input's, disambiguate with this prefix (or 'suffix' instead of 'prefix').",
+    explanation: "If a component name clashes with another input's, disambiguate with this prefix (or use a suffix instead).",
     yaml: [
       'dispute:',
       '  prefix: serviceA_',
       '  alwaysApply: false',
     ].join('\n'),
+    alternatives: [
+      [
+        'dispute:',
+        '  suffix: _serviceA',
+        '  alwaysApply: false',
+      ].join('\n'),
+    ],
   },
 ];
 
-/** Renders one {@link OptionalFieldBlock} as commented-out lines at the given indent. */
+/**
+ * Renders one {@link OptionalFieldBlock} as commented-out lines at the given
+ * indent: the explanation, `yaml` (the default), then every entry in
+ * `alternatives` -- each an equally valid, equally commented choice, so
+ * picking one is "uncomment this line instead of that one," never "edit
+ * this value by hand."
+ */
 function renderCommentedBlock(block: OptionalFieldBlock, indent: string): string {
-  const lines = [`${indent}# ${block.explanation}`, ...block.yaml.split('\n').map(line => `${indent}# ${line}`)];
+  const lines = [
+    `${indent}# ${block.explanation}`,
+    ...block.yaml.split('\n').map(line => `${indent}# ${line}`),
+    ...(block.alternatives ?? []).flatMap(alt => alt.split('\n').map(line => `${indent}# ${line}`)),
+  ];
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## Summary

Implements [proposal 39](ai-planning/39-proposal-init-convenience-defaults.md): `openapi-merge-cli init` now writes `resolveExternalReferences: true` and `inputRoot: .` as **active** settings, not commented-out suggestions like every other optional field.

- Every other optional `Configuration` field was assessed against the same bar (proposal 39 §3) and rejected — either it already matches the library's own default (writing it explicitly is inert), has no universal correct value (`info`, per-input fields), or is actively destructive with no offsetting benefit (`pruneUnusedComponents`). `outputRoot` is deliberately left out of scope, flagged for a separate decision.
- The two are paired deliberately, not two independent defaults: turning on `resolveExternalReferences` alone would widen the local-file read surface with nothing bounding it — exactly the gap [proposal 38](ai-planning/38-proposal-input-root-containment.md) (`inputRoot`, #144) exists to close. Pairing it with `inputRoot: .` costs nothing for what `init` itself generates, since `init` only ever scans `.` non-recursively.
- Fixed a live, present-tense gap found along the way: `resolveExternalReferences` and `inputRoot` were completely absent from `init`'s "every optional field shown" list, undetected because the existing coverage test compared two hand-maintained lists against each other rather than against `Configuration`'s actual keys. Added a compile-time guard (`as const satisfies` + a type-level `Exclude` check) so a future field can't silently repeat this — verified directly by temporarily renaming an entry and confirming `typecheck` fails, naming the exact missing field.

### ⚠️ One behaviour change worth a second look before merging (proposal 39 §9.5)

A `$ref` to a file **one directory up** — a common "shared components live in `../common/`" layout — used to fail silently (ref left unresolved, `ExitCode.Success`, output written) because discovery never ran. With both new defaults on, discovery now reaches the file, and `inputRoot` correctly refuses to read it: the merge now hard-fails instead (`ExitCode.ErrorUnsafeInputPath`, **no output written at all**).

This isn't a bug — it's `inputRoot`'s hard-fail-on-violation behaviour working exactly as designed in #144, and arguably loud-and-wrong beats quiet-and-wrong. But it's a genuine behaviour change caused specifically by turning `resolveExternalReferences` on by *default*, for what's likely the single most common way someone extends a freshly `init`-generated project. Traced, verified against the real CLI binary, and pinned with a regression test — see §9.5 in the proposal for the full writeup. Flagging it here explicitly rather than leaving it as a footnote in a generated comment.

## Stacked on #144 — should be conflict-free once that merges

This branch contains #144's commits (`inputRoot`) as real ancestors, via an explicit merge — the repo only allows regular merge commits (squash and rebase are both disabled, confirmed via the GitHub API), so once #144 lands the merge-base moves forward and this PR's diff should collapse to just proposal 39's changes automatically, no conflict. **Until #144 merges, this PR's diff will look large** (it includes #144's ~950 lines) — that's expected, not new work to review here.

## Test plan

- [x] `bun test` — 682 tests pass (up from 677 before this branch), including 3 new rendering tests for the active/commented distinction, 1 new coverage test, 1 new CLI end-to-end test proving the pairing actually resolves a real `$ref` into an undeclared subdirectory with zero edits to `init`'s own output, and 1 new CLI test pinning the §9.5 behaviour change
- [x] Lint and typecheck clean in both packages; `init-command.ts` and `index.ts` both at 100% function/line coverage
- [x] Manually verified the compile-time exhaustiveness guard by temporarily renaming a field and confirming `typecheck` fails with the correct missing-field name
- [x] Manually ran `openapi-merge-cli init` and the merge against its own unmodified output, both for the happy path and the §9.5 behaviour-change case

🤖 Generated with [Claude Code](https://claude.com/claude-code)