### PR TITLE
feat(cli): create missing output directories

### DIFF
--- a/ai-planning/42-proposal-create-output-directories.md
+++ b/ai-planning/42-proposal-create-output-directories.md
@@ -1,0 +1,227 @@
+# Implementation Proposal: Create Missing Output Directories
+
+**Status:** Proposal
+**Type:** CLI feature, improving on [PR #88](https://github.com/robertmassaioli/openapi-merge/pull/88)
+**Scope:** `packages/openapi-merge-cli/src/index.ts`, `exit-codes.ts`, README
+**Date:** 2026-08-02
+
+---
+
+## 0. TL;DR
+
+[PR #88](https://github.com/robertmassaioli/openapi-merge/pull/88) adds four
+lines to `writeOutput()`:
+
+```typescript
+const outputDir = path.dirname(outputFullPath);
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir);
+}
+```
+
+The idea is right — the CLI's own README example (`"output":
+"./dist/service.output.swagger.json"`) already assumes a subdirectory the
+tool does not create, and today's test suite proves the gap: `cli-output-
+safety.test.ts`'s "succeeds when the output stays inside outputRoot" case has
+to `fs.mkdirSync(path.join(cli.dir(), 'dist'))` itself before running the
+CLI, because the CLI won't. The mechanism has three problems, all invisible
+at the size of change in #88:
+
+1. **`fs.mkdirSync(dir)` is not recursive.** It creates exactly one missing
+   directory. `output: "./a/b/c/out.json"` where none of `a`, `b`, `c` exist
+   throws `ENOENT: no such file or directory, mkdir '.../a'` — actually,
+   worse: it throws trying to create `c` inside a non-existent `b` inside a
+   non-existent `a`, i.e. it still fails for the exact multi-level case a
+   user is most likely to hit (`./dist/output.json` when `dist/` itself
+   sits inside a package that hasn't been scaffolded yet).
+2. **The failure is uncaught.** Any `mkdirSync`/`writeFileSync` error —
+   permission denied, a path component that's an existing *file* rather
+   than a directory, a read-only filesystem — propagates out of `main()` as
+   a raw exception with a Node stack trace, exits `4`
+   (`ExitCode.ErrorUncaught`, "please report this as a bug in
+   openapi-merge"), and tells the user nothing about what to fix. Every
+   other failure mode this CLI has gets a specific exit code and a
+   one-line, actionable message; this one wouldn't.
+3. **No test coverage.** #88 ships with none, so the recursive case and the
+   error path above are both unverified.
+
+This proposal keeps the idea — auto-create the output directory, no new
+config flag — and fixes all three: `{ recursive: true }`, a dedicated exit
+code with a clear message, and the tests that would have caught 1 and 2.
+
+## 1. Current Behaviour
+
+`writeOutput()` (`packages/openapi-merge-cli/src/index.ts:361`) calls
+`fs.writeFileSync(outputFullPath, fileContents)` directly. If any directory
+in `outputFullPath`'s ancestry is missing, this throws `ENOENT`, which is not
+caught anywhere in `main()` — it becomes `ExitCode.ErrorUncaught` via the
+top-level handler in `cli.ts`.
+
+The check that runs immediately before it, `assertOutputContained()`
+(`path-resolution.ts:128`), already walks up from `outputFullPath` to find
+the closest *existing* ancestor, specifically because it has to handle the
+"user is writing to a new subdirectory" case for its own containment
+check (§3.2 below leans on this same walk).
+
+## 2. Design
+
+### 2.1 Recursive creation, after the containment check
+
+```typescript
+function writeOutput(outputFullPath: string, outputSchema: OpenApiDocument, indent: Indent = DEFAULT_INDENT): void {
+  const fileContents = isYamlExtension(outputFullPath)
+    ? dumpAsYaml(outputSchema, indent)
+    : JSON.stringify(outputSchema, null, indentToJsonStringifyArg(indent));
+
+  fs.mkdirSync(path.dirname(outputFullPath), { recursive: true });
+  fs.writeFileSync(outputFullPath, fileContents);
+}
+```
+
+`{ recursive: true }` fixes problem 1 outright — it creates every missing
+ancestor in one call — and is also a no-op (no throw) when the directory
+already exists, so the `fs.existsSync` guard in #88 was never needed even
+for the one-level case.
+
+This must run **after** `assertOutputContained` in `main()`, which it already
+does positionally (`writeOutput` is called at line 506, well after the
+containment check at line 492-501). That ordering is load-bearing, not
+incidental: `assertOutputContained` proves `outputFullPath` resolves inside
+`outputRoot` *before* anything on disk changes. Every directory
+`mkdirSync(..., { recursive: true })` would create is an ancestor of that
+already-validated path and a descendant of the already-validated closest
+existing ancestor — so it cannot land outside `outputRoot` by construction.
+No new call to the containment check is needed for the directories
+themselves.
+
+(The same defense-in-depth caveat that already applies to `writeFileSync`
+today applies here unchanged: this is a check against a less-trusted
+*configuration*, not a defense against a concurrent attacker racing the
+filesystem between the check and the write. Introducing `mkdirSync` in
+between doesn't widen that gap — nothing it creates is attacker-influenced
+that wasn't already covered by the realpath walk in `resolveContainment`.)
+
+### 2.2 A dedicated exit code instead of falling through to `ErrorUncaught`
+
+Every other failure category in this CLI — bad config, bad input, merge
+conflict, unsafe path, bad OpenAPI version — gets its own `ExitCode` and a
+clean one-line message (see `exit-codes.ts`). Directory creation failing
+(permissions, a path component that's an existing file, a read-only
+filesystem) is exactly that kind of user-actionable, non-bug failure, so it
+should not masquerade as `ErrorUncaught`, which explicitly tells users
+"please report it with the stack trace" — the wrong message for "you don't
+have write permission to `/etc`".
+
+New code, appended per the file's own numbering rule:
+
+```typescript
+/**
+ * The output directory could not be created.
+ *
+ * Fires when a directory in the resolved output path's ancestry is missing
+ * and creating it fails -- most commonly a permissions error, a read-only
+ * filesystem, or a path component that already exists as a regular file
+ * (e.g. `output: './build.json/nested/out.json'` where `build.json` is a
+ * file). Distinguished from `ErrorUnsafePath`: that code means the path was
+ * refused outright; this one means it was allowed and the filesystem then
+ * refused to cooperate.
+ */
+ErrorCreatingOutputDirectory = 11,
+```
+
+`writeOutput`'s `mkdirSync` call is wrapped narrowly (not the
+`writeFileSync` that follows it, which keeps its own uncaught-exception
+behaviour — a write failure after the directory exists is a different,
+rarer class of problem this proposal isn't trying to categorize):
+
+```typescript
+try {
+  fs.mkdirSync(path.dirname(outputFullPath), { recursive: true });
+} catch (e) {
+  const message = e instanceof Error ? e.message : String(e);
+  throw new OutputDirectoryCreationError(path.dirname(outputFullPath), message);
+}
+```
+
+with `main()` catching `OutputDirectoryCreationError` the same way it
+already catches `OutputOutsideRootError`:
+
+```typescript
+} catch (e) {
+  if (e instanceof OutputDirectoryCreationError) {
+    console.error(e.message);
+    process.exit(ExitCode.ErrorCreatingOutputDirectory);
+    return;
+  }
+  throw e;
+}
+```
+
+`OutputDirectoryCreationError` lives in `path-resolution.ts` alongside
+`OutputOutsideRootError`/`InputOutsideRootError`, matching the file's
+existing pattern of one typed error per failure class with a
+pre-formatted, user-facing `.message`.
+
+### 2.3 No new configuration flag
+
+#88's framing — "many tools allow writing to non-existing directories" — is
+right that this should be the default, not opt-in. There's no safety
+argument for gating it behind a flag: §2.1 shows the directories created are
+already bounded by `outputRoot`/`--restrict-output-to` when those are set,
+and when neither is set the CLI already writes anywhere on the filesystem
+the user points it at — auto-creating a directory in that same, already-
+unrestricted case adds no new capability. Keeping this un-flagged also
+means the fix is a patch release, not a config-schema change.
+
+## 3. Testing Strategy
+
+Extends `cli-output-safety.test.ts`, next to the existing outputRoot
+coverage, plus one addition to `cli-output.test.ts` for the plain
+happy-path case:
+
+| Case | Asserts |
+| --- | --- |
+| `output: './dist/output.json'`, `dist/` does not exist | Exit `Success`; `dist/output.json` exists — replaces the manual `fs.mkdirSync` the current "succeeds when the output stays inside outputRoot" test does for itself |
+| `output: './a/b/c/output.json'`, none of `a`/`b`/`c` exist | Exit `Success`; the full nested path is created — the case #88's non-recursive `mkdirSync` cannot handle |
+| `output` directory already exists | Exit `Success`, unchanged — proves the recursive call is a safe no-op |
+| A path component is an existing **file**, e.g. `output: './notadir/output.json'` where `notadir` is a file | Exit `ErrorCreatingOutputDirectory`; stderr names the offending path and the underlying reason |
+| Nested output still honours `outputRoot` | `output: '../escaped/output.json'` with `outputRoot: '.'` still exits `ErrorUnsafePath`, proving directory creation doesn't run before or bypass the existing containment check |
+
+The last row is the regression test for §2.1's ordering argument — it's the
+one a reviewer should look for first, since silently reordering the
+`mkdirSync` ahead of `assertOutputContained` is the most likely way this
+proposal itself could be implemented wrong later.
+
+## 4. Documentation
+
+- `packages/openapi-merge-cli/README.md`: a one-line note near the `output`
+  field description — missing directories in `output` are created
+  automatically (mirroring how `outputRoot`/`--restrict-output-to` are
+  documented immediately after it).
+- `exit-codes.ts`'s doc comment table gets its new row; `AGENTS.md`'s exit
+  code references, if any, updated to match (checked: none currently
+  enumerate individual codes, so no change needed there beyond the new code
+  existing).
+
+## 5. Effort
+
+| Task | Effort |
+| --- | --- |
+| `ErrorCreatingOutputDirectory` exit code + `OutputDirectoryCreationError` | 30 min |
+| `writeOutput`/`main()` changes | 30 min |
+| Tests (table in §3) | 1 hour |
+| README | 15 min |
+| **Total** | **~2.5 hours** |
+
+## 6. Non-goals
+
+- A config flag to opt out of auto-creation. Nobody has asked for that, and
+  §2.3 argues it adds no safety value given the existing containment model.
+- Creating the directory for the `outputRoot`/`--restrict-input-to` flags
+  themselves if *those* don't exist — they're boundaries the user asserts
+  already exist (or don't, in which case containment trivially holds/fails
+  against their lexical path); auto-creating a jail the user named but
+  never made would be a much larger behavioural change than "the output
+  file's own directory."
+- Retrying or otherwise handling transient filesystem errors. One attempt,
+  clean failure, matching every other exit path in this CLI.

--- a/ai-planning/README.md
+++ b/ai-planning/README.md
@@ -69,6 +69,7 @@ dependency health, build migrations. Named by topic rather than by issue number.
 | [`38-proposal-input-root-containment.md`](38-proposal-input-root-containment.md) | ✅ `inputRoot` — a read-side containment boundary mirroring `outputRoot`, closing the gap proposal 37 left open |
 | [`39-proposal-init-convenience-defaults.md`](39-proposal-init-convenience-defaults.md) | ✅ `resolveExternalReferences` + `inputRoot` turned on by default in `init`'s output |
 | [`41-proposal-release-gated-npm-publish.md`](41-proposal-release-gated-npm-publish.md) | `npm-publish.yml` triggers on a published GitHub Release instead of every push to `main` |
+| [`42-proposal-create-output-directories.md`](42-proposal-create-output-directories.md) | Auto-create missing output directories, improving on PR #88's non-recursive, uncaught-exception approach |
 | [`issue-triage-value-vs-effort.md`](issue-triage-value-vs-effort.md) | Value/effort scoring of every open issue; the index into `issues/` |
 | [`spec-edge-case-findings.md`](spec-edge-case-findings.md) | Divergences between the merge and the spec, found by edge-case testing |
 | [`bun-tsgo-migration-build-timings.md`](bun-tsgo-migration-build-timings.md) | Measured build timings for the Bun + tsgo migration |

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -255,6 +255,14 @@ configuration file. Absolute paths (e.g. `/tmp/merged.yaml`,
 `C:\build\out.json`) are used as-is. This means you can safely write the
 merged spec into directories like `/tmp` or `/var/build/...` from CI.
 
+Any directory in `output`'s path that doesn't exist yet is created
+automatically (including multiple missing levels at once), so
+`"output": "./dist/service.output.swagger.json"` works even on a project
+where `dist/` hasn't been created yet. If a directory can't be created --
+a permissions error, or a path component that's already a regular file --
+the CLI exits with `ErrorCreatingOutputDirectory` (see [Exit
+codes](#exit-codes)) rather than a raw stack trace.
+
 ## Cross-document `$ref`s
 
 If one input's `$ref` points at *another file* rather than somewhere inside
@@ -367,6 +375,7 @@ branch on them.
 | `8` | An `inputURL` responded with some other non-2xx status |
 | `9` | An input declared an unsupported OpenAPI version, or the inputs disagreed |
 | `10` | A local file read escaped `inputRoot` / `--restrict-input-to` |
+| `11` | The output directory could not be created (permissions, read-only filesystem, or a path component that's an existing file) |
 
 Codes `6`–`8` are separate from `2` on purpose. `2` means an input could not be
 obtained at all — a missing file, an unreachable host, content that parses as

--- a/packages/openapi-merge-cli/src/__tests__/cli-output-safety.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/cli-output-safety.test.ts
@@ -25,9 +25,8 @@ describe('main - output path safety', () => {
     expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafePath);
   });
 
-  it('succeeds when the output stays inside outputRoot', async () => {
+  it('succeeds when the output stays inside outputRoot, creating the missing directory', async () => {
     cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
-    fs.mkdirSync(path.join(cli.dir(), 'dist'));
     const config = cli.writeJson('openapi-merge.json', {
       inputs: [{ inputFile: './a.json' }],
       output: './dist/output.json',
@@ -58,5 +57,40 @@ describe('main - output path safety', () => {
     });
 
     expect(await cli.run('-c', config, '--restrict-output-to', './allowed')).toBe(ExitCode.Success);
+  });
+
+  it('creates every missing directory in a multi-level output path (proposal 42)', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './a/b/c/output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.Success);
+    expect(cli.exists('a/b/c/output.json')).toBe(true);
+  });
+
+  it('does not create any directory when the output escapes outputRoot (proposal 42)', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: '../escaped/nested/output.json',
+      outputRoot: '.',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorUnsafePath);
+    expect(fs.existsSync(path.join(cli.dir(), '..', 'escaped'))).toBe(false);
+  });
+
+  it('exits ErrorCreatingOutputDirectory when a path component is an existing file (proposal 42)', async () => {
+    cli.writeJson('a.json', oas({ '/a': getPath('getA') }));
+    cli.write('notadir', 'this is a file, not a directory');
+    const config = cli.writeJson('openapi-merge.json', {
+      inputs: [{ inputFile: './a.json' }],
+      output: './notadir/nested/output.json',
+    });
+
+    expect(await cli.run('-c', config)).toBe(ExitCode.ErrorCreatingOutputDirectory);
+    expect(cli.stderr().some(line => line.includes('notadir'))).toBe(true);
   });
 });

--- a/packages/openapi-merge-cli/src/__tests__/exit-codes.test.ts
+++ b/packages/openapi-merge-cli/src/__tests__/exit-codes.test.ts
@@ -20,6 +20,7 @@ const documented: { [member: string]: number } = {
   ErrorInputUrlUnexpectedStatus: 8,
   ErrorOpenApiVersion: 9,
   ErrorUnsafeInputPath: 10,
+  ErrorCreatingOutputDirectory: 11,
 };
 
 describe('ExitCode contract', () => {

--- a/packages/openapi-merge-cli/src/data.ts
+++ b/packages/openapi-merge-cli/src/data.ts
@@ -255,6 +255,8 @@ export type Configuration = {
    * The output file to put the results in. If you use the .yml or .yaml extension then the schema will be output
    * in YAML format, otherwise, it will be output in JSON format.
    *
+   * Any missing directories in this path are created automatically.
+   *
    * @minLength 1
    */
   output: string;

--- a/packages/openapi-merge-cli/src/exit-codes.ts
+++ b/packages/openapi-merge-cli/src/exit-codes.ts
@@ -22,6 +22,7 @@
  * | 8         | ExitCode.ErrorInputUrlUnexpectedStatus | `inputURL` non-2xx, neither 4xx nor 5xx  |
  * | 9         | ExitCode.ErrorOpenApiVersion           | Input version unsupported or inconsistent |
  * | 10        | ExitCode.ErrorUnsafeInputPath          | A local file read escaped `inputRoot`    |
+ * | 11        | ExitCode.ErrorCreatingOutputDirectory  | Could not create the output directory   |
  */
 export enum ExitCode {
   /**
@@ -192,4 +193,22 @@ export enum ExitCode {
    * comparing, so a symlink pointing out of the jail does not defeat it.
    */
   ErrorUnsafeInputPath = 10,
+
+  /**
+   * A directory in the resolved output path's ancestry was missing and could
+   * not be created.
+   *
+   * Fires after the `outputRoot`/`--restrict-output-to` containment check has
+   * already passed -- this is not a rejection of *where* the output would go,
+   * it is the filesystem refusing to cooperate once that location was
+   * allowed. Most commonly a permissions error, a read-only filesystem, or a
+   * path component that already exists as a regular file (e.g. `output:
+   * './build.json/nested/out.json'` where `build.json` is a file, not a
+   * directory).
+   *
+   * Distinguished from {@link ExitCode.ErrorUnsafePath}: that code means the
+   * path was never going to be attempted; this one means it was attempted and
+   * the filesystem said no.
+   */
+  ErrorCreatingOutputDirectory = 11,
 }

--- a/packages/openapi-merge-cli/src/index.ts
+++ b/packages/openapi-merge-cli/src/index.ts
@@ -18,7 +18,7 @@ import { Swagger } from "@atlassian/atlassian-openapi";
 import { dump as dumpYaml } from 'js-yaml';
 import { readFileAsString, readYamlOrJSON } from "./file-loading";
 import { ExitCode } from "./exit-codes";
-import { assertInputContained, assertOutputContained, InputOutsideRootError, OutputOutsideRootError, resolveConfigPath } from "./path-resolution";
+import { assertInputContained, assertOutputContained, InputOutsideRootError, OutputDirectoryCreationError, OutputOutsideRootError, resolveConfigPath } from "./path-resolution";
 import { discoverExternalDocuments, DocumentReference, fileInputIdentity, urlInputIdentity } from "./external-reference-discovery";
 import { indentToJsonStringifyArg, indentToYamlArg } from "./formatting";
 import { DEFAULT_INDENT, Indent } from "./data";
@@ -363,6 +363,17 @@ function writeOutput(outputFullPath: string, outputSchema: OpenApiDocument, inde
     ? dumpAsYaml(outputSchema, indent)
     : JSON.stringify(outputSchema, null, indentToJsonStringifyArg(indent));
 
+  // Runs after assertOutputContained() has already approved outputFullPath
+  // (proposal 42) -- every directory this creates is an ancestor of an
+  // already-validated path, so it cannot land outside outputRoot.
+  const outputDir = path.dirname(outputFullPath);
+  try {
+    fs.mkdirSync(outputDir, { recursive: true });
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
+    throw new OutputDirectoryCreationError(outputDir, reason);
+  }
+
   fs.writeFileSync(outputFullPath, fileContents);
 }
 
@@ -483,8 +494,16 @@ export async function main(): Promise<void> {
 
   logger.log(`## Inputs merged, writing the results out to '${outputFullPath}'`);
 
-
-  writeOutput(outputFullPath, mergeResult.output, config.formatting?.indent);
+  try {
+    writeOutput(outputFullPath, mergeResult.output, config.formatting?.indent);
+  } catch (e) {
+    if (e instanceof OutputDirectoryCreationError) {
+      console.error(e.message);
+      process.exit(ExitCode.ErrorCreatingOutputDirectory);
+      return;
+    }
+    throw e;
+  }
 
   logger.log(`## Finished writing to '${outputFullPath}'`);
 }

--- a/packages/openapi-merge-cli/src/path-resolution.ts
+++ b/packages/openapi-merge-cli/src/path-resolution.ts
@@ -46,6 +46,29 @@ export class OutputOutsideRootError extends Error {
 }
 
 /**
+ * Error thrown when a directory in the resolved output path's ancestry is
+ * missing and `fs.mkdirSync(dir, { recursive: true })` fails to create it --
+ * a permissions error, a read-only filesystem, or a path component that
+ * already exists as a regular file rather than a directory.
+ *
+ * Raised strictly after {@link assertOutputContained} has already approved
+ * the path (proposal 42): this is the filesystem refusing to cooperate with
+ * an already-allowed location, not a rejection of the location itself. Kept
+ * as its own error/exit-code pair for the same reason `OutputOutsideRootError`
+ * is: a script branching on exit codes needs "the path was refused" and "the
+ * path was allowed but couldn't be created" to stay distinguishable.
+ */
+export class OutputDirectoryCreationError extends Error {
+  public readonly directory: string;
+
+  constructor(directory: string, reason: string) {
+    super(`Could not create output directory '${directory}': ${reason}`);
+    this.name = 'OutputDirectoryCreationError';
+    this.directory = directory;
+  }
+}
+
+/**
  * Error thrown when the (defence-in-depth) `inputRoot` safety knob is set
  * (proposal 38) and a local file the CLI would read -- a declared
  * `inputFile` or one discovered via `resolveExternalReferences` -- escapes


### PR DESCRIPTION
## Summary
- Supersedes #88. Same idea (auto-create the output directory), but recursive, correctly ordered relative to the existing `outputRoot`/`--restrict-output-to` containment check, and with a dedicated exit code instead of an uncaught exception.
- `writeOutput()` now runs `fs.mkdirSync(dir, { recursive: true })`, so multi-level missing paths (`./a/b/c/out.json`) work, not just one missing level.
- New `ExitCode.ErrorCreatingOutputDirectory` (`11`) + `OutputDirectoryCreationError`, for when directory creation itself fails (permissions, read-only filesystem, a path component that's an existing file) -- matches every other failure class in this CLI instead of falling through to the generic uncaught-exception code.
- Directory creation happens strictly after `assertOutputContained` approves the resolved output path, so everything created is provably inside `outputRoot` by construction.
- Full design/rationale, including why no new config flag is needed, in `ai-planning/42-proposal-create-output-directories.md`.

## Test plan
- [x] New tests: multi-level directory creation, existing "stays inside outputRoot" test now proves auto-creation rather than pre-creating the dir itself, a regression test proving directory creation can't run before/instead of the containment check, and the file-as-directory-component failure case exiting `11`.
- [x] Full test suite (694 tests across both packages) passes, 100% line coverage held on `index.ts` and `path-resolution.ts`.
- [x] `bun run lint` (ESLint + typecheck) passes in both packages.
- [x] JSON Schema regenerated to reflect the updated `output` field description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)