### PR TITLE
docs: add a VitePress documentation microsite, deployed to GitHub Pages (issue #149, option 3)

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy Documentation Site
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/docs-site/**
+      - packages/openapi-merge/src/**
+      - packages/openapi-merge/typedoc.json
+      - .github/workflows/docs-deploy.yml
+  # Lets the site be redeployed on demand from the Actions tab without an
+  # empty commit -- e.g. after enabling Pages for the first time.
+  workflow_dispatch:
+
+# Only one Pages deployment at a time; a second push while one is still
+# building queues behind it instead of racing it.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: 1.3.14
+    - run: bun install --frozen-lockfile
+    # Runs the library's TypeDoc generation (straight from src/, no build
+    # step needed first) into public/api/, then the VitePress production
+    # build. See packages/docs-site/package.json.
+    - run: bun run --cwd packages/docs-site build
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@v5
+    - name: Upload site artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: packages/docs-site/.vitepress/dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ the **MIT License**. Source is hosted at
 
 ```
 .
-├── .github/workflows/        # CI workflows: branch-test, npm-publish, codeql-analysis
+├── .github/workflows/        # CI workflows: branch-test, npm-publish, codeql-analysis, docs-deploy
 ├── .husky/pre-commit         # Husky pre-commit hook (runs `bun run lint`: eslint + typecheck)
 ├── scripts/publish-changed.sh # Publishes any workspace package whose version has changed
 ├── LICENSE                   # MIT
@@ -45,16 +45,24 @@ the **MIT License**. Source is hosted at
     ├── openapi-merge/        # Library package (published as `openapi-merge` on npm)
     │   ├── src/              # Library source
     │   ├── src/__tests__/    # bun:test suites for the library
+    │   ├── typedoc.json      # Generated API reference config (`bun run docs` -> docs-api/, gitignored)
     │   ├── bunfig.toml
     │   ├── tsconfig.json
     │   └── package.json
-    └── openapi-merge-cli/    # CLI package (published as `openapi-merge-cli` on npm)
-        ├── src/              # CLI source (entrypoint: `cli.ts` → `index.ts`)
-        ├── confluence.swagger.yaml   # Example OpenAPI input used for manual testing
-        ├── openapi-merge.test.json   # Example merge configuration
-        ├── bunfig.toml
-        ├── tsconfig.json         # Main project config (includes ambient `bun`/`node` types)
-        ├── tsconfig.schema.json  # Narrow config used only by `typescript-json-schema`
+    ├── openapi-merge-cli/    # CLI package (published as `openapi-merge-cli` on npm)
+    │   ├── src/              # CLI source (entrypoint: `cli.ts` → `index.ts`)
+    │   ├── confluence.swagger.yaml   # Example OpenAPI input used for manual testing
+    │   ├── openapi-merge.test.json   # Example merge configuration
+    │   ├── bunfig.toml
+    │   ├── tsconfig.json         # Main project config (includes ambient `bun`/`node` types)
+    │   ├── tsconfig.schema.json  # Narrow config used only by `typescript-json-schema`
+    │   └── package.json
+    └── docs-site/            # Documentation microsite (VitePress; not published to npm)
+        ├── index.md, guide/, cli/, library/  # Hand-written content -- source of truth for
+        │                                     # CLI/library reference detail (proposal 47)
+        ├── .vitepress/config.mts             # Nav/sidebar; `base: '/openapi-merge/'` for GitHub Pages
+        ├── public/api/        # Generated (gitignored): the library's TypeDoc reference, built into
+        │                      # the site at /api/ by `bun run build`'s build:api step
         └── package.json
 ```
 
@@ -281,6 +289,8 @@ fails the build rather than someone's pipeline.
 | `7`  | `ErrorInputUrlServerStatus` | An `inputURL` returned a 5xx status       |
 | `8`  | `ErrorInputUrlUnexpectedStatus` | `inputURL` non-2xx, neither 4xx nor 5xx |
 | `9`  | `ErrorOpenApiVersion`  | Input version unsupported, or inputs disagreed  |
+| `10` | `ErrorUnsafeInputPath` | A local file read escaped `inputRoot`          |
+| `11` | `ErrorCreatingOutputDirectory` | The output directory could not be created |
 
 The three URL-status codes are split by **responsibility**, so callers can
 branch on retryability: 4xx will fail identically on retry, 5xx may not. A
@@ -289,7 +299,8 @@ distinction is whether the server answered at all.
 
 Adding a code means: append the next unused integer (never re-use a retired
 one), add a row to the table in `exit-codes.ts`, add it to the `documented`
-list in `exit-codes.test.ts`, and update the tables here and in the CLI README.
+list in `exit-codes.test.ts`, and update the tables here, in the CLI README,
+and in the documentation site (`packages/docs-site/cli/exit-codes.md`).
 
 ### Build / Test / Lint / Generate
 
@@ -513,6 +524,28 @@ Required GitHub secrets:
 GitHub-provided CodeQL JavaScript scan: runs on push/PR against `main` and on a
 weekly cron (`28 21 * * 5`).
 
+### `.github/workflows/docs-deploy.yml`
+
+Builds and deploys the documentation microsite (`packages/docs-site`, see §2
+above) to GitHub Pages. Runs on push to `main` when `packages/docs-site/**`,
+`packages/openapi-merge/src/**`, `packages/openapi-merge/typedoc.json`, or the
+workflow file itself changes, or on demand via `workflow_dispatch`.
+
+1. `bun install --frozen-lockfile`
+2. `bun run --cwd packages/docs-site build` -- regenerates the library's
+   TypeDoc API reference straight from source into `public/api/`, then runs
+   the VitePress production build.
+3. `actions/configure-pages` + `actions/upload-pages-artifact` +
+   `actions/deploy-pages`, gated by `concurrency: { group: pages }` so two
+   pushes to `main` in quick succession queue rather than race.
+
+Requires **Settings → Pages → Source → GitHub Actions** to be enabled once;
+until then the workflow still runs and builds a deployable artifact, it just
+has nowhere to publish it. VitePress's `base` is hardcoded to `/openapi-merge/`
+(`packages/docs-site/.vitepress/config.mts`) to match where a project-repo
+Pages site with no custom domain serves from -- if a custom domain is ever
+configured instead, that needs to change to `/`.
+
 ---
 
 ## 7. Coding Conventions
@@ -604,7 +637,10 @@ When editing this repository, please follow these guidelines:
 | Regenerate the CLI Markdown docs           | `bun run --cwd packages/openapi-merge-cli gen-docs`            |
 | Run the CLI in dev mode                    | `bun run cli` (or `bun run --cwd packages/openapi-merge-cli start`) |
 | Run the CLI against the example config     | `bun run cli -- --config openapi-merge.test.json` |
+| Preview the documentation site locally     | `bun run --cwd packages/docs-site dev`                         |
+| Build the documentation site (incl. API reference) | `bun run --cwd packages/docs-site build`               |
 | Publish (CI only, on a published Release)   | Handled by `npm-publish.yml` → `scripts/publish-changed.sh` after version bump |
+| Deploy the docs site (CI only, on push to `main`) | Handled by `docs-deploy.yml`, once GitHub Pages is enabled |
 
 ---
 

--- a/ai-planning/issue-triage-value-vs-effort.md
+++ b/ai-planning/issue-triage-value-vs-effort.md
@@ -89,7 +89,8 @@ Higher is better; ties broken by lower effort first.
 | 26 | [#10](https://github.com/robertmassaioli/openapi-merge/issues/10) | Resolve / bundle external `$ref`s | 5 | 5 | **5** | Big Bet | ✅ [37-proposal-10-external-ref-bundling.md](issues/37-proposal-10-external-ref-bundling.md) (Option 2-refined) |
 | 27 | [#113](https://github.com/robertmassaioli/openapi-merge/issues/113) | Add support for OpenAPI 3.1.x | 5 | 5 | **5** | Big Bet | ✅ [26](issues/26-proposal-oas-phase1-version-checking.md)/[27](issues/27-proposal-oas-phase2-31-support.md)/[28](issues/28-proposal-oas-phase3-32-support.md) |
 | 28 | [#96](https://github.com/robertmassaioli/openapi-merge/issues/96) | OpenAPI 3.1 `webhook` support | 3 | 4 | **2** | Big Bet | ✅ Closed 2026-08-01, shipped with #113 |
-| 29 | [#149](https://github.com/robertmassaioli/openapi-merge/issues/149) | Improve repository documentation (microsite + playground) | 3 | 2 | **4** | Quick Win | 📝 [43-proposal-149-readme-and-api-docs.md](issues/43-proposal-149-readme-and-api-docs.md) (options 1–2 of 4; opened 2026-08-02, after this file's generation date) |
+| 29 | [#149](https://github.com/robertmassaioli/openapi-merge/issues/149) | Improve repository documentation (microsite + playground) | 3 | 2 | **4** | Quick Win | ✅ [43-proposal-149-readme-and-api-docs.md](issues/43-proposal-149-readme-and-api-docs.md) (options 1–2 of 4; shipped as [#151](https://github.com/robertmassaioli/openapi-merge/pull/151)) |
+| 30 | [#149](https://github.com/robertmassaioli/openapi-merge/issues/149) | Documentation microsite (option 3 of 4) | 4 | 3 | **5** | Big Bet (low) | 📝 [47-proposal-149-documentation-microsite.md](issues/47-proposal-149-documentation-microsite.md) |
 
 ---
 

--- a/ai-planning/issues/47-proposal-149-documentation-microsite.md
+++ b/ai-planning/issues/47-proposal-149-documentation-microsite.md
@@ -1,0 +1,111 @@
+# Implementation Proposal: Issue #149 — Documentation Microsite
+
+**Status:** Proposal
+**Value:** 4/5 — a single, navigable reference for both packages; closes the gap between "quick npm README" and "actually understanding the merge model."
+**Effort:** 3/5 — new tooling (VitePress), a GitHub Pages deploy workflow, and a genuinely large amount of content.
+
+---
+
+## 1. Issue Summary
+
+**GitHub Issue:** [#149 — Proposal: dramatically improve repository documentation (microsite + playground)](https://github.com/robertmassaioli/openapi-merge/issues/149)
+
+Issue #149 proposed four options. [Proposal 43](43-proposal-149-readme-and-api-docs.md) covered options 1–2 (README
+enrichment + generated TypeDoc reference) and shipped as [PR #151](https://github.com/robertmassaioli/openapi-merge/pull/151).
+
+This proposal covers **option 3**: a documentation microsite covering both the CLI and the library, deployed to GitHub
+Pages. **Option 4 (the interactive playground) remains out of scope** and is not attempted here.
+
+---
+
+## 2. The canonical-source decision
+
+Proposal 43 §4.2 already flagged the risk: "each README should link to the microsite for deeper reference material,
+rather than trying to be the single source of truth **once the microsite exists**." That moment is now. Without a
+decision here, this proposal would create a *fourth* copy of content already duplicated three times (`exit-codes.ts`'s
+header comment, the CLI README, `AGENTS.md`) — the exact class of drift PR #151 spent an entire session fixing.
+
+**Decision: the site is canonical for CLI configuration reference, exit codes, `MergeOptions`, and merging-behaviour
+detail.** The two package READMEs remain the quick-start / npm-landing-page layer (per proposal 43's "which package
+do I want" framing) and, once this and #151 have both landed, get trimmed to point at the site for depth instead of
+repeating it.
+
+**This proposal does not touch the READMEs.** This branch was forked from `main` before #151 merged, so its READMEs are
+the pre-#151, less-accurate versions; editing them here would conflict with an already-open PR touching the same files
+for an unrelated reason. Trimming the READMEs down to pointers is recorded as an explicit **follow-up**, to be done once
+#151 merges, rather than attempted speculatively against a moving target.
+
+For exit codes specifically — now duplicated in `exit-codes.ts`, the CLI README, `AGENTS.md`, *and* the new
+`cli/exit-codes.md` — the "renumbering fails the build" test guard doesn't reach documentation, so the only defence is
+the existing convention (`exit-codes.ts`'s header comment: "Adding a code means: ... update the tables here and in the
+CLI README"). That reminder, and the matching one in `AGENTS.md` §4, are extended to name the site page too, so a future
+change has one place telling it about all four mirrors instead of three.
+
+---
+
+## 3. Tooling: VitePress, in `packages/docs-site`
+
+- **Generator:** VitePress — Vite-based, minimal config, built-in local search, fits the existing Vite/Bun/TS toolchain
+  rather than introducing a second one (chosen over Starlight/Astro and Docusaurus/React, both heavier for a two-package
+  reference site with no blog or multi-version story).
+- **Location:** `packages/docs-site`, a new Bun workspace member. `private: true` (never published; also excluded by
+  `publish-changed.sh`'s explicit `PUBLISH_ORDER` array, which does not glob `packages/*`).
+- **Root script impact:** verified empirically — `bun run --filter '*' <script>` silently skips a workspace package
+  that lacks that script (behaves like `--if-present`, not a hard requirement). `docs-site` only needs a real `build`
+  script; it does not need no-op `lint`/`typecheck`/`test` entries for `bun run lint`/`test` at the root to keep working.
+  A minimal `lint` script is added anyway, for the site's own config file, as a matter of hygiene rather than necessity.
+
+### API reference integration
+
+The library's generated TypeDoc reference (`bun run docs` in `packages/openapi-merge`, from proposal 43) is built a
+second time with a different `--out`, directly into `packages/docs-site/public/api/` (gitignored, generated at site-build
+time, not committed — same policy as `packages/openapi-merge/docs-api/`). VitePress copies everything under `public/`
+into the site output verbatim, so the API reference is served at `/api/` alongside the hand-written guide pages, without
+a second templating system. Verified: `vitepress preview` resolves `/api/` correctly and TypeDoc's own `assets/`
+directory does not collide with VitePress's `assets/` (different subpaths).
+
+### GitHub Pages deploy
+
+- `.github/workflows/docs-deploy.yml`: on push to `main`, builds the site (`bun run --cwd packages/docs-site build`,
+  which itself runs the TypeDoc step first) and deploys via `actions/configure-pages` /
+  `actions/upload-pages-artifact` / `actions/deploy-pages`, with `concurrency` scoped to the Pages deployment group (so
+  two pushes to `main` in quick succession queue rather than race) and `permissions: pages: write, id-token: write`.
+- **GitHub Pages is not currently enabled for this repository** (`gh api repos/robertmassaioli/openapi-merge/pages` →
+  404, checked directly rather than assumed). The workflow runs and produces a deployable artifact regardless, but the
+  site does not actually go live until the maintainer flips **Settings → Pages → Source → GitHub Actions** once — a
+  repository-settings change no workflow can make on its own.
+- Because a project-repo Pages site with no custom domain serves at `https://robertmassaioli.github.io/openapi-merge/`,
+  not the domain root, VitePress's `base` is set to `/openapi-merge/`. This cannot be verified by a local dev server
+  (which always serves at `/`), so it is the one thing in this proposal that needs a post-merge, post-Pages-enable
+  eyeball rather than a pre-merge test.
+
+---
+
+## 4. Content plan
+
+Structured as three sections plus a landing page, so the nav mirrors the "which package do I want" split already
+established in the root README:
+
+- **Guide** — which package to use, quick start for each, a development/contributing page (mirrors the root README's
+  "Developing on openapi-merge" section, expanded).
+- **CLI reference** — configuration file reference (every field), `init`, CLI flags, formatting, cross-document `$ref`s,
+  the security/trust model (`inputRoot`/`outputRoot`), exit codes, OpenAPI version support, worked examples.
+- **Library reference** — `merge()` and its types, `MergeOptions` in depth, merging behaviour (first-wins vs. merged
+  fields, and where they differ per input), per-input options, worked examples, and a pointer into the generated
+  `/api/` reference for exact type shapes.
+
+Every factual claim (exit codes, version support, defaults) is written from current source
+(`packages/openapi-merge-cli/src/exit-codes.ts`, `packages/openapi-merge/src/data.ts`, `servers.ts`,
+`security-schemes.ts`), not copied from the READMEs — this branch predates #151's README fixes, and the source is the
+only thing guaranteed current on both branches.
+
+---
+
+## 5. Testing
+
+- `bun run lint` / `bun run test` at the repository root pass unaffected (no changes to `src/` in either package).
+- `bun run --cwd packages/docs-site build` succeeds: runs the TypeDoc step, then `vitepress build`, with zero errors.
+- `bun run --cwd packages/docs-site preview` manually checked: home page, guide, CLI reference, library reference and
+  `/api/` all resolve; internal links between pages work.
+- `packages/docs-site/public/api` and `.vitepress/{cache,dist}` confirmed gitignored before the first build (checked
+  with `git status` immediately after, not just declared in `.gitignore`).

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,18 @@
         "husky": "^9.1.7",
       },
     },
+    "packages/docs-site": {
+      "name": "openapi-merge-docs-site",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.0.0",
+        "eslint-formatter-visualstudio": "^9.0.1",
+        "globals": "^17.7.0",
+        "typescript-eslint": "^8.65.0",
+        "vitepress": "^1.6.4",
+      },
+    },
     "packages/openapi-merge": {
       "name": "openapi-merge",
       "version": "1.4.0",
@@ -64,13 +76,107 @@
   "packages": {
     "@adobe/jsonschema2md": ["@adobe/jsonschema2md@8.0.11", "", { "dependencies": { "@types/json-schema": "^7.0.8", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.3", "es2015-i18n-tag": "1.6.1", "ferrum": "1.9.4", "fs-extra": "11.3.4", "github-slugger": "2.0.0", "js-yaml": "4.1.1", "json-schema": "^0.4.0", "mdast-builder": "1.1.1", "mdast-util-to-string": "4.0.0", "readdirp": "5.0.0", "remark-gfm": "^4.0.0", "remark-parse": "11.0.0", "remark-stringify": "11.0.0", "unified": "11.0.5", "unist-util-inspect": "8.1.0", "yargs": "18.0.0" }, "bin": { "jsonschema2md": "cli.js" } }, "sha512-WRfZRqoyQqQ5eRWcfFPa/r3UUnOoKqREsED09pHj6AU3upcNdw/Mj28CYX8C5SUyov2VjIOhZZSsNaUovm6tUw=="],
 
+    "@algolia/abtesting": ["@algolia/abtesting@1.22.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g=="],
+
+    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.7", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.7", "@algolia/autocomplete-shared": "1.17.7" } }, "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q=="],
+
+    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A=="],
+
+    "@algolia/autocomplete-preset-algolia": ["@algolia/autocomplete-preset-algolia@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA=="],
+
+    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.7", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg=="],
+
+    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg=="],
+
+    "@algolia/client-analytics": ["@algolia/client-analytics@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA=="],
+
+    "@algolia/client-common": ["@algolia/client-common@5.56.0", "", {}, "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg=="],
+
+    "@algolia/client-insights": ["@algolia/client-insights@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w=="],
+
+    "@algolia/client-personalization": ["@algolia/client-personalization@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA=="],
+
+    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A=="],
+
+    "@algolia/client-search": ["@algolia/client-search@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ=="],
+
+    "@algolia/ingestion": ["@algolia/ingestion@1.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA=="],
+
+    "@algolia/monitoring": ["@algolia/monitoring@1.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA=="],
+
+    "@algolia/recommend": ["@algolia/recommend@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA=="],
+
+    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0" } }, "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew=="],
+
+    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0" } }, "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ=="],
+
+    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0" } }, "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q=="],
+
     "@atlassian/atlassian-openapi": ["@atlassian/atlassian-openapi@1.0.6", "", { "dependencies": { "jsonpointer": "^5.0.0", "urijs": "^1.19.10" } }, "sha512-yy0aoEL9eQNGHYO6seBGnvY6jb9LlAm2y+vngO9Gy/B0OkmBr9GYrRM8ng0SgQz1IFGFQFhvZDcIEklBlD52rQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
+
+    "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
+
+    "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
 
@@ -100,6 +206,10 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.92", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-hR0ozxR97t1dzWw+esoxFijZ15gagt7EIgF3CNifu2yICXhS7gnun4Y+j+odJQtNSl7wvqMdoLbViIShwe/fdw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
     "@jest/diff-sequences": ["@jest/diff-sequences@30.4.0", "", {}, "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g=="],
 
     "@jest/expect-utils": ["@jest/expect-utils@30.4.1", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ=="],
@@ -118,13 +228,71 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.4", "", { "os": "android", "cpu": "arm" }, "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.4", "", { "os": "android", "cpu": "arm64" }, "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.4", "", { "os": "none", "cpu": "arm64" }, "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
+
+    "@shikijs/core": ["@shikijs/core@2.5.0", "", { "dependencies": { "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^3.1.0" } }, "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w=="],
+
     "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
 
     "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
 
     "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
 
-    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+    "@shikijs/transformers": ["@shikijs/transformers@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/types": "2.5.0" } }, "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg=="],
+
+    "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
@@ -158,9 +326,15 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
     "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
 
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
@@ -169,6 +343,8 @@
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
@@ -210,6 +386,42 @@
 
     "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ=="],
 
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
+
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.40", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/shared": "3.5.40", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.40", "", { "dependencies": { "@vue/compiler-core": "3.5.40", "@vue/shared": "3.5.40" } }, "sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.40", "", { "dependencies": { "@babel/parser": "^7.29.7", "@vue/compiler-core": "3.5.40", "@vue/compiler-dom": "3.5.40", "@vue/compiler-ssr": "3.5.40", "@vue/shared": "3.5.40", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.19", "source-map-js": "^1.2.1" } }, "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.40", "", { "dependencies": { "@vue/compiler-dom": "3.5.40", "@vue/shared": "3.5.40" } }, "sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@7.7.10", "", { "dependencies": { "@vue/devtools-kit": "^7.7.10" } }, "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA=="],
+
+    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.10", "", { "dependencies": { "@vue/devtools-shared": "^7.7.10", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw=="],
+
+    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.10", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.40", "", { "dependencies": { "@vue/shared": "3.5.40" } }, "sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.40", "", { "dependencies": { "@vue/reactivity": "3.5.40", "@vue/shared": "3.5.40" } }, "sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.40", "", { "dependencies": { "@vue/reactivity": "3.5.40", "@vue/runtime-core": "3.5.40", "@vue/shared": "3.5.40", "csstype": "^3.2.3" } }, "sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.40", "", { "dependencies": { "@vue/compiler-ssr": "3.5.40", "@vue/runtime-dom": "3.5.40", "@vue/shared": "3.5.40" } }, "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw=="],
+
+    "@vue/shared": ["@vue/shared@3.5.40", "", {}, "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg=="],
+
+    "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
+
+    "@vueuse/integrations": ["@vueuse/integrations@12.8.2", "", { "dependencies": { "@vueuse/core": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g=="],
+
+    "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
+
+    "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
+
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -219,6 +431,8 @@
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "algoliasearch": ["algoliasearch@5.56.0", "", { "dependencies": { "@algolia/abtesting": "1.22.0", "@algolia/client-abtesting": "5.56.0", "@algolia/client-analytics": "5.56.0", "@algolia/client-common": "5.56.0", "@algolia/client-insights": "5.56.0", "@algolia/client-personalization": "5.56.0", "@algolia/client-query-suggestions": "5.56.0", "@algolia/client-search": "5.56.0", "@algolia/ingestion": "1.56.0", "@algolia/monitoring": "1.56.0", "@algolia/recommend": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -232,6 +446,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
+
     "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -239,6 +455,10 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
@@ -248,11 +468,17 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
     "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
     "create-require": ["create-require@1.1.1", "", {}, "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "cuint": ["cuint@0.2.2", "", {}, "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="],
 
@@ -270,9 +496,13 @@
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
+
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es2015-i18n-tag": ["es2015-i18n-tag@1.6.1", "", {}, "sha512-MYoh9p+JTkgnzBh0MEBON6xUyzdmwT6wzsmmFJvZujGSXiI2kM+3XvFl6+AcIO2eeL6VWgtX9szSiDTMwDxyYA=="],
+
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -293,6 +523,8 @@
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -322,7 +554,11 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
+
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -340,6 +576,14 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -351,6 +595,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -400,7 +646,11 @@
 
     "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
 
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
+
+    "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
 
     "markdown-it": ["markdown-it@14.3.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.5.0", "linkify-it": "^5.0.2", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw=="],
 
@@ -425,6 +675,8 @@
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
@@ -492,13 +744,23 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
     "openapi-merge": ["openapi-merge@workspace:packages/openapi-merge"],
 
     "openapi-merge-cli": ["openapi-merge-cli@workspace:packages/openapi-merge-cli"],
+
+    "openapi-merge-docs-site": ["openapi-merge-docs-site@workspace:packages/docs-site"],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -514,13 +776,21 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -532,6 +802,12 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
@@ -540,7 +816,13 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
+
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -548,17 +830,33 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
@@ -588,6 +886,8 @@
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
     "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
@@ -605,6 +905,12 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
+
+    "vue": ["vue@3.5.40", "", { "dependencies": { "@vue/compiler-dom": "3.5.40", "@vue/compiler-sfc": "3.5.40", "@vue/runtime-dom": "3.5.40", "@vue/server-renderer": "3.5.40", "@vue/shared": "3.5.40" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -632,7 +938,19 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@gerrit0/mini-shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/core/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+
+    "@shikijs/engine-oniguruma/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/langs/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/themes/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
+
+    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -641,6 +959,12 @@
     "mdast-builder/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+
+    "shiki/@shikijs/langs": ["@shikijs/langs@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w=="],
+
+    "shiki/@shikijs/themes": ["@shikijs/themes@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 

--- a/packages/docs-site/.gitignore
+++ b/packages/docs-site/.gitignore
@@ -1,0 +1,13 @@
+# Temp Files
+*.sw[a-p]
+*~
+
+# Node modules
+/node_modules
+
+# VitePress build output and dev cache
+/.vitepress/cache
+/.vitepress/dist
+
+# Generated TypeDoc API reference (bun run build:api)
+/public/api

--- a/packages/docs-site/.vitepress/config.mts
+++ b/packages/docs-site/.vitepress/config.mts
@@ -1,0 +1,88 @@
+import { defineConfig } from 'vitepress';
+
+// Served from GitHub Pages as a project site (no custom domain configured),
+// so every asset and internal link must be rooted at /openapi-merge/, not /.
+// Cannot be exercised by `vitepress dev`/`preview`, which always serve at /;
+// verify this against the live URL after the first deploy.
+const base = '/openapi-merge/';
+
+export default defineConfig({
+  base,
+  title: 'openapi-merge',
+  description: 'Merge multiple OpenAPI 3.0, 3.1 and 3.2 documents into one, via a CLI tool or a TypeScript library.',
+  lastUpdated: true,
+  cleanUrls: true,
+
+  head: [['link', { rel: 'icon', href: `${base}favicon.svg` }]],
+
+  themeConfig: {
+    logo: '/favicon.svg',
+
+    nav: [
+      { text: 'Guide', link: '/guide/which-package' },
+      { text: 'CLI Reference', link: '/cli/' },
+      { text: 'Library Reference', link: '/library/' },
+      { text: 'API Reference', link: '/api/', target: '_self' },
+      { text: 'GitHub', link: 'https://github.com/robertmassaioli/openapi-merge' },
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Guide',
+          items: [
+            { text: 'Which package do I want?', link: '/guide/which-package' },
+            { text: 'Quick start: CLI', link: '/guide/quick-start-cli' },
+            { text: 'Quick start: library', link: '/guide/quick-start-library' },
+            { text: 'Developing on openapi-merge', link: '/guide/development' },
+          ],
+        },
+      ],
+      '/cli/': [
+        {
+          text: 'CLI reference',
+          items: [
+            { text: 'Getting started', link: '/cli/' },
+            { text: 'Configuration reference', link: '/cli/configuration' },
+            { text: 'Command-line flags', link: '/cli/cli-flags' },
+            { text: 'Formatting', link: '/cli/formatting' },
+            { text: 'Cross-document $refs', link: '/cli/cross-document-refs' },
+            { text: 'Security', link: '/cli/security' },
+            { text: 'Exit codes', link: '/cli/exit-codes' },
+            { text: 'OpenAPI version support', link: '/cli/openapi-versions' },
+            { text: 'Examples', link: '/cli/examples' },
+          ],
+        },
+      ],
+      '/library/': [
+        {
+          text: 'Library reference',
+          items: [
+            { text: 'Getting started', link: '/library/' },
+            { text: 'Merge options', link: '/library/merge-options' },
+            { text: 'Per-input options', link: '/library/per-input-options' },
+            { text: 'Merging behaviour', link: '/library/merging-behaviour' },
+            { text: 'Examples', link: '/library/examples' },
+            { text: 'Generated API reference', link: '/library/api-reference' },
+          ],
+        },
+      ],
+    },
+
+    search: {
+      provider: 'local',
+    },
+
+    socialLinks: [{ icon: 'github', link: 'https://github.com/robertmassaioli/openapi-merge' }],
+
+    editLink: {
+      pattern: 'https://github.com/robertmassaioli/openapi-merge/edit/main/packages/docs-site/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © Robert Massaioli',
+    },
+  },
+});

--- a/packages/docs-site/cli/cli-flags.md
+++ b/packages/docs-site/cli/cli-flags.md
@@ -1,0 +1,25 @@
+# Command-line flags
+
+## `openapi-merge-cli [flags]`
+
+Run with no arguments to merge according to `openapi-merge.yaml` (or `openapi-merge.json`, if that's the only one
+present) in the current directory.
+
+| Flag | Description |
+| --- | --- |
+| `-c, --config <config_file>` | Path to the configuration file to use, instead of the default `openapi-merge.yaml`/`openapi-merge.json` lookup. |
+| `--restrict-output-to <dir>` | Refuse to write output anywhere outside `<dir>`. Overrides `outputRoot` in the config if both are set. See [Security](/cli/security). |
+| `--restrict-input-to <dir>` | Refuse to read any local input file from outside `<dir>`. Overrides `inputRoot` in the config if both are set. See [Security](/cli/security). |
+| `--version` | Print the installed version and exit. |
+| `--help` | Print usage, including the `init` subcommand below. |
+
+## `openapi-merge-cli init [--force]`
+
+Writes a starter `openapi-merge.yaml` in the current directory — see
+[Getting started: `init`](/cli/#getting-started-init) for the full behaviour. `init` is deliberately not a
+`commander` subcommand in the usual sense (so that a bare `openapi-merge-cli` with no arguments still runs the merge
+rather than printing help), but it's dispatched the same way.
+
+| Flag | Description |
+| --- | --- |
+| `--force` | Overwrite an existing `openapi-merge.yaml` even if one (or an `openapi-merge.json`) already exists. Without it, `init` refuses to run if either default config file is present. `--force` only ever writes `openapi-merge.yaml`. |

--- a/packages/docs-site/cli/configuration.md
+++ b/packages/docs-site/cli/configuration.md
@@ -1,0 +1,85 @@
+# Configuration reference
+
+Every field the CLI's configuration file (`openapi-merge.yaml` / `openapi-merge.json`) accepts, grouped as top-level
+settings and per-input settings. `openapi-merge-cli init` will write all of these for you, commented out where
+optional — see [Getting started: `init`](/cli/#getting-started-init).
+
+## Top-level fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `inputs` | `ConfigurationInput[]` | *(required)* | One entry per OpenAPI document to merge. At least one required. |
+| `output` | `string` | *(required)* | Where to write the merged document. `.yaml`/`.yml` writes YAML, anything else writes JSON. Missing directories in this path are created automatically. |
+| `outputRoot` | `string` | unset | Refuse to write the output anywhere outside this directory. See [Security](/cli/security). |
+| `inputRoot` | `string` | unset | Refuse to read any local file — declared or discovered — from outside this directory. See [Security](/cli/security). |
+| `formatting` | `OutputFormatting` | 2-space indent | Controls indentation of the emitted output. See [Formatting](/cli/formatting). |
+| `serversStrategy` | `'first' \| 'concat'` | `'first'` | How the top-level `servers` array is combined. `'first'` keeps only the first input's servers (the API-gateway case); `'concat'` keeps every input's servers, deduplicated by URL. |
+| `securitySchemesStrategy` | `'merge' \| 'first' \| 'error'` | `'merge'` | How `components.securitySchemes` is combined. `'merge'` combines them like any other component (renaming on conflict); `'first'` takes only the first input's schemes (may leave later operations referencing an undefined scheme); `'error'` combines identical definitions but fails on a genuine conflict instead of renaming around it. |
+| `pruneUnusedComponents` | `boolean` | `false` | Drop components nothing in the merged output references. Useful alongside `operationSelection`, which can otherwise leave orphaned schemas behind. |
+| `info` | `{ title?, version?, description? }` | unset | Override fields of the merged `info` object, field by field — setting only `title` doesn't require restating `version`. Without this, `info` comes entirely from the first input. |
+| `resolveExternalReferences` | `boolean` | `false` | Follow `$ref`s into files/URLs that aren't declared `inputs`, pulling in just the components they ask for. See [Cross-document `$ref`s](/cli/cross-document-refs). |
+
+## Per-input fields
+
+Each entry in `inputs` is either a file input or a URL input, plus the fields below (all optional except the source).
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `inputFile` **or** `inputURL` | `string` | Exactly one of these, per input. `inputFile` is a relative or absolute path; `inputURL` must be `http://` or `https://`. |
+| `pathModification.stripStart` | `string` | Strip this prefix from every path in this input, if present. Runs before `prepend`. |
+| `pathModification.prepend` | `string` | Prepend this to every path in this input. Runs after `stripStart`. |
+| `operationSelection.includeTags` | `string[]` | Allow-list: only operations carrying one of these tags survive. Untagged operations are excluded. |
+| `operationSelection.excludeTags` | `string[]` | Deny-list: operations carrying any of these tags are dropped, and the tags are removed from the top-level `tags` array for this input. |
+| `operationSelection.includePaths` | `PathSelector[]` | Allow-list by path (and optionally method) instead of by tag. `path` supports a `*` wildcard. See [Examples](/cli/examples). |
+| `operationSelection.excludePaths` | `PathSelector[]` | Deny-list by path (and optionally method). |
+| `description.append` | `boolean` | Whether this input's `info.description` is appended into the merged `info.description`. |
+| `description.title.value` | `string` | Optional Markdown heading text for this input's section of the merged description. |
+| `description.title.headingLevel` | `number` (1–6) | Heading level for the title above. Default `1`. |
+| `duplicatePathHandling` | `'error' \| 'skip-later' \| 'prefer-later' \| 'merge-operations'` | What to do when this input declares a path (or webhook) an earlier input already contributed. Default `'error'`. See below. |
+| `tag` | `{ name, description? }` | Add a tag to every operation from this input, applied after `operationSelection` so it can't influence which operations survive. |
+| `dispute` | `{ prefix, alwaysApply? } \| { suffix, alwaysApply? }` | How to rename a component that collides by name with one from another input. `alwaysApply: true` applies the prefix/suffix to every schema from this input, not just ones actually in conflict. |
+
+### `operationSelection` precedence
+
+Exclusion always wins over inclusion, and a path rule and a tag rule are independent gates:
+
+- If an operation is matched by both an `includeTags` and an `excludeTags` entry, it's excluded.
+- If it's matched by both `includePaths` and `excludePaths`, it's excluded.
+- If it's matched by an exclude rule of *either* kind (path or tag), it's excluded.
+- If `includeTags` and `includePaths` are both configured, the operation must pass *both* to survive.
+
+### `duplicatePathHandling` values
+
+- **`error`** (default) — fail the merge, the historical behaviour.
+- **`skip-later`** — keep the path definition already present; drop this input's.
+- **`prefer-later`** — replace the definition already present with this input's.
+- **`merge-operations`** — combine them when their method sets don't overlap and their path-level fields agree (so
+  `GET /thing` from one input and `POST /thing` from another end up in one path item). Refuses with the same
+  `duplicate-paths` error whenever a union would be a guess: overlapping methods, differing path-level fields, or
+  either side being a `$ref` path item.
+
+Applies to `webhooks` (OpenAPI 3.1) the same way it applies to `paths` — they collide by event name instead of by
+path string, but the resolution rules are identical.
+
+## Full example
+
+```json
+{
+  "inputs": [
+    { "inputFile": "./gateway.swagger.json" },
+    {
+      "inputFile": "./jira.swagger.json",
+      "pathModification": { "stripStart": "/rest", "prepend": "/jira" },
+      "operationSelection": { "includeTags": ["included"] },
+      "description": { "append": true, "title": { "value": "Jira", "headingLevel": 2 } }
+    },
+    {
+      "inputFile": "./confluence.swagger.yaml",
+      "dispute": { "prefix": "Confluence" },
+      "pathModification": { "prepend": "/confluence" },
+      "operationSelection": { "excludeTags": ["excluded"] }
+    }
+  ],
+  "output": "./output.swagger.json"
+}
+```

--- a/packages/docs-site/cli/cross-document-refs.md
+++ b/packages/docs-site/cli/cross-document-refs.md
@@ -1,0 +1,37 @@
+# Cross-document `$ref`s
+
+If one input's `$ref` points at *another file* rather than somewhere inside itself —
+`$ref: "../common/Errors.yml#/components/schemas/ServerError"` — two different things can happen, depending on
+whether that file is one of your declared `inputs`.
+
+## The target is already one of your `inputs`
+
+The `$ref` is rewritten to point at wherever that component ended up in the merged document, automatically and
+unconditionally — no configuration needed. This is always correct: the alternative is a `$ref` that's already
+broken in the merged output, since the original relative path means nothing once the inputs are combined into one
+document ([issue #104](https://github.com/robertmassaioli/openapi-merge/issues/104)).
+
+## The target isn't one of your `inputs`
+
+By default the `$ref` is left as-is (resolved to an absolute path or URL, so at least it's unambiguous, but still
+not something the merged document can resolve on its own). Set `resolveExternalReferences: true` to have the CLI
+follow it: load that file (or URL), pull in *just* the component the `$ref` asked for, and rewrite the `$ref` to
+point at it locally — following further `$ref`s the same way, however many files deep, with cycles detected and
+reported rather than hanging ([issue #10](https://github.com/robertmassaioli/openapi-merge/issues/10)).
+
+```json
+{
+  "inputs": [{ "inputFile": "./api.yaml" }],
+  "output": "./bundle.yaml",
+  "resolveExternalReferences": true
+}
+```
+
+A `$ref` this discovers but cannot load — a missing file, a failed fetch, a document that doesn't parse — is left
+exactly as written and reported as a warning, not a hard failure, the same way an unresolvable `$ref` into a
+declared input is also left alone rather than erroring.
+
+::: tip
+`resolveExternalReferences` widens what gets *read*, not just written — see [Security](/cli/security) for what
+that means if your inputs aren't fully trusted.
+:::

--- a/packages/docs-site/cli/examples.md
+++ b/packages/docs-site/cli/examples.md
@@ -1,0 +1,96 @@
+# Examples
+
+## Selecting only the operations owned by each service, by tag
+
+A common case ([issue #100](https://github.com/robertmassaioli/openapi-merge/issues/100)) is merging several
+services but taking only the operations each one owns, identified by a tag:
+
+```json
+{
+  "inputs": [
+    { "inputFile": "service1/swagger.json", "operationSelection": { "includeTags": ["Service1"] } },
+    { "inputFile": "service2/swagger.json", "operationSelection": { "includeTags": ["Service2"] } },
+    { "inputFile": "service3/swagger.json", "operationSelection": { "includeTags": ["Service3"] } }
+  ],
+  "output": "./dist/service.output.swagger.json"
+}
+```
+
+Three things worth knowing about how this behaves:
+
+- **Untagged operations are excluded.** `includeTags` is an allow-list, so an operation with no tags at all does
+  not survive it. If a service has operations you want that aren't tagged, either tag them upstream or use
+  `excludeTags` to remove what you don't want instead.
+- **A partially-filtered path keeps its remaining operations.** Filtering is per operation; the path itself
+  survives as long as one of its operations does.
+- **The top-level `tags` array is only pruned by `excludeTags`.** `includeTags` deliberately leaves it alone, so a
+  tag you filtered *in* keeps its description.
+
+## Selecting operations by path instead of by tag
+
+Not every input's tags are under your control — some generators don't let you customise them at all — and two
+services can legitimately share a tag while only some of the operations under it should survive. `includePaths` /
+`excludePaths` select by where an operation lives in the document instead:
+
+```json
+{
+  "inputs": [
+    {
+      "inputFile": "admin-service/swagger.json",
+      "operationSelection": { "excludePaths": [{ "path": "/admin/users", "method": "get" }] }
+    },
+    {
+      "inputFile": "internal-service/swagger.json",
+      "operationSelection": { "excludePaths": [{ "path": "/internal/*" }] }
+    }
+  ],
+  "output": "./dist/service.output.swagger.json"
+}
+```
+
+- **`path` supports a `*` wildcard**, matched the same way `includeTags`/`excludeTags` are: `*` matches any run of
+  characters (including none), nothing else is special, and the match is anchored at both ends — `/admin/*`
+  matches `/admin/users` but not `/other/admin/users`. A literal `.` or other regex-looking character
+  (`/v1.2/status`) is matched literally, not interpreted.
+- **`method` is optional.** Omit it to match every method on that path. Give a single method (`"get"`) or a list
+  (`["get", "post"]`) to narrow it — including a 3.2 `additionalOperations` custom verb like `"PURGE"`, matched
+  case-sensitively. Standard methods are lowercase in a parsed OpenAPI document (`get`, not `GET`) — a selector
+  must match that spelling.
+- **Selectors match this input's own original path**, before `pathModification` runs. Write the selector against
+  the path as it appears in that input's own file, not the path it'll have in the merged output.
+- **If an operation matches both an `includePaths` and an `excludePaths` selector, exclusion wins** — the same
+  precedence `includeTags`/`excludeTags` already have. See
+  [Configuration reference → `operationSelection` precedence](/cli/configuration#operationselection-precedence) for
+  the full rule when tag and path selectors are combined.
+- **`includePaths` on a document with 3.1 `webhooks` drops every webhook operation**, unless one of your selectors
+  happens to match the webhook's event name — the same allow-list behaviour `includeTags` already has for untagged
+  webhooks. If you need to keep webhooks while filtering paths, tag the webhook operations and use `includeTags`
+  instead, or use `excludePaths` (which doesn't have this effect).
+
+## Combining several inputs with dispute resolution
+
+```json
+{
+  "inputs": [
+    { "inputFile": "./gateway.swagger.json" },
+    {
+      "inputFile": "./jira.swagger.json",
+      "pathModification": { "stripStart": "/rest", "prepend": "/jira" },
+      "operationSelection": { "includeTags": ["included"] },
+      "description": { "append": true, "title": { "value": "Jira", "headingLevel": 2 } }
+    },
+    {
+      "inputFile": "./confluence.swagger.yaml",
+      "dispute": { "prefix": "Confluence" },
+      "pathModification": { "prepend": "/confluence" },
+      "operationSelection": { "excludeTags": ["excluded"] }
+    }
+  ],
+  "output": "./output.swagger.json"
+}
+```
+
+Here, `jira.swagger.json`'s paths lose their `/rest` prefix and gain a `/jira` one; only operations tagged
+`included` are kept; and its description is appended to the merged `info.description` under a level-2 "Jira"
+heading. `confluence.swagger.yaml` gets a `/confluence` prefix, drops operations tagged `excluded`, and any
+component name it shares with another input is disambiguated with a `Confluence` prefix.

--- a/packages/docs-site/cli/exit-codes.md
+++ b/packages/docs-site/cli/exit-codes.md
@@ -1,0 +1,50 @@
+# Exit codes
+
+The CLI's exit codes are part of its contract — scripts and CI pipelines can branch on them.
+
+::: tip Source of truth
+This table mirrors the header comment in
+[`packages/openapi-merge-cli/src/exit-codes.ts`](https://github.com/robertmassaioli/openapi-merge/blob/main/packages/openapi-merge-cli/src/exit-codes.ts),
+which is pinned by a test (renumbering a code fails the build). If this page ever disagrees with that file, the
+file is right — please [open an issue](https://github.com/robertmassaioli/openapi-merge/issues/new).
+:::
+
+| Code | Member | Meaning |
+| ---: | --- | --- |
+| `0` | `Success` | The merge completed and the output was written. |
+| `1` | `ErrorLoadingConfig` | Failed to load, parse, or validate the configuration file. |
+| `2` | `ErrorLoadingInputs` | Failed to obtain or parse one or more inputs (missing file, unreachable URL, content that's neither valid JSON nor YAML). |
+| `3` | `ErrorMerging` | The merge itself failed: duplicate paths, an unresolvable `operationId` conflict, a cyclic cross-document `$ref` chain, etc. |
+| `4` | `ErrorUncaught` | An exception escaped the CLI's own error handling — please report this as a bug. |
+| `5` | `ErrorUnsafePath` | The resolved output path escaped `outputRoot` / `--restrict-output-to`. |
+| `6` | `ErrorInputUrlClientStatus` | An `inputURL` responded with a **4xx** status. |
+| `7` | `ErrorInputUrlServerStatus` | An `inputURL` responded with a **5xx** status. |
+| `8` | `ErrorInputUrlUnexpectedStatus` | An `inputURL` responded with some other non-2xx status. |
+| `9` | `ErrorOpenApiVersion` | An input declared an unsupported OpenAPI version, or the inputs disagreed. |
+| `10` | `ErrorUnsafeInputPath` | A local file read escaped `inputRoot` / `--restrict-input-to`. |
+| `11` | `ErrorCreatingOutputDirectory` | The output directory could not be created (permissions, read-only filesystem, or a path component that's an existing file). |
+
+## Why `6`–`8` are separate from `2`
+
+`2` means an input could not be obtained at all — a missing file, an unreachable host, content that parses as
+neither JSON nor YAML. `6`–`8` mean the server answered and refused.
+
+They're separate from *each other* so CI can branch on **retryability**:
+
+- **`6` (4xx)** is the request's fault — a stale URL, missing credentials, a retired endpoint. Retrying changes
+  nothing; the configuration needs to change.
+- **`7` (5xx)** is the server's fault and is plausibly transient. If you merge specs published by other teams,
+  you'll see this during their deploys, and a retry is usually the right response.
+- **`8`** is anything else outside the 2xx range. Ordinary redirects are followed automatically and never surface;
+  in practice this is a `304 Not Modified` from a caching proxy. Read the printed status.
+
+## Example: retry only on a transient failure
+
+```bash
+openapi-merge-cli
+case $? in
+  0) echo "merged" ;;
+  7) echo "upstream is down, retrying later"; exit 75 ;;  # EX_TEMPFAIL
+  *) echo "merge failed permanently"; exit 1 ;;
+esac
+```

--- a/packages/docs-site/cli/formatting.md
+++ b/packages/docs-site/cli/formatting.md
@@ -1,0 +1,42 @@
+# Formatting
+
+Control the indentation of the merged output via an optional `formatting` block. Indentation is expressed as a
+discriminated union, so contradictory combinations (e.g. "tabs of width 4") are unrepresentable:
+
+```jsonc
+{
+  "inputs": [ /* ... */ ],
+  "output": "./merged.json",
+
+  // 4-space indentation (default is 2 spaces).
+  "formatting": { "indent": { "style": "spaces", "width": 4 } }
+}
+```
+
+```jsonc
+{
+  "inputs": [ /* ... */ ],
+  "output": "./merged.json",
+
+  // Tab indentation. JSON only — see below.
+  "formatting": { "indent": { "style": "tabs" } }
+}
+```
+
+If `formatting` is omitted, the output keeps the historical default of two-space indentation.
+
+::: warning
+YAML 1.1 disallows tab characters as indentation. Combining `{ "style": "tabs" }` with a `.yaml`/`.yml` output is
+rejected at configuration-load time with a clear error message, not a broken YAML file.
+:::
+
+## Paths
+
+Both `inputFile` and `output` accept relative or absolute paths. Relative paths are resolved against the directory
+containing the configuration file. Absolute paths (e.g. `/tmp/merged.yaml`, `C:\build\out.json`) are used as-is —
+you can safely write the merged spec into `/tmp` or `/var/build/...` from CI.
+
+Any directory in `output`'s path that doesn't exist yet is created automatically, including multiple missing levels
+at once, so `"output": "./dist/service.output.swagger.json"` works even before `dist/` exists. If a directory can't
+be created — a permissions error, or a path component that's already a regular file — the CLI exits with
+`ErrorCreatingOutputDirectory` (see [Exit codes](/cli/exit-codes)) rather than a raw stack trace.

--- a/packages/docs-site/cli/index.md
+++ b/packages/docs-site/cli/index.md
@@ -1,0 +1,94 @@
+# CLI reference
+
+`openapi-merge-cli` merges one or more OpenAPI 3.0, 3.1 or 3.2 documents together according to a configuration file.
+It's built on top of the [`openapi-merge`](/library/) library — every merging rule described in the
+[Library reference](/library/) applies here too.
+
+## Getting started
+
+You need one or more OpenAPI files to merge and a configuration file — `openapi-merge.yaml` by default
+(`openapi-merge.json` is also read, for configurations written before this tool wrote YAML). The
+[`init`](#getting-started-init) command below writes a starting point for you.
+
+Written by hand, a configuration looks like:
+
+```json
+{
+  "inputs": [
+    { "inputFile": "./gateway.swagger.json" },
+    {
+      "inputFile": "./jira.swagger.json",
+      "pathModification": { "stripStart": "/rest", "prepend": "/jira" },
+      "operationSelection": { "includeTags": ["included"] },
+      "description": { "append": true, "title": { "value": "Jira", "headingLevel": 2 } }
+    },
+    {
+      "inputFile": "./confluence.swagger.yaml",
+      "dispute": { "prefix": "Confluence" },
+      "pathModification": { "prepend": "/confluence" },
+      "operationSelection": { "excludeTags": ["excluded"] }
+    }
+  ],
+  "output": "./output.swagger.json"
+}
+```
+
+See [Configuration reference](/cli/configuration) for what every field means.
+
+## Getting started: `init` {#getting-started-init}
+
+To write that configuration file for you, run:
+
+```bash
+npx openapi-merge-cli init
+```
+
+It creates `openapi-merge.yaml` in the current directory, pre-filled with any OpenAPI 3.x files it finds alongside
+it:
+
+```
+## Wrote openapi-merge.yaml with 2 inputs:
+##   ./service-a.yaml
+##   ./service-b.yaml
+##   resolveExternalReferences and inputRoot are turned on by default -- see the
+##   comments above them. Every other setting is included, commented out -- uncomment what you need.
+## Edit openapi-merge.yaml, then run openapi-merge-cli to produce './openapi.yaml'.
+```
+
+The generated file is not just `inputs` and `output`. Two settings, `resolveExternalReferences` and `inputRoot`, are
+turned **on** by default — see [Cross-document `$ref`s](/cli/cross-document-refs) for what the first one does; the
+second bounds it to the directory `init` just scanned, which costs nothing since everything `init` found already
+lives there. Every other optional setting this tool supports — both per-input (`dispute`, `pathModification`,
+`operationSelection`, `description`, `duplicatePathHandling`, `tag`) and top-level (`outputRoot`, `formatting`,
+`serversStrategy`, `securitySchemesStrategy`, `pruneUnusedComponents`, `info`) — is written out commented, with a
+one-line explanation and a working example. Uncomment a block and it is immediately valid.
+
+If you would rather start from the historical permissive defaults (both settings unset), delete or comment out the
+two active lines — deleting an active line is exactly as valid as leaving a commented one uncommented.
+
+Details worth knowing:
+
+- **It identifies inputs by content, not by extension.** Every `.json`, `.yaml` and `.yml` file is opened and kept
+  only if it has a top-level `openapi: 3.x`. That's what keeps `package.json` and CI config out of the result
+  without a list of names to exclude.
+- **It scans the current directory only.** Not recursive.
+- **It will not overwrite an existing configuration** — `openapi-merge.yaml` *or* `openapi-merge.json` — unless you
+  pass `--force`. `--force` only ever writes `openapi-merge.yaml`.
+- **Swagger 2.0 files are named, not silently skipped.** Convert them with `swagger2openapi` first.
+- **It warns if the files it found declare different OpenAPI minor versions**, since the merge requires them all to
+  agree.
+- If nothing is found, you still get a valid file with one placeholder input to replace.
+
+## Running the merge
+
+```bash
+npx openapi-merge-cli
+```
+
+Reads the configuration from the current directory and writes the merged document. Point at a specific file with:
+
+```bash
+npx openapi-merge-cli --config path/to/openapi-merge.yaml
+```
+
+Full flag list: [Command-line flags](/cli/cli-flags).

--- a/packages/docs-site/cli/openapi-versions.md
+++ b/packages/docs-site/cli/openapi-versions.md
@@ -1,0 +1,40 @@
+# OpenAPI version support
+
+`openapi-merge-cli` (via the `openapi-merge` library) merges **OpenAPI 3.0.x, 3.1.x and 3.2.x** documents. Every
+input must declare a full `openapi` version (for example `"3.2.0"`), and all inputs must agree on the
+`major.minor` version — patch differences such as `3.1.0` and `3.1.1` are fine, since they're the same feature set,
+but 3.0, 3.1 and 3.2 inputs cannot be mixed with each other.
+
+An input declaring a version this tool doesn't know, no version at all, or a version that disagrees with the other
+inputs exits with code `9` (see [Exit codes](/cli/exit-codes)) and a message naming the offending input.
+
+## What each version adds
+
+### 3.1
+
+- `webhooks` — merged exactly like `paths`: the same duplicate-path rule, the same `operationId` uniqueness check,
+  the same `$ref` rewriting.
+- `components.pathItems`.
+- `jsonSchemaDialect`.
+- Documents with no `paths` at all (valid in 3.1, since `webhooks` can carry everything).
+
+### 3.2
+
+- The `query` HTTP method and `additionalOperations` (custom verbs such as `PURGE`) — both participate fully in
+  operation counting, `operationId` uniqueness, `$ref` rewriting and tag-based selection.
+- New tag fields `summary`, `parent` and `kind`, carried through.
+- `itemSchema`, discriminator `defaultMapping`, OAuth2 device-authorization flows, and `in: querystring`
+  parameters.
+
+## `$self`
+
+`$self` (3.1+) declares a document's *own* identity. A merged document is not any one of its inputs, so carrying an
+input's `$self` forward would assert an identity the output doesn't have. It's kept only when there's exactly one
+input — the degenerate case where the output really is that document — and dropped otherwise, rather than
+arbitrarily inheriting one input's identity, which would also affect how relative `$ref`s resolve.
+
+## Output version
+
+The output declares the version the (agreeing) inputs used, rather than always `3.0.3`. Merging documents that
+declare `3.0.0` produces `3.0.0`. Relabelling within a minor version is safe in both directions, so no document
+becomes invalid — but if you were relying on the output always being exactly `3.0.3`, that's no longer guaranteed.

--- a/packages/docs-site/cli/security.md
+++ b/packages/docs-site/cli/security.md
@@ -1,0 +1,63 @@
+# Security
+
+`openapi-merge-cli` reads, merges, and writes files using the paths specified in your `openapi-merge.yaml`/`.json`
+(or via `--config`). The tool assumes that this configuration file is **trusted**, the same way you trust a
+`Makefile`, `package.json`, or `webpack.config.js` in your repository. Do not run the CLI against a configuration
+file from an untrusted source without restricting the input and output locations, below.
+
+## Widened reads from `resolveExternalReferences`
+
+`resolveExternalReferences` widens what gets *read*, not just written: with it on, the files and URLs the CLI loads
+are no longer limited to what `inputs` names — it follows wherever a `$ref` in *any* loaded document points,
+transitively. Leave it off (the default) unless your inputs are trusted to the same degree the configuration file
+itself is.
+
+## Restricting output: `outputRoot` / `--restrict-output-to`
+
+For defence-in-depth in less-trusted contexts (for example, a server that accepts user-supplied configs), restrict
+where the CLI will write the merged output:
+
+- Add `"outputRoot": "/path/to/safe/dir"` to your configuration, **or**
+- Pass `--restrict-output-to /path/to/safe/dir` on the command line (the flag takes precedence over the config
+  field).
+
+When set, any resolved output path that doesn't lie under the configured root is rejected at config-load time with
+a clear error message, and the CLI exits with code `5` (`ErrorUnsafePath`). Symlink-out-of-jail tricks are defeated
+by realpath-ing the closest existing ancestor of the output.
+
+When unset, the CLI keeps its historical permissive default and writes wherever you tell it to.
+
+## Restricting input: `inputRoot` / `--restrict-input-to`
+
+The read-side counterpart, and the one that matters most once `resolveExternalReferences` is on — that setting is
+what makes the reachable file set transitive rather than confined to what `inputs` lists:
+
+- Add `"inputRoot": "/path/to/safe/dir"` to your configuration, **or**
+- Pass `--restrict-input-to /path/to/safe/dir` on the command line (the flag takes precedence over the config
+  field).
+
+When set, any local file the CLI would read — a declared `inputFile` or a file `resolveExternalReferences`
+discovers — that doesn't lie under the configured root is refused, and the CLI exits with code `10`
+(`ErrorUnsafeInputPath`). The offending file is never opened: the check runs before the read is attempted, using
+the same realpath-based containment check as `outputRoot`, extended to also realpath the file itself (not just its
+parent directory) before comparing — an input, unlike an output, normally already exists, so a symlink planted as
+the file itself, not just an ancestor directory, has to be defeated too.
+
+A declared `inputFile` outside the root is reported before the merge starts at all; a discovered file outside the
+root aborts the merge the same way, rather than being left as an unresolved `$ref` the way an ordinary missing or
+unparseable discovered file is.
+
+`inputURL` and URLs discovered via `resolveExternalReferences` are **unaffected** by `inputRoot` — it bounds the
+filesystem, not the network.
+
+When unset, the CLI keeps its historical permissive default and reads whatever the inputs point to.
+
+## Summary
+
+| Setting | Bounds | Config field | CLI flag | Exit code on violation |
+| --- | --- | --- | --- | --- |
+| Output containment | Where the merged file can be written | `outputRoot` | `--restrict-output-to` | `5` |
+| Input containment | Which local files can be read | `inputRoot` | `--restrict-input-to` | `10` |
+
+Neither is on by default; both are additive defence-in-depth for the case where the configuration or its inputs
+aren't fully trusted — not something a typical local/CI usage needs to set.

--- a/packages/docs-site/eslint.config.mjs
+++ b/packages/docs-site/eslint.config.mjs
@@ -1,0 +1,21 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  // public/api and .vitepress/{cache,dist} are all generated; docs-api and
+  // node_modules are dependencies. None of it is ours to lint.
+  { ignores: ['.vitepress/cache/**', '.vitepress/dist/**', 'public/**', 'node_modules/**'] },
+
+  {
+    files: ['**/*.{js,mjs,cjs,ts,mts}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+);

--- a/packages/docs-site/guide/development.md
+++ b/packages/docs-site/guide/development.md
@@ -1,0 +1,56 @@
+# Developing on openapi-merge
+
+This repository is a multi-package monorepo (`packages/openapi-merge`, `packages/openapi-merge-cli`, and this
+documentation site at `packages/docs-site`), managed with [Bun](https://bun.sh/) workspaces. Packages are compiled
+with [`tsgo`](https://github.com/microsoft/typescript-go), the Go-based native preview of the TypeScript compiler.
+
+## Setup
+
+```bash
+bun install
+```
+
+## Running things
+
+```bash
+bun run cli                    # run the CLI tool in dev mode
+bun run --cwd packages/openapi-merge build -- --watch   # watch-build the library, so the CLI picks up changes live
+```
+
+If you're changing the library and testing against the CLI, run the library's watch build in one terminal and
+`bun run cli` in another — the CLI imports the library's compiled `dist/`, not its TypeScript source directly.
+
+## Before committing
+
+```bash
+bun run test   # bun:test, both packages
+bun run lint   # eslint --fix, then a full tsgo typecheck of both packages
+```
+
+`bun run lint` also runs automatically on every `git commit` via a Husky pre-commit hook (`.husky/pre-commit`), so a
+broken build is caught locally rather than in CI.
+
+## Working on this documentation site
+
+```bash
+bun run --cwd packages/docs-site dev       # live-reloading local preview
+bun run --cwd packages/docs-site build     # production build, including the generated API reference
+bun run --cwd packages/docs-site preview   # serve the production build locally
+```
+
+`bun run --cwd packages/docs-site build` runs two steps: it regenerates the library's TypeDoc API reference straight
+into `public/api/` (so it's always built from the checked-out source, not a stale copy), then runs the VitePress
+production build. Both `public/api/` and `.vitepress/dist` are gitignored — nothing generated here is committed.
+
+## The `ai-planning/` convention
+
+Design decisions in this repository are written up **before** the implementation, not after — see
+[`ai-planning/README.md`](https://github.com/robertmassaioli/openapi-merge/blob/main/ai-planning/README.md) on
+GitHub for the numbering scheme and layout. If you're proposing a non-trivial change, a short proposal there
+describing the current behaviour, what's changing and why, saves a lot of back-and-forth in review.
+
+## Contributing
+
+Issues and pull requests are welcome at
+[github.com/robertmassaioli/openapi-merge](https://github.com/robertmassaioli/openapi-merge). If you're fixing a bug,
+a `bun:test` case that reproduces it first makes review much faster.

--- a/packages/docs-site/guide/quick-start-cli.md
+++ b/packages/docs-site/guide/quick-start-cli.md
@@ -1,0 +1,80 @@
+# Quick start: CLI
+
+## 1. Install
+
+You don't need to install anything up front — `npx` fetches it on demand. If you'd rather install it:
+
+```bash
+npm install --save-dev openapi-merge-cli
+# or: bun add -d openapi-merge-cli
+```
+
+## 2. Generate a starting configuration
+
+Run `init` in a directory containing your OpenAPI files:
+
+```bash
+npx openapi-merge-cli init
+```
+
+`init` scans the current directory (not recursively) for `.json`/`.yaml`/`.yml` files that declare a top-level
+`openapi: 3.x`, and writes `openapi-merge.yaml` pre-filled with what it found — plus every other optional setting
+this tool supports, included and commented out, each with a one-line explanation. See
+[CLI reference → Getting started](/cli/#getting-started-init) for the full behaviour.
+
+## 3. Edit the configuration
+
+Open `openapi-merge.yaml`. At minimum you need `inputs` (one entry per file to merge) and `output`. A typical
+gateway-style configuration looks like:
+
+```yaml
+inputs:
+  - inputFile: ./gateway.swagger.json
+  - inputFile: ./jira.swagger.json
+    pathModification:
+      stripStart: /rest
+      prepend: /jira
+    operationSelection:
+      includeTags: [included]
+  - inputFile: ./confluence.swagger.yaml
+    dispute:
+      prefix: Confluence
+    pathModification:
+      prepend: /confluence
+output: ./output.swagger.json
+```
+
+The full field-by-field reference is in [CLI reference → Configuration](/cli/configuration).
+
+## 4. Run the merge
+
+```bash
+npx openapi-merge-cli
+```
+
+This reads `openapi-merge.yaml` (or `openapi-merge.json`, for older configurations) from the current directory and
+writes the merged document to the configured `output` path. Point at a specific file instead with:
+
+```bash
+npx openapi-merge-cli --config path/to/openapi-merge.yaml
+```
+
+## 5. Check the exit code in CI
+
+The CLI's exit codes are part of its contract — see [CLI reference → Exit codes](/cli/exit-codes) for the full table
+and which failures are worth retrying.
+
+```bash
+openapi-merge-cli
+case $? in
+  0) echo "merged" ;;
+  7) echo "upstream is down, retrying later"; exit 75 ;;
+  *) echo "merge failed permanently"; exit 1 ;;
+esac
+```
+
+## Next steps
+
+- [Selecting only some operations by tag or path](/cli/examples)
+- [Following cross-document `$ref`s](/cli/cross-document-refs)
+- [Restricting where the CLI reads/writes, for untrusted configs](/cli/security)

--- a/packages/docs-site/guide/quick-start-library.md
+++ b/packages/docs-site/guide/quick-start-library.md
@@ -1,0 +1,67 @@
+# Quick start: library
+
+## 1. Install
+
+```bash
+npm install openapi-merge
+# or: bun add openapi-merge
+```
+
+## 2. Call `merge()`
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const serviceA = {
+  openapi: '3.0.2',
+  info: { title: 'Service A', version: '1.0' },
+  paths: {
+    '/cats': {
+      get: { summary: 'Get the cats', responses: { 200: { description: 'All of the cats' } } },
+    },
+  },
+};
+
+const serviceB = {
+  openapi: '3.0.2',
+  info: { title: 'Service B', version: '1.0' },
+  paths: {
+    '/dogs': {
+      get: { summary: 'Get the dogs', responses: { 200: { description: 'All of the dogs' } } },
+    },
+  },
+};
+
+const result = merge([
+  { oas: serviceA, pathModification: { prepend: '/one' } },
+  { oas: serviceB, pathModification: { prepend: '/two' } },
+]);
+
+if (isErrorResult(result)) {
+  console.error(`${result.message} (${result.type})`);
+} else {
+  console.log(JSON.stringify(result.output, null, 2));
+}
+```
+
+`merge()` takes an array of inputs (each `{ oas, ...per-input options }`) and an optional second argument,
+`MergeOptions`, for settings that apply to the merge as a whole. See:
+
+- [Library reference → Per-input options](/library/per-input-options) for `pathModification`, `dispute`,
+  `operationSelection`, `description`, `duplicatePathHandling` and `tag`.
+- [Library reference → Merge options](/library/merge-options) for `pruneUnusedComponents`, `info`,
+  `serversStrategy`, `securitySchemesStrategy` and `externalDocuments`.
+
+## 3. Handle the result
+
+`merge()` never throws for a malformed *merge* — every failure comes back as a typed `ErrorMergeResult` (`isErrorResult`
+narrows to it), with a `type` and a human-readable `message`. See
+[Library reference → Merging behaviour](/library/merging-behaviour) for what each error type means and when it fires.
+
+## 4. Go deeper
+
+- The full type shapes (`MergeInput`, `MergeOptions`, `MergeResult`, and every option type) are generated straight
+  from the source in the [Generated API reference](/library/api-reference) — that's the place to check an exact
+  field name or optionality rather than this guide.
+- [Library reference → Examples](/library/examples) has a couple of end-to-end scenarios (tag-based filtering,
+  pulling in an external document via `externalDocuments`).

--- a/packages/docs-site/guide/which-package.md
+++ b/packages/docs-site/guide/which-package.md
@@ -1,0 +1,46 @@
+# Which package do I want?
+
+This repository publishes two npm packages, and almost everything you read in this site's **CLI reference** and
+**Library reference** sections applies to both — the CLI is a thin wrapper around the library, so the merge semantics
+(what "first input wins" means, how `paths` and `components` get combined, what `dispute` does) are identical either
+way.
+
+## Use the CLI: [`openapi-merge-cli`](https://www.npmjs.com/package/openapi-merge-cli)
+
+Use this if you have one or more OpenAPI files on disk (or reachable by URL) and want a merged file produced by a
+configuration file and a command — no code to write.
+
+```bash
+npx openapi-merge-cli init   # writes a starting openapi-merge.yaml
+npx openapi-merge-cli        # merges according to that configuration
+```
+
+Start at [CLI reference → Getting started](/cli/).
+
+## Use the library: [`openapi-merge`](https://www.npmjs.com/package/openapi-merge)
+
+Use this if you're merging specs programmatically — as part of a larger build step, a gateway-generation tool, or
+anywhere you'd rather call a function than shell out to a CLI and read a config file back off disk.
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const result = merge([{ oas: serviceA }, { oas: serviceB }]);
+if (!isErrorResult(result)) {
+  console.log(result.output);
+}
+```
+
+Start at [Library reference → Getting started](/library/).
+
+## The intended use case
+
+Both packages are built around one motivating scenario: **you have several microservices, each with its own OpenAPI
+spec, and you want to expose them through a single API gateway with one combined spec.** That shapes several default
+decisions you'll run into in the reference sections — for example, `info`, `servers` and `externalDocs` default to
+"the first input wins" rather than "merge them somehow," because in the gateway scenario the first input is usually
+the gateway's own spec and the rest are backends whose own top-level metadata shouldn't leak into the published
+document.
+
+The merging logic is generic enough to use outside that scenario, but if a default ever seems surprising, this is
+usually why it's the default.

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -1,0 +1,35 @@
+---
+layout: home
+
+hero:
+  name: openapi-merge
+  text: Merge OpenAPI documents, deterministically
+  tagline: Combine multiple OpenAPI 3.0, 3.1 or 3.2 files into one — from the command line or from TypeScript — for the common case of exposing several microservices behind a single API gateway.
+  actions:
+    - theme: brand
+      text: Which package do I want?
+      link: /guide/which-package
+    - theme: alt
+      text: CLI reference
+      link: /cli/
+    - theme: alt
+      text: Library reference
+      link: /library/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/robertmassaioli/openapi-merge
+
+features:
+  - icon: 🧩
+    title: Deterministic merging
+    details: The first input always takes precedence for element-level conflicts (info, servers, security schemes), while paths, components and tags are merged so nothing is silently dropped.
+  - icon: 🛠️
+    title: CLI or library
+    details: Merge from a YAML/JSON config file with openapi-merge-cli, or call merge() directly from TypeScript/JavaScript with openapi-merge — the CLI is a thin wrapper around the library.
+  - icon: 🧬
+    title: OpenAPI 3.0, 3.1 and 3.2
+    details: Merges webhooks, components.pathItems, additionalOperations custom verbs, and the other constructs newer OpenAPI versions introduce — not just the 3.0 subset.
+  - icon: 🔒
+    title: Safe by default for untrusted input
+    details: inputRoot / outputRoot (and their CLI flags) bound where the CLI will read from and write to, for the case where the configuration or inputs aren't fully trusted.
+---

--- a/packages/docs-site/library/api-reference.md
+++ b/packages/docs-site/library/api-reference.md
@@ -1,0 +1,47 @@
+---
+next: false
+---
+
+<script setup>
+import { withBase } from 'vitepress';
+</script>
+
+# Generated API reference
+
+The pages in this section describe *what each option means and when to use it*. For the exact TypeScript shape of
+every type — every field, its optionality, and its JSDoc — the generated API reference is produced directly from
+the library's source (`packages/openapi-merge/src/index.ts` and everything it exports), via
+[TypeDoc](https://typedoc.org/), so it cannot drift from what the code actually accepts the way hand-written prose
+can.
+
+<a :href="withBase('/api/')" class="api-reference-link">Open the generated API reference →</a>
+
+::: tip
+That link only resolves after a full production build (`bun run --cwd packages/docs-site build`), since the API
+reference is generated straight into `public/api/` as part of that build — it 404s under `vitepress dev`, which
+doesn't run the generation step. Use `bun run --cwd packages/docs-site build && bun run --cwd packages/docs-site preview`
+to see it locally.
+:::
+
+Useful starting points once you're there:
+
+- `MergeInput` / `SingleMergeInput` — the first argument to `merge()`.
+- `MergeOptions` — the second argument, documented in prose at [Merge options](/library/merge-options).
+- `MergeResult`, `SuccessfulMergeResult`, `ErrorMergeResult`, `ErrorType` — what `merge()` returns; see
+  [Merging behaviour](/library/merging-behaviour) for the prose version of every error type.
+
+<style>
+.api-reference-link {
+  display: inline-block;
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  border-radius: 6px;
+  background-color: var(--vp-c-brand-1);
+  color: var(--vp-c-white);
+  text-decoration: none;
+  font-weight: 600;
+}
+.api-reference-link:hover {
+  background-color: var(--vp-c-brand-2);
+}
+</style>

--- a/packages/docs-site/library/examples.md
+++ b/packages/docs-site/library/examples.md
@@ -1,0 +1,74 @@
+# Examples
+
+## Filtering operations by tag while merging
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const result = merge([
+  { oas: gatewaySpec },
+  {
+    oas: jiraSpec,
+    pathModification: { stripStart: '/rest', prepend: '/jira' },
+    operationSelection: { includeTags: ['included'] },
+  },
+  {
+    oas: confluenceSpec,
+    dispute: { prefix: 'Confluence' },
+    pathModification: { prepend: '/confluence' },
+    operationSelection: { excludeTags: ['excluded'] },
+  },
+]);
+
+if (isErrorResult(result)) {
+  throw new Error(`${result.type}: ${result.message}`);
+}
+
+console.log(result.output);
+```
+
+Same configuration shape as the [CLI's configuration file](/cli/configuration) — that's deliberate, since the CLI
+is a thin wrapper that just deserialises YAML/JSON into these same objects and calls `merge()`.
+
+## Pulling in an external document via `MergeOptions.externalDocuments`
+
+This is what powers the CLI's `resolveExternalReferences` — the library itself does no I/O, so the caller loads the
+documents and hands them over:
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const commonErrors = await loadDocument('./common/Errors.yml'); // your own loader
+
+const result = merge(
+  [{ oas: apiSpec, sourceIdentity: './api.yaml' }],
+  {
+    externalDocuments: {
+      './common/Errors.yml': commonErrors,
+    },
+  },
+);
+```
+
+A `$ref` in `apiSpec` shaped `../common/Errors.yml#/components/schemas/ServerError` is resolved against the key
+`'./common/Errors.yml'` here (resolving that relative path to the same key is the caller's job — see
+[Per-input options → `sourceIdentity`](/library/per-input-options#sourceidentity)). Only the specific components
+actually referenced are pulled in; `commonErrors` is never included wholesale.
+
+## Overriding the merged `info` and requiring stricter security-scheme handling
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const result = merge(inputs, {
+  info: { title: 'Combined Gateway API', description: 'All backend services, one document.' },
+  securitySchemesStrategy: 'error', // fail fast on a genuine scheme conflict, rather than renaming around it
+  pruneUnusedComponents: true,      // this merge filters operations, so drop schemas nothing references anymore
+});
+
+if (isErrorResult(result)) {
+  console.error(`${result.message} (${result.type})`);
+}
+```
+
+See [Merge options](/library/merge-options) for the full set of second-argument settings.

--- a/packages/docs-site/library/index.md
+++ b/packages/docs-site/library/index.md
@@ -1,0 +1,62 @@
+# Library reference
+
+`openapi-merge` provides a single `merge()` function that takes an array of OpenAPI 3.0, 3.1 or 3.2 documents (each
+with per-input options) and produces one combined OpenAPI document, or a typed error describing why the merge
+failed. [`openapi-merge-cli`](/cli/) is a thin wrapper around this library — everything documented here applies to
+the CLI too.
+
+## Installing
+
+```bash
+npm install openapi-merge
+```
+
+## `merge()`
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const result = merge(inputs, options);
+
+if (isErrorResult(result)) {
+  console.error(`${result.message} (${result.type})`);
+} else {
+  console.log(result.output); // the merged OpenAPI document
+}
+```
+
+```ts
+function merge(inputs: MergeInput, options?: MergeOptions): MergeResult;
+```
+
+- **`inputs`** (`MergeInput`, i.e. `SingleMergeInput[]`) — one entry per document to merge, each `{ oas, ...
+  per-input options }`. See [Per-input options](/library/per-input-options).
+- **`options`** (`MergeOptions`, optional) — settings for the merge as a whole rather than any one input. See
+  [Merge options](/library/merge-options).
+- **Returns** a `MergeResult`: either `{ output: OpenApiDocument }` on success, or `{ type, message }` on failure —
+  `isErrorResult()` narrows to the latter. See [Merging behaviour](/library/merging-behaviour) for what each error
+  `type` means.
+
+`merge()` is synchronous and never throws for a malformed merge: every failure mode comes back as a typed result.
+(It *can* throw for a small class of programmer errors treated as internal invariants — see
+[Merging behaviour](/library/merging-behaviour#thrown-vs-returned-errors).)
+
+## Other exports
+
+| Export | What it is |
+| --- | --- |
+| `merge` | The function above. |
+| `isErrorResult` | Type guard narrowing a `MergeResult` to its error case. |
+| `MalformedDocumentError` | The error class thrown (not returned) for a `null` in a structural slot — see [Merging behaviour](/library/merging-behaviour#thrown-vs-returned-errors). |
+| `MergeInput`, `MergeResult`, `PathModification`, `OperationSelection`, `MergeOptions`, `ServersStrategy`, `SecuritySchemesStrategy` | Types, re-exported for consumers who want to name them explicitly. |
+
+Every other type (`SingleMergeInput`, `SuccessfulMergeResult`, `ErrorMergeResult`, `Dispute`, `TagInjection`, …) is
+part of the public shape reachable from these but not re-exported by name from the package root — see the
+[Generated API reference](/library/api-reference) for the exact shapes.
+
+## Next
+
+- [Merge options](/library/merge-options) — the second argument to `merge()`.
+- [Per-input options](/library/per-input-options) — everything you can set per document being merged.
+- [Merging behaviour](/library/merging-behaviour) — what gets combined, what's first-wins, and every error type.
+- [Examples](/library/examples) — a couple of end-to-end scenarios.

--- a/packages/docs-site/library/merge-options.md
+++ b/packages/docs-site/library/merge-options.md
@@ -1,0 +1,97 @@
+# Merge options
+
+`merge()`'s optional second argument, `MergeOptions`, holds settings that apply to the merge as a whole rather than
+to any single input. Every field is optional, and every default reproduces the behaviour that existed before the
+option did — `merge(inputs)` with no second argument is unchanged.
+
+## `pruneUnusedComponents`
+
+```ts
+pruneUnusedComponents?: boolean; // default: false
+```
+
+Drop components that nothing in the merged document references
+([issue #94](https://github.com/robertmassaioli/openapi-merge/issues/94)). Off by default because pruning is
+destructive — this library has always preserved every component it was given, and a document may carry
+definitions referenced only from outside it. Turn it on when `operationSelection` is removing operations and you
+expect the schemas only those operations used to go with them. Reachability is computed from the surviving
+document, so a component still used by another endpoint is kept.
+
+## `info`
+
+```ts
+info?: Partial<Swagger.Info>;
+```
+
+Override fields of the merged `info` object ([issue #102](https://github.com/robertmassaioli/openapi-merge/issues/102)).
+`info` is otherwise taken entirely from the first input, so a merged document is titled after whichever service
+happens to be listed first — misleading for an aggregate API that is none of its inputs. Merged field by field, so
+overriding only `title` doesn't require restating the required `version`. Applied *after* description appending, so
+an explicit `description` here wins over the appended one.
+
+## `serversStrategy`
+
+```ts
+serversStrategy?: ServersStrategy; // 'first' | 'concat', default: 'first'
+```
+
+How the top-level `servers` array is combined ([issue #4](https://github.com/robertmassaioli/openapi-merge/issues/4)):
+
+- **`'first'`** (default) — the first input that declares `servers` wins; the rest are discarded. This is the
+  historical behaviour, and remains the default because the library is aimed at putting several services behind
+  one API gateway, where the gateway's servers are canonical and a backend's own URLs are an implementation detail
+  that must not leak into the published document.
+- **`'concat'`** — every input's servers, in input order, deduplicated by URL alone (two entries with the same URL
+  but different `description`s are treated as the same server described twice).
+
+## `securitySchemesStrategy`
+
+```ts
+securitySchemesStrategy?: SecuritySchemesStrategy; // 'first' | 'merge' | 'error', default: 'merge'
+```
+
+How `components.securitySchemes` is combined ([issue #33](https://github.com/robertmassaioli/openapi-merge/issues/33)).
+Unlike `serversStrategy`, whose default keeps the historical first-wins behaviour, **this one changed its default**:
+first-wins here produced documents whose operations required a scheme the document didn't define, which is a
+defect rather than a preference.
+
+- **`'merge'`** (default) — combine them exactly as every other component bucket is combined: identical
+  definitions collapse, differing ones are renamed using the input's `dispute` prefix/suffix (or a numeric
+  suffix), and every security requirement naming a renamed scheme is rewritten to match.
+- **`'first'`** — take the schemes from the first input that declares any, and drop the rest. The behaviour before
+  this option existed. Right for an API gateway that owns authentication and doesn't want a backend's own scheme
+  definitions in the published document — but a later input's operations may then require a scheme the output
+  doesn't define.
+- **`'error'`** — combine them like `'merge'`, but fail if two inputs define the same scheme name differently,
+  rather than renaming around it. Identical definitions still collapse.
+
+## `externalDocuments`
+
+```ts
+externalDocuments?: Record<string, OpenApiDocument>;
+```
+
+Documents this merge may need to pull individual components out of, keyed by the same opaque identity described on
+each input's `sourceIdentity` ([issue #10](https://github.com/robertmassaioli/openapi-merge/issues/10)). Unlike an
+input, a document here never contributes `paths`, `webhooks`, `info`, `security`, `tags` or anything else to the
+output on its own — only the specific components a `$ref` elsewhere in the merge actually asks for are pulled in
+(and, transitively, whatever those components' own references need), deduplicated against the rest of the output
+exactly like any other component. A document listed here that nothing ends up referencing contributes nothing at
+all.
+
+Loading these — from disk, or over the network — is entirely the caller's job. By the time this reaches `merge()`,
+every document is already an in-memory object and merging proceeds synchronously, same as always. This is exactly
+what [`openapi-merge-cli`'s `resolveExternalReferences`](/cli/cross-document-refs) does the file/URL loading for.
+
+## Full example
+
+```ts
+import { merge, ServersStrategy, SecuritySchemesStrategy } from 'openapi-merge';
+
+const result = merge(inputs, {
+  pruneUnusedComponents: true,
+  info: { title: 'Combined Gateway API' },
+  serversStrategy: 'concat' satisfies ServersStrategy,
+  securitySchemesStrategy: 'error' satisfies SecuritySchemesStrategy,
+});
+```

--- a/packages/docs-site/library/merging-behaviour.md
+++ b/packages/docs-site/library/merging-behaviour.md
@@ -1,0 +1,96 @@
+# Merging behaviour
+
+Inputs are processed sequentially: **the first input in the list takes precedence**, and subsequent inputs are
+modified to merge seamlessly into it. This section is the reference for exactly what that means, field by field,
+and for every way `merge()` can fail.
+
+## What's actually merged vs. first-wins
+
+For `paths`, `components`, `webhooks` and `tags`, the library **merges** the definitions from every input, so
+there's no overlap and no information is dropped (subject to the conflict rules below).
+
+For most other top-level elements, the default is that **the first input that declares it wins**, and later inputs'
+values are discarded:
+
+| Element | Default | Configurable? |
+| --- | --- | --- |
+| `info` | First input | Field-by-field override via [`MergeOptions.info`](/library/merge-options#info) |
+| `servers` | First input with any | [`MergeOptions.serversStrategy`](/library/merge-options#serversstrategy): `'concat'` keeps every input's servers instead |
+| `externalDocs` | First input with any | Not configurable |
+| `components.securitySchemes` | **Merged** (not first-wins) | [`MergeOptions.securitySchemesStrategy`](/library/merge-options#securityschemesstrategy) can select `'first'` or `'error'` instead |
+
+Security schemes are the one component bucket that does **not** default to first-wins the way `info`/`servers`/
+`externalDocs` do — see [Merge options → `securitySchemesStrategy`](/library/merge-options#securityschemesstrategy)
+for why the default changed.
+
+The intent behind first-wins-by-default: this library is aimed at putting several services behind one API gateway,
+where the gateway's own `info`/`servers`/`externalDocs` are canonical and a backend's own values are an
+implementation detail that shouldn't leak into the published document.
+
+## `$self` (OpenAPI 3.1+)
+
+`$self` declares a document's own identity. A merged document is not any one of its inputs, so carrying one input's
+`$self` forward would assert an identity the output doesn't have — and because `$self` participates in reference
+resolution, a stale value could change how relative `$ref`s resolve. It's kept only in the degenerate single-input
+case, where the output really is that document, and dropped otherwise.
+
+## Deduplication
+
+Components (schemas, parameters, responses, etc.) that are structurally identical across inputs are collapsed into
+one. Components that share a name but differ are renamed using that input's `dispute` setting (prefix or suffix),
+or reported as a `component-definition-conflict` error if no dispute is configured. `operationId`s follow the same
+pattern: a genuine collision that no dispute can resolve is an `operation-id-conflict`.
+
+## Error types
+
+Every failure `merge()` can return comes back as `{ type: ErrorType, message: string }`:
+
+| `type` | When it fires |
+| --- | --- |
+| `no-inputs` | `inputs` was empty. |
+| `duplicate-paths` | Two inputs declared the same path (or webhook) and `duplicatePathHandling` didn't resolve it. |
+| `component-definition-conflict` | Two inputs defined a component with the same name but different content, and no `dispute` resolved it. |
+| `operation-id-conflict` | Two operations ended up with the same `operationId` and no `dispute` resolved it. |
+| `unsupported-openapi-version` | An input declared a version this library can't merge, or none at all. |
+| `mixed-openapi-versions` | The inputs didn't all declare the same `major.minor` OpenAPI version. |
+| `duplicate-webhooks` | Two inputs declared the same webhook name (3.1). |
+| `cyclic-external-reference` | A component reachable from `MergeOptions.externalDocuments` transitively references itself. |
+| `malformed-document` | A `null` sits in a slot the spec requires to be an object (or, for a discriminator mapping target, a string) — e.g. `schemas: { Widget: }`, an empty YAML value. |
+
+## Thrown vs. returned errors {#thrown-vs-returned-errors}
+
+Almost everything above is *returned* as an `ErrorMergeResult` — `merge()` does not throw for a malformed merge.
+There is one deliberate exception: `malformed-document` is detected deep inside a recursive reference-walk with no
+error-return type threaded through dozens of intermediate call sites, so it's *thrown* as `MalformedDocumentError`
+from wherever it's found, and caught narrowly at the top of `merge()` — converted into the `malformed-document`
+result before it ever reaches your code
+([issue #92](https://github.com/robertmassaioli/openapi-merge/issues/92)).
+
+`MalformedDocumentError` is exported from the package root in case you need to recognise it in a context that
+bypasses `merge()`'s own catch (it shouldn't, in normal use). Anything else thrown out of `merge()` — an internal
+invariant violation, like "more than one matching key" during deduplication — represents a real bug in this
+library, not a merge failure to handle, and is intentionally left to propagate rather than swallowed.
+
+## Example: handling every error type
+
+```ts
+import { merge, isErrorResult } from 'openapi-merge';
+
+const result = merge(inputs);
+
+if (isErrorResult(result)) {
+  switch (result.type) {
+    case 'duplicate-paths':
+    case 'component-definition-conflict':
+    case 'operation-id-conflict':
+      // Configuration problem: adjust `dispute` / `duplicatePathHandling` and retry.
+      break;
+    case 'unsupported-openapi-version':
+    case 'mixed-openapi-versions':
+      // The inputs themselves need to change (convert or align versions).
+      break;
+    default:
+      console.error(result.message);
+  }
+}
+```

--- a/packages/docs-site/library/per-input-options.md
+++ b/packages/docs-site/library/per-input-options.md
@@ -1,0 +1,133 @@
+# Per-input options
+
+Each entry in `MergeInput` (the first argument to `merge()`) is a `SingleMergeInput`: `{ oas, ...options }`. `oas` is
+the only required field — an in-memory OpenAPI document. Everything else is optional.
+
+## `sourceIdentity`
+
+```ts
+sourceIdentity?: string;
+```
+
+An opaque identity for this input — typically the resolved absolute path or URL it was loaded from
+([issue #104](https://github.com/robertmassaioli/openapi-merge/issues/104)). The library never parses or resolves
+this string; it only compares it for exact equality against the non-fragment portion of a `$ref` found elsewhere in
+the merge. A `$ref` shaped `<this input's sourceIdentity>#/components/schemas/X` found anywhere in the merge is
+treated as if it were the bare, in-document ref `#/components/schemas/X` *as seen from this input* — rewritten to
+wherever this input's `X` ended up after deduplication/renaming, exactly like any other reference into this input.
+
+Resolving the file-path or URL portion of a cross-document `$ref` against this identity (e.g. deciding that
+`../common/Errors.yml` in one input refers to the same file as another input's own path) is the caller's job —
+normally `openapi-merge-cli`, which knows about file paths and can do the async I/O this library deliberately does
+not do.
+
+## `pathModification`
+
+```ts
+pathModification?: { stripStart?: string; prepend?: string };
+```
+
+Rewrites every path (and 3.1 webhook name) imported from this input. `stripStart` removes that prefix if present;
+`prepend` adds a prefix. `prepend` always runs after `stripStart`, so the two compose predictably.
+
+## `duplicatePathHandling`
+
+```ts
+duplicatePathHandling?: 'error' | 'skip-later' | 'prefer-later' | 'merge-operations'; // default: 'error'
+```
+
+What to do when this input declares a path (or webhook) another input already added
+([issue #71](https://github.com/robertmassaioli/openapi-merge/issues/71)):
+
+- **`'error'`** (default) — fail with `duplicate-paths`, the historical behaviour.
+- **`'skip-later'`** — keep the definition already present and drop this input's.
+- **`'prefer-later'`** — replace the definition already present with this one.
+- **`'merge-operations'`** — combine them when their method sets are disjoint and their path-level fields agree, so
+  `GET /thing` from one input and `POST /thing` from another end up in one path item. Refuses with
+  `duplicate-paths` whenever a union would be a guess: overlapping methods, differing path-level fields, or a
+  `$ref` path item on either side.
+
+Per input rather than global, because what people actually want to express is "this one input wins and the rest
+are additive," which a single global setting can't say.
+
+## `operationSelection`
+
+```ts
+operationSelection?: {
+  includeTags?: string[];
+  excludeTags?: string[];
+  includePaths?: PathSelector[];
+  excludePaths?: PathSelector[];
+};
+```
+
+Filters which operations from this input are kept:
+
+- **`includeTags`** — allow-list. Only operations carrying one of these tags survive; an operation with no tags at
+  all does not. Does not remove other tags from this input's top-level `tags` definition.
+- **`excludeTags`** — deny-list. Operations carrying any of these tags are dropped, and the tags themselves are
+  removed from this input's top-level `tags` before merging.
+- **`includePaths` / `excludePaths`** (`PathSelector[]`, `{ path: string; method?: string | string[] }`) — the same
+  two allow/deny lists, but matched by path (with an optional `*` wildcard) and method instead of by tag. Matched
+  against this input's own original path, before `pathModification` runs. `method` accepts a 3.2
+  `additionalOperations` custom verb like `"PURGE"`, matched case-sensitively.
+
+**Precedence**: exclusion always wins over inclusion. If an operation is matched by both an include and an exclude
+rule — of the same kind or different kinds — it's excluded. If both `includeTags` and `includePaths` are set, an
+operation must pass *both* to survive. See [CLI reference → Configuration](/cli/configuration#operationselection-precedence)
+for the full precedence table (the library and the CLI share this logic exactly).
+
+## `description`
+
+```ts
+description?: { append: boolean; title?: { value: string; headingLevel?: number } };
+```
+
+Controls how this input's `info.description` contributes to the merged `info.description`. `append: true` appends
+it (in input order) to the merged description; `title` optionally wraps it in a Markdown heading (`headingLevel`
+1–6, default 1).
+
+## `tag`
+
+```ts
+tag?: { name: string; description?: string };
+```
+
+Adds a tag to every operation from this input ([issue #112](https://github.com/robertmassaioli/openapi-merge/issues/112)).
+Lets a merged document distinguish which service each operation came from without anybody editing the upstream
+specification. Applied *after* `operationSelection`, so an injected tag cannot influence which operations survive —
+applying it first would make `includeTags: ['billing']` match operations solely because this input injects
+`billing`, which would read as a filter doing nothing. If another input already contributed a tag of the same name,
+that input's `description` wins (first-wins, as everywhere else in this merge).
+
+## `dispute`
+
+```ts
+dispute?: { prefix: string; alwaysApply?: boolean } | { suffix: string; alwaysApply?: boolean };
+```
+
+How to resolve a naming collision when two inputs define a component with the same name but different content.
+`prefix`/`suffix` names the string to disambiguate with; `alwaysApply: true` applies it to every schema from this
+input, not just the ones actually in conflict (useful for keeping naming consistent, at the cost of possibly
+preventing deduplication of components that would otherwise have collapsed).
+
+::: details Deprecated: `disputePrefix` (v1 shape)
+The original shape, `disputePrefix?: string` directly on the input (instead of `dispute: { prefix }`), still works
+and is exercised by existing configurations, but is deprecated in favour of `dispute`. New code should use
+`dispute`.
+:::
+
+## Full example
+
+```ts
+const input: SingleMergeInput = {
+  oas: confluenceSpec,
+  sourceIdentity: './confluence.swagger.yaml',
+  pathModification: { stripStart: '/rest', prepend: '/confluence' },
+  duplicatePathHandling: 'merge-operations',
+  operationSelection: { excludeTags: ['internal'] },
+  description: { append: true, title: { value: 'Confluence', headingLevel: 2 } },
+  tag: { name: 'confluence', description: 'Operations from the Confluence service' },
+  dispute: { prefix: 'Confluence', alwaysApply: false },
+};
+```

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "openapi-merge-docs-site",
+  "version": "0.0.0",
+  "description": "Documentation microsite for openapi-merge and openapi-merge-cli.",
+  "private": true,
+  "scripts": {
+    "dev": "vitepress dev",
+    "build:api": "bun run --cwd ../openapi-merge docs -- --out ../docs-site/public/api",
+    "build": "bun run build:api && vitepress build",
+    "preview": "vitepress preview",
+    "lint": "eslint .vitepress --fix --format=visualstudio"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.0.0",
+    "eslint-formatter-visualstudio": "^9.0.1",
+    "globals": "^17.7.0",
+    "typescript-eslint": "^8.65.0",
+    "vitepress": "^1.6.4"
+  }
+}

--- a/packages/docs-site/public/favicon.svg
+++ b/packages/docs-site/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#3c8772"/>
+  <path d="M8 12 L16 8 L24 12 M8 12 L8 20 L16 24 L24 20 L24 12 M8 12 L16 16 L24 12 M16 16 L16 24"
+        fill="none" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>

--- a/packages/openapi-merge-cli/src/exit-codes.ts
+++ b/packages/openapi-merge-cli/src/exit-codes.ts
@@ -9,6 +9,11 @@
  * Every member is pinned by `src/__tests__/exit-codes.test.ts`, so renumbering
  * one fails the build rather than someone's pipeline.
  *
+ * This table is mirrored by hand in three other places -- none of them build-
+ * checked, so a new code silently drifts if only added here. Update all of
+ * them: this package's README, `AGENTS.md`, and
+ * `packages/docs-site/cli/exit-codes.md`.
+ *
  * | Exit Code | Member                                 | Meaning                                  |
  * |-----------|----------------------------------------|------------------------------------------|
  * | 0         | ExitCode.Success                       | Merge succeeded, output written          |


### PR DESCRIPTION
## Summary

Implements option 3 of #149: a documentation microsite covering both `openapi-merge` and `openapi-merge-cli`, built with VitePress and deployed to GitHub Pages.

- **`packages/docs-site`** (new, unpublished workspace member): a Guide (which package, quick starts, developing), a full **CLI reference** (configuration, every flag, formatting, cross-document `$ref`s, the `inputRoot`/`outputRoot` trust model, exit codes, OpenAPI version support, examples) and a full **Library reference** (`merge()`, `MergeOptions`, per-input options, merging behaviour and every error type, examples).
- The library's generated TypeDoc API reference (added in #151) is built a second time straight into `public/api/` (gitignored) and served at `/api/` alongside the hand-written pages — verified end-to-end with `vitepress preview`.
- **`.github/workflows/docs-deploy.yml`**: builds and deploys the site to GitHub Pages on push to `main`.

Full rationale, including the canonical-source decision, in [`ai-planning/issues/47-proposal-149-documentation-microsite.md`](../blob/worktree-docs-microsite/ai-planning/issues/47-proposal-149-documentation-microsite.md).

## Things worth knowing before merging

- **GitHub Pages is not currently enabled for this repo** (checked via `gh api repos/robertmassaioli/openapi-merge/pages` → 404, not assumed). The workflow runs and produces a deployable artifact regardless, but you'll need to flip **Settings → Pages → Source → GitHub Actions** once for it to actually go live.
- **VitePress's `base` is hardcoded to `/openapi-merge/`**, matching where a project-repo Pages site with no custom domain serves from. This can't be exercised by a local dev server (always serves at `/`), so it's the one thing here that needs a post-merge, post-Pages-enable eyeball against the live URL — everything else was verified locally against a full production build under that base path.
- **The two package READMEs are untouched.** This branch forked from `main` before #151 merged and would have conflicted with it on the same files for an unrelated reason. The proposal records trimming the READMEs down to quick-start pointers (now that the site is canonical for reference depth) as an explicit follow-up, not attempted here.
- Every factual claim on the site (exit codes, OpenAPI version support, option defaults, CLI flags) was written from current source, not copied from the READMEs.

## Test plan

- [x] `bun run lint` / `bun run test` at the repository root pass (docs-site adds no build/typecheck/test burden to the other packages — verified empirically that `bun run --filter '*'` skips a workspace package lacking a given script)
- [x] `bun run --cwd packages/docs-site build` succeeds (TypeDoc generation + VitePress build, 0 errors)
- [x] `vitepress preview` manually checked: home, every guide/CLI/library page, `/api/`, and the nav's API Reference link all resolve correctly under `/openapi-merge/`
- [x] Confirmed `public/api/`, `.vitepress/dist/`, `.vitepress/cache/` are all gitignored (checked `git status` after a build, not just declared)
- [x] Validated the new workflow's YAML syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)