### PR TITLE
docs(readme): link the live documentation site front and center

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## The openapi-merge repository
 
+### 📖 [Read the full documentation](https://robertmassaioli.github.io/openapi-merge/)
+
 Welcome to the openapi-merge repository. This library is intended to be used for merging multiple OpenAPI 3.0, 3.1 and 3.2 files together. The most common reason that developers want to do this is because they have multiple services that they wish to expose underneath a single API Gateway. Therefore, even though this merging logic is sufficiently generic to be used for most use cases, some of the feature decisions are tailored for that specific use case.
 
 ### Screenshots
@@ -16,10 +18,10 @@ This is a multi-package repository that contains:
 
 #### Which package do I want?
 
-* **Use the CLI** ([`openapi-merge-cli`](packages/openapi-merge-cli)) if you have one or more OpenAPI files on disk (or reachable by URL) and want a merged file produced by a config file and a command — no code to write.
-* **Use the library** ([`openapi-merge`](packages/openapi-merge)) if you're merging specs programmatically, e.g. as part of a larger build or gateway-generation tool. The CLI is itself a thin wrapper around this library, so anything the CLI can do, the library can do from your own code.
+* **Use the CLI** ([`openapi-merge-cli`](packages/openapi-merge-cli)) if you have one or more OpenAPI files on disk (or reachable by URL) and want a merged file produced by a config file and a command — no code to write. See the [CLI reference](https://robertmassaioli.github.io/openapi-merge/cli/).
+* **Use the library** ([`openapi-merge`](packages/openapi-merge)) if you're merging specs programmatically, e.g. as part of a larger build or gateway-generation tool. The CLI is itself a thin wrapper around this library, so anything the CLI can do, the library can do from your own code. See the [library reference](https://robertmassaioli.github.io/openapi-merge/library/).
 
-Please see the README file of the specific package for full usage details.
+Please see the README file of the specific package, or the [documentation site](https://robertmassaioli.github.io/openapi-merge/), for full usage details.
 
 ### Developing on openapi-merge
 

--- a/packages/openapi-merge-cli/README.md
+++ b/packages/openapi-merge-cli/README.md
@@ -1,5 +1,7 @@
 # openapi-merge-cli
 
+### 📖 [Read the full CLI reference](https://robertmassaioli.github.io/openapi-merge/cli/)
+
 This tool is based on the [![npm](https://img.shields.io/npm/v/openapi-merge?label=openapi-merge&logo=npm)](https://bit.ly/2WnIytF) library. Please read
 [that README](https://github.com/robertmassaioli/openapi-merge/blob/main/packages/openapi-merge/README.md) for more details on how the merging algorithm works.
 
@@ -70,7 +72,7 @@ default -- see below). Written by hand, it should look something like this:
 In this configuration you specify your inputs and your output file. For each input you have the following parameters:
 
 * `inputFile` or `inputURL`: the relative or absolute path (or URL), from the `openapi-merge.json`, to the OpenAPI schema file for that input (in JSON or Yaml format). Absolute paths (e.g. `/tmp/spec.yaml`) are honoured as-is.
-* `dispute`: if two inputs both define a component with the same name then, in order to prevent incorrect overlaps, we will attempt to use the dispute prefix or suffix to come up with a unique name for that component. Please [read the documentation for more details on the format](https://github.com/robertmassaioli/openapi-merge/wiki/configuration-definitions-dispute).
+* `dispute`: if two inputs both define a component with the same name then, in order to prevent incorrect overlaps, we will attempt to use the dispute prefix or suffix to come up with a unique name for that component. See [`dispute`](https://robertmassaioli.github.io/openapi-merge/library/per-input-options#dispute) for the full format.
 * `pathModification.stripStart`: When copying over the `paths` from your OpenAPI specification for this input, it will strip this string from the start of the path if it is found.
 * `pathModification.prepend`: When copying over the `paths` from your OpenAPI specification for this input, it will prepend this string to the start of the path if it is found. `prepend` will always run after `stripStart` so that it is deterministic.
 * `operationSelection.includeTags`: Only operations that are tagged with the tags configured here will be extracted from the OpenAPI file and merged with the others. This instruction will not remove other tags from the top level tags definition for this input. **This filter works per operation, not per path**: if `GET /thing` carries the tag and `POST /thing` does not, the merged document contains `/thing` with only its `GET`. A path whose operations are all filtered out is dropped entirely.
@@ -248,7 +250,8 @@ And then, once you have your Inputs in place and your configuration file you mer
 npx openapi-merge-cli
 ```
 
-For more fine grained details on what `Configuration` options are available to you. [Please read the docs](https://github.com/robertmassaioli/openapi-merge/wiki/README).
+For more fine grained details on what `Configuration` options are available to you, see the
+[full configuration reference](https://robertmassaioli.github.io/openapi-merge/cli/configuration).
 
 If you wish, you may write your configuration file in YAML format and then run:
 

--- a/packages/openapi-merge/README.md
+++ b/packages/openapi-merge/README.md
@@ -1,5 +1,7 @@
 # openapi-merge
 
+### 📖 [Read the full library reference](https://robertmassaioli.github.io/openapi-merge/library/)
+
 This library assumes that you have a number of microservices that you wish to expose through one main service or gateway.
 
 With this assumption in mind, it allows you to provide multiple OpenAPI 3.0, 3.1 or 3.2 files (all inputs must agree on the
@@ -130,7 +132,11 @@ first-wins — see `MergeOptions.securitySchemesStrategy` above for why.
 ## API reference
 
 The full type shapes for `MergeInput`, `MergeOptions`, `MergeResult` and every option mentioned above are generated
-directly from the TypeScript source, so they can't drift from what the code actually accepts. Generate a local copy with:
+directly from the TypeScript source, so they can't drift from what the code actually accepts.
+
+The latest published copy is at
+**[robertmassaioli.github.io/openapi-merge/api](https://robertmassaioli.github.io/openapi-merge/api/)**. To generate
+your own local copy against a checkout:
 
 ``` shell
 bun run docs


### PR DESCRIPTION
## Summary

The documentation microsite from #154 is now live at **https://robertmassaioli.github.io/openapi-merge/**. This adds a prominent link to it at the top of all three READMEs:

- Root README: a "📖 Read the full documentation" link right under the title, and the "Which package do I want?" section now links each option straight to its CLI/library reference on the site.
- Library README: a "📖 Read the full library reference" link at the top, and the API reference section now links the published copy at `/api/` in addition to the local `bun run docs` generation step.
- CLI README: a "📖 Read the full CLI reference" link at the top, and its two stale GitHub wiki links (`dispute` format, configuration options) are replaced with links to the site's fuller, now-canonical pages.

Branched from the latest `main` (includes #151 and #154).

## Test plan

- [x] `bun run lint` passes
- [x] Every newly-linked URL checked directly with `curl` and confirmed `200` before being added (home, `/cli/`, `/cli/configuration`, `/library/`, `/library/per-input-options`, `/api/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)