### PR TITLE
fix(docs-site): link /api/index.html to fix a 404 under vitepress dev

### DIFF
--- a/packages/docs-site/.vitepress/config.mts
+++ b/packages/docs-site/.vitepress/config.mts
@@ -2,8 +2,10 @@ import { defineConfig } from 'vitepress';
 
 // Served from GitHub Pages as a project site (no custom domain configured),
 // so every asset and internal link must be rooted at /openapi-merge/, not /.
-// Cannot be exercised by `vitepress dev`/`preview`, which always serve at /;
-// verify this against the live URL after the first deploy.
+// `vitepress dev`/`preview` do honour this locally too (confirmed: both serve
+// at http://localhost:<port>/openapi-merge/, not /) -- verified directly
+// rather than assumed, after an earlier version of this comment claimed the
+// opposite.
 const base = '/openapi-merge/';
 
 export default defineConfig({
@@ -22,7 +24,14 @@ export default defineConfig({
       { text: 'Guide', link: '/guide/which-package' },
       { text: 'CLI Reference', link: '/cli/' },
       { text: 'Library Reference', link: '/library/' },
-      { text: 'API Reference', link: '/api/', target: '_self' },
+      // /api/index.html, not /api/: `vitepress dev`'s SPA history-fallback
+      // intercepts a bare directory path before it reaches the static file in
+      // public/api/, serving a blank app shell instead (`vitepress preview`
+      // and the real GitHub Pages deploy both resolve /api/ correctly via a
+      // real static-file server, so this only bites the dev server -- but the
+      // explicit filename works identically in all three, so there's no
+      // reason not to always use it).
+      { text: 'API Reference', link: '/api/index.html', target: '_self' },
       { text: 'GitHub', link: 'https://github.com/robertmassaioli/openapi-merge' },
     ],
 

--- a/packages/docs-site/library/api-reference.md
+++ b/packages/docs-site/library/api-reference.md
@@ -14,13 +14,17 @@ the library's source (`packages/openapi-merge/src/index.ts` and everything it ex
 [TypeDoc](https://typedoc.org/), so it cannot drift from what the code actually accepts the way hand-written prose
 can.
 
-<a :href="withBase('/api/')" class="api-reference-link">Open the generated API reference →</a>
+<a :href="withBase('/api/index.html')" class="api-reference-link">Open the generated API reference →</a>
 
 ::: tip
-That link only resolves after a full production build (`bun run --cwd packages/docs-site build`), since the API
-reference is generated straight into `public/api/` as part of that build — it 404s under `vitepress dev`, which
-doesn't run the generation step. Use `bun run --cwd packages/docs-site build && bun run --cwd packages/docs-site preview`
-to see it locally.
+That link only resolves once the API reference has actually been generated into `public/api/` — it isn't there on a
+fresh checkout, and neither `vitepress dev` nor `vitepress preview` generates it for you. Run
+`bun run --cwd packages/docs-site build:api` (or the full `build`, which includes it) at least once; under `dev` you
+don't even need to restart the server afterwards, it picks up the new files immediately.
+
+The link points at `/api/index.html`, not `/api/` — `vitepress dev`'s own client-side routing intercepts a bare
+directory path before it reaches the static file, serving a blank page instead of a 404 or the real content. The
+explicit filename works the same way in `dev`, `preview`, and the real GitHub Pages deploy, so it's used everywhere.
 :::
 
 Useful starting points once you're there:


### PR DESCRIPTION
## Summary

Follow-up to #154/#155. Reported: generating the API reference locally and opening it 404s.

Reproduced with `bun run --cwd packages/docs-site dev`: hitting the bare `/api/` path returns HTTP 200 but a blank page — `vitepress dev`'s own client-side routing intercepts a directory-style path before it reaches the static file at `public/api/index.html`, so it never gets the chance to serve the real content (or a genuine 404, either one).

`vitepress preview` and the real GitHub Pages deploy don't have this problem — both resolve a directory path to its `index.html` via a real static-file server. That's why the original verification (checking HTTP status codes only, not response content) didn't catch it: `/api/` returned `200` in every environment, including the broken one.

**Fix:** link the explicit `/api/index.html` everywhere (nav bar, and the button on `library/api-reference.md`) instead of the bare directory path. Confirmed this serves the real TypeDoc page in all three environments — `dev`, `preview`, and the live site.

## Test plan

- [x] `bun run lint` passes
- [x] Reproduced the bug under `vitepress dev` (blank page, empty `<title>`, at the bare `/api/` path)
- [x] Confirmed `/api/index.html` serves real TypeDoc content under `dev`, `preview`, and the production build
- [x] Confirmed both the nav bar link and the `library/api-reference` button now render `href=".../api/index.html"` in the built static HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)